### PR TITLE
Stop outputting the versioning information multiple times depending on tasks being run

### DIFF
--- a/bin/docblox.php
+++ b/bin/docblox.php
@@ -39,11 +39,13 @@ if (count($task_parts) == 1)
 }
 $class_name = 'DocBlox_Task_'.ucfirst($task_parts[0]).'_'. ucfirst($task_parts[1])  ;
 
+// Output versioning information up front
+DocBlox_TextUI::outputHeader();
+
 // sorry about the shut up operator but we do this check to determine whether this works
 // and Zend_Loader throws a warning if the class does not exist.
 if (!@class_exists($class_name))
 {
-  echo 'DocBlox version ' . DocBlox_Core_Abstract::VERSION . PHP_EOL . PHP_EOL;
   echo 'ERROR: Unable to execute task: '.implode(':', $task_parts).', it is not found'.PHP_EOL.PHP_EOL;
   exit(1);
 }

--- a/src/DocBlox/Task/Abstract.php
+++ b/src/DocBlox/Task/Abstract.php
@@ -45,7 +45,7 @@ abstract class DocBlox_Task_Abstract extends Zend_Console_Getopt
    */
   protected function outputHeader()
   {
-    echo 'DocBlox version ' . DocBlox_Core_Abstract::VERSION . PHP_EOL . PHP_EOL;
+
   }
 
   /**

--- a/src/DocBlox/TextUI.php
+++ b/src/DocBlox/TextUI.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * DocBlox TextUI
+ *
+ * @category  DocBlox
+ * @package   Base
+ * @copyright Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @author    Ben Selby <benmatselby@gmail.com>
+ */
+
+/**
+ * This class represents the UI aspect of the application
+ *
+ * @category  DocBlox
+ * @package   Base
+ * @copyright Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @author    Ben Selby <benmatselby@gmail.com>
+ */
+class DocBlox_TextUI
+{
+    /**
+     * Output the header
+     *
+     * @return void
+     */
+    public static function outputHeader()
+    {
+        echo 'DocBlox version ' . DocBlox_Core_Abstract::VERSION . PHP_EOL . PHP_EOL;
+    }
+}

--- a/tests/common/bootstrap.php
+++ b/tests/common/bootstrap.php
@@ -17,5 +17,6 @@ set_include_path(
 // include and initialize the autoloader
 require_once('Zend/Loader/Autoloader.php');
 require_once('markdown/markdown.php');
+require_once('PHPUnit/Extensions/OutputTestCase.php');
 $autoloader = Zend_Loader_Autoloader::getInstance();
 $autoloader->registerNamespace('DocBlox_');

--- a/tests/unit/DocBlox/TextUITest.php
+++ b/tests/unit/DocBlox/TextUITest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * DocBlox TextUI
+ *
+ * @category  DocBlox
+ * @package   Tests
+ * @copyright Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @author    Ben Selby <benmatselby@gmail.com>
+ */
+
+/**
+ * Testing class for DocBlox_TextUI which represents the UI for the application
+ *
+ * @category  DocBlox
+ * @package   Tests
+ * @copyright Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @author    Ben Selby <benmatselby@gmail.com>
+ */
+class DocBlox_TextUITest extends PHPUnit_Extensions_OutputTestCase
+{
+    /** 
+     * Test that the TextUI can output the version number correctly
+     * rather than having each task define the output
+     *
+     * @covers DocBlox_TextUI::outputHeader
+     *
+     * @return void
+     */
+    public function testTextUICanOutputVersionNumber()
+    {
+        $this->expectOutputString('DocBlox version ' . DocBlox_Core_Abstract::VERSION . PHP_EOL . PHP_EOL);
+        DocBlox_TextUI::outputHeader();
+    }
+}


### PR DESCRIPTION
Start a TextUI class to represent the UI. Currently can output the version number so you do not end up with double versioning information in the terminal when running project:run, as currently happens:

$ php ../Docblox/bin/docblox.php project:run
DocBlox version 0.9.0

DocBlox version 0.9.0

ERROR: No parsable files were found, did you specify any using the -f or -d parameter?

Not yet implemented
