### PR TITLE
Relativepath

### DIFF
--- a/DocBlox/Parser.php
+++ b/DocBlox/Parser.php
@@ -6,6 +6,7 @@ class DocBlox_Parser extends DocBlox_Abstract
   protected $force           = false;
   protected $validate        = false;
   protected $markers         = array('TODO', 'FIXME');
+  protected $path            = null;
 
   public function isForced()
   {
@@ -77,7 +78,7 @@ class DocBlox_Parser extends DocBlox_Abstract
     {
       $file = new DocBlox_Reflection_File($filename, $this->doValidation());
       $file->setMarkers($this->getMarkers());
-
+      $file->setRelativeFilename($this->getRelativeFilename($filename));
       if (($this->existing_xml !== null) && (!$this->isForced()))
       {
         $xpath = new DOMXPath($this->existing_xml);
@@ -109,6 +110,29 @@ class DocBlox_Parser extends DocBlox_Abstract
     $this->debugTimer('>> Parsed file');
 
     return $result;
+  }
+
+  /**
+   * Sets the path to the files that will be parsed.
+   *
+   * @param string $path
+   */
+  function setPath($path)
+  {
+	  $this->path=$path;
+  }
+
+  /**
+   * Returns the filename, relative to the root of the source-directory.
+   *
+   * @param string $filename
+   *
+   * @return string
+   */
+  protected function getRelativeFilename($filename)
+  {
+	  $filename=preg_replace('~^'.preg_quote($this->path).'~','',$filename);
+	  return ltrim($filename,'/');
   }
 
   /**

--- a/DocBlox/Reflection/File.php
+++ b/DocBlox/Reflection/File.php
@@ -54,6 +54,11 @@ class DocBlox_Reflection_File extends DocBlox_Reflection_DocBlockedAbstract
     $this->marker_terms[] = $name;
   }
 
+  public function setRelativeFilename($filename)
+  {
+	  $this->filename = $filename;
+  }
+
   public function setMarkers(array $markers)
   {
     $this->marker_terms = $markers;

--- a/bin/parse.php
+++ b/bin/parse.php
@@ -64,6 +64,7 @@ $docblox->setIgnorePatterns($opts->getIgnorePatterns());
 $docblox->setForced($opts->getOption('force'));
 $docblox->setMarkers($opts->getMarkers());
 $docblox->setValidate($opts->getOption('validate'));
+$docblox->setPath($opts->getOption('directory'));
 
 // save the generate file to the path given as the 'target' option
 file_put_contents($path.'/structure.xml', $docblox->parseFiles($opts->getFiles()));


### PR DESCRIPTION
Hi.

In this branch, I've fixed issue #9: paths are now relative to the directory that is being parsed. It drastically decreases clutter when watching the documentation.
