### PR TITLE
Fix pathcheck

### DIFF
--- a/bin/transform.php
+++ b/bin/transform.php
@@ -66,7 +66,7 @@ try
   if ($opts->getOption('source'))
   {
     $path = realpath($opts->getOption('source'));
-    if (!file_exists($path) || !is_readable($path))
+    if (!file_exists($path) || !is_readable($path) || !is_file($path))
     {
       throw new Exception('Given source does not exist or is not readable');
     }


### PR DESCRIPTION
As mentioned in issue #5, Docblox' bin/transform.php will show a bunch of errors about not being able to parse a XML file when you've passed the name of a directory. This is fixed simply by expanding the "source check" to include a check if the source file is actually a file.
