### PR TITLE
Hotfix/pathfix

### DIFF
--- a/bin/parse.php
+++ b/bin/parse.php
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 // set path to add lib folder, load the Zend Autoloader and include the symfony timer
-set_include_path(get_include_path().PATH_SEPARATOR.'./lib');
+set_include_path(dirname(__FILE__).'/../'.PATH_SEPARATOR.dirname(__FILE__).'/../lib'.PATH_SEPARATOR.get_include_path());
 require_once('Zend/Loader/Autoloader.php');
 require_once('symfony/sfTimer.class.php');
 $autoloader = Zend_Loader_Autoloader::getInstance();


### PR DESCRIPTION
I've modified the set_include_path statement as follows:
- Put paths local to the Docblox distro first
- Add paths for both main Docblox distro directory as well as lib/ subdirectory

This corrected several path resolution errors, particularly when invoking the docblox.php script from outside the Docblox distribution.
