### PR TITLE
Issue 93

### DIFF
--- a/src/DocBlox/Reflection/DocBlockedAbstract.php
+++ b/src/DocBlox/Reflection/DocBlockedAbstract.php
@@ -3,253 +3,236 @@
  * DocBlox
  *
  * @category   DocBlox
- * @package    Static_Reflection
- * @copyright  Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @package    DocBlox
+ * @subpackage Reflection
+ * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright  2010-2011 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://docblox-project.org
  */
 
 /**
  * Abstract base class for all Reflection entities which have a docblock.
  *
  * @category   DocBlox
- * @package    Static_Reflection
+ * @package    Parser
+ * @subpackage Reflection
  * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://docblox-project.org
  */
 abstract class DocBlox_Reflection_DocBlockedAbstract extends DocBlox_Reflection_Abstract
 {
-  /** @var DocBlox_Reflection_DocBlock|null */
-  protected $doc_block = null;
+    /** @var DocBlox_Reflection_DocBlock|null */
+    protected $doc_block = null;
 
-  /**
-   * Any generic information that needs to be retrieved is the docblock itself.
-   *
-   * @param DocBlox_Token_Iterator $tokens
-   *
-   * @return void
-   */
-  protected function processGenericInformation(DocBlox_Token_Iterator $tokens)
-  {
-    $this->doc_block = $this->findDocBlock($tokens);
-  }
-
-  /**
-   * Returns the DocBlock reflection object.
-   *
-   * @return DocBlox_Reflection_Docblock|null
-   */
-  public function getDocBlock()
-  {
-    return $this->doc_block;
-  }
-
-  /**
-   * Returns the first docblock preceding the active token within 10 tokens.
-   *
-   * Please note that the iterator cursor does not change with to this method.
-   *
-   * @param  DocBlox_Token_Iterator $tokens
-   *
-   * @return DocBlox_Reflection_DocBlock|null
-   */
-  protected function findDocBlock(DocBlox_Token_Iterator $tokens)
-  {
-    $result = null;
-    $docblock = $tokens->findPreviousByType(T_DOC_COMMENT, 10, array('{', '}', ';'));
-    try
+    /**
+     * Any generic information that needs to be retrieved is the docblock itself.
+     *
+     * @param DocBlox_Token_Iterator $tokens Tokens to process
+     *
+     * @return void
+     */
+    protected function processGenericInformation(DocBlox_Token_Iterator $tokens)
     {
-      $result = $docblock ? new DocBlox_Reflection_DocBlock($docblock->getContent()) : null;
-      if ($result)
-      {
-        // attach line number to class, the DocBlox_Reflection_DocBlock does not know the number
-        $result->line_number = $docblock->getLineNumber();
-      }
-    }
-    catch (Exception $e)
-    {
-      $this->log($e->getMessage(), Zend_Log::CRIT);
+        $this->doc_block = $this->findDocBlock($tokens);
     }
 
-    $this->validateDocBlock($this->filename, $docblock ? $docblock->getLineNumber() : 0, $result);
-
-    // if the object has no DocBlock _and_ is not a Closure; throw a warning
-    $type = substr(get_class($this), strrpos(get_class($this), '_') + 1);
-    if (!$result && (($type !== 'Function') && ($this->getName() !== 'Closure')))
+    /**
+     * Returns the DocBlock reflection object.
+     *
+     * @return DocBlox_Reflection_Docblock|null
+     */
+    public function getDocBlock()
     {
-      $this->log(
-        'No DocBlock was found for ' . $type . ' ' . $this->getName()
-          . ' in file ' . $tokens->getFilename()
-          . ' on line ' . $this->getLineNumber(),
-        Zend_Log::ERR
-      );
+        return $this->doc_block;
     }
 
-    return $result;
-  }
-
-  /**
-   * Tries to expand a type to it's full namespaced equivalent.
-   *
-   * @param string $type
-   *
-   * @return string
-   */
-  protected function expandType($type)
-  {
-    if ($type === null)
+    /**
+     * Returns the first docblock preceding the active token within 10 tokens.
+     *
+     * Please note that the iterator cursor does not change with to this method.
+     *
+     * @param DocBlox_Token_Iterator $tokens Tokens to process
+     *
+     * @return DocBlox_Reflection_DocBlock|null
+     */
+    protected function findDocBlock(DocBlox_Token_Iterator $tokens)
     {
-      return null;
-    }
-
-    $non_objects = array('string', 'int', 'integer', 'bool', 'boolean', 'float', 'double',
-      'object', 'mixed', 'array', 'resource', 'void', 'null', 'callback');
-    $namespace = $this->getNamespace() == 'default' ? '' : $this->getNamespace().'\\';
-
-    $type = explode('|', $type);
-    foreach($type as &$item)
-    {
-      $item = trim($item);
-
-      // add support for array notation
-      $is_array = false;
-      if (substr($item, -2) == '[]')
-      {
-        $item = substr($item, 0, -2);
-        $is_array = true;
-      }
-
-      if ((substr($item, 0, 1) != '\\') && (!in_array(strtolower($item), $non_objects)))
-      {
-        $type_parts = explode('\\', $item);
-
-        // if the first part is the keyword 'namespace', replace it with the current namespace
-        if ($type_parts[0] == 'namespace')
-        {
-          $type_parts[0] = $this->getNamespace();
-          $item = implode('\\', $type_parts);
+        $result = null;
+        $docblock = $tokens->findPreviousByType(T_DOC_COMMENT, 10, array('{', '}', ';'));
+        try {
+            $result = $docblock ? new DocBlox_Reflection_DocBlock($docblock->getContent()) : null;
+            if ($result) {
+                // attach line number to class, the DocBlox_Reflection_DocBlock does not know the number
+                $result->line_number = $docblock->getLineNumber();
+            }
+        } catch (Exception $e) {
+            $this->log($e->getMessage(), Zend_Log::CRIT);
         }
 
-        // if the first segment is an alias; replace with full name
-        if (isset($this->namespace_aliases[$type_parts[0]]))
-        {
-          $type_parts[0] = $this->namespace_aliases[$type_parts[0]];
+        $this->validateDocBlock($this->filename, $docblock ? $docblock->getLineNumber() : 0, $result);
 
-          $item = implode('\\', $type_parts);
+        // if the object has no DocBlock _and_ is not a Closure; throw a warning
+        $type = substr(get_class($this), strrpos(get_class($this), '_') + 1);
+        if (!$result && (($type !== 'Function') && ($this->getName() !== 'Closure'))) {
+            $this->log(
+                'No DocBlock was found for ' . $type . ' ' . $this->getName() .
+                ' in file ' . $tokens->getFilename() .
+                ' on line ' . $this->getLineNumber(),
+                Zend_Log::ERR
+            );
         }
-        elseif (count($type_parts) == 1)
-        {
-          // prefix the item with the namespace if there is only one part and no alias
-          $item = $namespace . $item;
-        }
-      }
 
-      // re-add the array notation markers
-      if ($is_array)
-      {
-        $item .= '[]';
-      }
+        return $result;
     }
 
-    return implode('|', $type);
-  }
-
-  /**
-   * Adds the DocBlock XML definition to the given SimpleXMLElement.
-   *
-   * @param SimpleXMLElement $xml
-   *
-   * @return void
-   */
-  protected function addDocblockToSimpleXmlElement(SimpleXMLElement $xml)
-  {
-    if ($this->getDocBlock())
+    /**
+     * Tries to expand a type to it's full namespaced equivalent.
+     *
+     * @param string $type Type to expand into full namespaced equivalent
+     *
+     * @return string
+     */
+    protected function expandType($type)
     {
-      if (!isset($xml->docblock))
-      {
-        $xml->addChild('docblock');
-      }
-      $xml->docblock->description          = $this->getDocBlock()->getShortDescription();
-      $xml->docblock->{'long-description'} = $this->getDocBlock()->getLongDescription()->getFormattedContents();
-
-      /** @var DocBlox_Reflection_Docblock_Tag $tag */
-      foreach ($this->getDocBlock()->getTags() as $tag)
-      {
-        $description = htmlspecialchars($tag->getDescription(), ENT_QUOTES, 'UTF-8');
-        if ($tag->getName() instanceof DocBlox_Reflection_DocBlock_Tag_Var)
-        {
-          $description = $tag->getDescription();
+        if ($type === null) {
+            return null;
         }
 
-        $tag_object                = $xml->docblock->addChild('tag');
-        $tag_object['name']        = $tag->getName();
-        $tag_object['description'] = trim($description);
+        $non_objects = array(
+            'string', 'int', 'integer', 'bool', 'boolean', 'float', 'double',
+            'object', 'mixed', 'array', 'resource', 'void', 'null', 'callback'
+        );
+        $namespace = $this->getNamespace() == 'default' ? '' : $this->getNamespace().'\\';
 
-        if (method_exists($tag, 'getTypes'))
-        {
-          foreach($tag->getTypes() as $type)
-          {
-            if ($type == '')
-            {
-              continue;
+        $type = explode('|', $type);
+        foreach ($type as &$item) {
+            $item = trim($item);
+
+            // add support for array notation
+            $is_array = false;
+            if (substr($item, -2) == '[]') {
+                $item = substr($item, 0, -2);
+                $is_array = true;
             }
 
-            $type = trim($this->expandType($type));
+            if ((substr($item, 0, 1) != '\\') && (!in_array(strtolower($item), $non_objects))) {
+                $type_parts = explode('\\', $item);
 
-            // strip ampersands
-            $name = str_replace('&', '', $type);
-            $type_object = $tag_object->addChild('type', $name);
+                // if the first part is the keyword 'namespace', replace it with the current namespace
+                if ($type_parts[0] == 'namespace') {
+                    $type_parts[0] = $this->getNamespace();
+                    $item = implode('\\', $type_parts);
+                }
 
-            // register whether this variable is by reference by checking the first and last character
-            $type_object['by_reference'] = ((substr($type, 0, 1) === '&') || (substr($type, -1) === '&'))
-              ? 'true'
-              : 'false';
-          }
+                // if the first segment is an alias; replace with full name
+                if (isset($this->namespace_aliases[$type_parts[0]])) {
+                    $type_parts[0] = $this->namespace_aliases[$type_parts[0]];
 
-          $tag_object['type'] = $this->expandType($tag->getType());
+                    $item = implode('\\', $type_parts);
+                } elseif (count($type_parts) == 1) {
+                    // prefix the item with the namespace if there is only one part and no alias
+                    $item = $namespace . $item;
+                }
+            }
+
+            // re-add the array notation markers
+            if ($is_array) {
+                $item .= '[]';
+            }
         }
 
-        if (method_exists($tag, 'getVariableName'))
-        {
-          if (trim($tag->getVariableName()) == '')
-          {
-            // TODO: get the name from the argument list
-          }
-
-          $tag_object['variable'] = $tag->getVariableName();
-        }
-
-        if (method_exists($tag, 'getLink'))
-        {
-          $tag_object['link'] = $tag->getLink();
-        }
-
-        // custom attached member variable, see line 51
-        if (isset($this->getDocBlock()->line_number))
-        {
-          $tag_object['line'] = $this->getDocBlock()->line_number;
-        }
-      }
+        return implode('|', $type);
     }
-  }
 
-  /**
-   * Validate the docblock
-   *
-   * @param string                           $filename   Filename
-   * @param int                              $lineNumber The line number for the docblock
-   * @param DocBlox_Reflection_DocBlock|null $docblock   Docbloc
-   *
-   * @return boolean
-   */
-  protected function validateDocBlock($filename, $lineNumber, $docblock)
-  {
-    $valid = true;
-    $class = get_class($this);
-    $part = substr($class, strrpos($class, '_') + 1);
-
-    if (@class_exists('DocBlox_Parser_DocBlock_Validator_'.$part))
+    /**
+     * Adds the DocBlock XML definition to the given SimpleXMLElement.
+     *
+     * @param SimpleXMLElement $xml SimpleXMLElement to be appended to
+     *
+     * @return void
+     */
+    protected function addDocblockToSimpleXmlElement(SimpleXMLElement $xml)
     {
-      $validator = new DocBlox_Parser_DocBlock_Validator_File($filename, $lineNumber, $docblock);
-      $valid = $validator->isValid();
+        if ($this->getDocBlock()) {
+            if (!isset($xml->docblock)) {
+                $xml->addChild('docblock');
+            }
+            $xml->docblock->description          = $this->getDocBlock()->getShortDescription();
+            $xml->docblock->{'long-description'} = $this->getDocBlock()->getLongDescription()->getFormattedContents();
+
+            /** @var DocBlox_Reflection_Docblock_Tag $tag */
+            foreach ($this->getDocBlock()->getTags() as $tag) {
+                $description = htmlspecialchars($tag->getDescription(), ENT_QUOTES, 'UTF-8');
+                if ($tag->getName() instanceof DocBlox_Reflection_DocBlock_Tag_Var) {
+                    $description = $tag->getDescription();
+                }
+
+                $tag_object                = $xml->docblock->addChild('tag');
+                $tag_object['name']        = $tag->getName();
+                $tag_object['description'] = trim($description);
+
+                if (method_exists($tag, 'getTypes')) {
+                    foreach ($tag->getTypes() as $type) {
+                        if ($type == '') {
+                            continue;
+                        }
+
+                        $type = trim($this->expandType($type));
+
+                        // strip ampersands
+                        $name = str_replace('&', '', $type);
+                        $type_object = $tag_object->addChild('type', $name);
+
+                        // register whether this variable is by reference by checking the first and last character
+                        $type_object['by_reference'] = ((substr($type, 0, 1) === '&') || (substr($type, -1) === '&'))
+                          ? 'true'
+                          : 'false';
+                    }
+
+                    $tag_object['type'] = $this->expandType($tag->getType());
+                }
+
+                if (method_exists($tag, 'getVariableName')) {
+                    if (trim($tag->getVariableName()) == '') {
+                        // TODO: get the name from the argument list
+                    }
+
+                    $tag_object['variable'] = $tag->getVariableName();
+                }
+
+                if (method_exists($tag, 'getLink')) {
+                    $tag_object['link'] = $tag->getLink();
+                }
+
+                // custom attached member variable, see line 51
+                if (isset($this->getDocBlock()->line_number)) {
+                    $tag_object['line'] = $this->getDocBlock()->line_number;
+                }
+            }
+        }
     }
-    return $valid;
-  }
+
+    /**
+     * Validate the docblock
+     *
+     * @param string                           $filename   Filename
+     * @param int                              $lineNumber The line number for the docblock
+     * @param DocBlox_Reflection_DocBlock|null $docblock   Docbloc
+     *
+     * @return boolean
+     */
+    protected function validateDocBlock($filename, $lineNumber, $docblock)
+    {
+        $valid = true;
+        $class = get_class($this);
+        $part = substr($class, strrpos($class, '_') + 1);
+
+        if (@class_exists('DocBlox_Parser_DocBlock_Validator_'.$part)) {
+            $validator = new DocBlox_Parser_DocBlock_Validator_File($filename, $lineNumber, $docblock);
+            $valid = $validator->isValid();
+        }
+        return $valid;
+    }
 }

--- a/src/DocBlox/Reflection/File.php
+++ b/src/DocBlox/Reflection/File.php
@@ -598,12 +598,11 @@ class DocBlox_Reflection_File extends DocBlox_Reflection_DocBlockedAbstract
         $function->setNamespaceAliases($this->namespace_aliases);
         $function->parseTokenizer($tokens);
 
+        $this->functions[$function->getName()] = $function;
         $this->debugTimer(
             '>> Processed function ' . $function->getName(),
             'function'
         );
-
-        $this->functions[$function->getName()] = $function;
     }
 
     /**

--- a/src/DocBlox/Reflection/Interface.php
+++ b/src/DocBlox/Reflection/Interface.php
@@ -136,8 +136,8 @@ class DocBlox_Reflection_Interface extends DocBlox_Reflection_BracesAbstract
     $property->parseTokenizer($tokens);
     $property->setNamespace($this->getNamespace());
     $property->setNamespaceAliases($this->getNamespaceAliases());
-    $this->properties[] = $property;
 
+    $this->properties[] = $property;
     $this->debugTimer('>> Processed property '.$property->getName(), 'variable');
   }
 
@@ -156,6 +156,7 @@ class DocBlox_Reflection_Interface extends DocBlox_Reflection_BracesAbstract
     $method->parseTokenizer($tokens);
     $method->setNamespace($this->getNamespace());
     $method->setNamespaceAliases($this->getNamespaceAliases());
+
     $this->methods[$method->getName()] = $method;
     $this->debugTimer('>>  Processed method '.$method->getName(), 'method');
   }

--- a/src/DocBlox/Task/ConfigurableAbstract.php
+++ b/src/DocBlox/Task/ConfigurableAbstract.php
@@ -53,6 +53,25 @@ abstract class DocBlox_Task_ConfigurableAbstract extends DocBlox_Task_Abstract
     parent::setConfig($value);
   }
 
+    /**
+     * Configuration override for setting the parser visibility
+     *
+     * By default it will use the command line options first, and then
+     * look at the config file if no options have been supplied
+     *
+     * @return string
+     */
+    protected function getVisibility()
+    {
+        $visibility = parent::getVisibility();
+
+        if ('' == $visibility) {
+            $visibility = DocBlox_Core_Abstract::config()->parser->visibility;
+        }
+
+        return $visibility;
+    }
+
   /**
    * Merge the config files before population.
    *

--- a/src/DocBlox/Task/Project/Parse.php
+++ b/src/DocBlox/Task/Project/Parse.php
@@ -5,258 +5,260 @@
  * The parse task uses the source files defined either by -f or -d options and generates a structure
  * file (structure.xml) at the target location (which is the folder 'output' unless the option -t is provided).
  *
+ * @category   DocBlox
  * @package    DocBlox
- * @subpackage Tasks
+ * @subpackage Task
  * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://docblox-project.org
  */
 class DocBlox_Task_Project_Parse extends DocBlox_Task_ConfigurableAbstract
 {
-  /** @var string The name of this task including namespace */
-  protected $taskname = 'project:parse';
+    /** @var string The name of this task including namespace */
+    protected $taskname = 'project:parse';
 
-  /**
-   * Sets the options and description for this task.
-   *
-   * @return void
-   */
-  protected function configure()
-  {
-    $this->addOption('f|filename', '=s',
-      'Comma-separated list of files to parse. The wildcards ? and * are supported'
-    );
-    $this->addOption('d|directory', '=s',
-      'Comma-separated list of directories to (recursively) parse.'
-    );
-    $this->addOption('t|target', '-s',
-      'Path where to store the generated output (optional, defaults to "'. DocBlox_Core_Abstract::config()->target . '")'
-    );
-    $this->addOption('e|extensions', '-s',
-      'Optional comma-separated list of extensions to parse, defaults to php, php3 and phtml'
-    );
-    $this->addOption('i|ignore', '-s',
-      'Comma-separated list of file(s) and directories that will be ignored. Wildcards * and ? are supported'
-    );
-    $this->addOption('m|markers', '-s',
-      'Comma-separated list of markers/tags to filter, (optional, defaults to: "TODO,FIXME")'
-    );
-    $this->addOption('v|verbose', '',
-      'Provides additional information during parsing, usually only needed for debugging purposes'
-    );
-    $this->addOption('title', '-s',
-      'Sets the title for this project; default is the DocBlox logo'
-    );
-    $this->addOption('force', '',
-      'Forces a full build of the documentation, does not increment existing documentation'
-    );
-    $this->addOption('validate', '',
-      'Validates every processed file using PHP Lint, costs a lot of performance'
-    );
-  }
-
-  /**
-   * Returns the target location where to store the structure.xml.
-   *
-   * @throws Zend_Console_Getopt_Exception
-   *
-   * @return string
-   */
-  public function getTarget()
-  {
-    $target = parent::getTarget();
-    $target = ($target === null)
-      ? trim(DocBlox_Core_Abstract::config()->parser->target)
-      : trim($target);
-
-    if (($target == '') || ($target == DIRECTORY_SEPARATOR))
+    /**
+     * Sets the options and description for this task.
+     *
+     * @return void
+     */
+    protected function configure()
     {
-      throw new Zend_Console_Getopt_Exception('Either an empty path or root was given: ' . $target);
+        $this->addOption(
+            'f|filename', '=s',
+            'Comma-separated list of files to parse. The wildcards ? and * are supported'
+        );
+        $this->addOption(
+            'd|directory', '=s',
+            'Comma-separated list of directories to (recursively) parse.'
+        );
+        $this->addOption(
+            't|target', '-s',
+            'Path where to store the generated output (optional, defaults to "'. DocBlox_Core_Abstract::config()->target . '")'
+        );
+        $this->addOption(
+            'e|extensions', '-s',
+            'Optional comma-separated list of extensions to parse, defaults to php, php3 and phtml'
+        );
+        $this->addOption(
+            'i|ignore', '-s',
+            'Comma-separated list of file(s) and directories that will be ignored. Wildcards * and ? are supported'
+        );
+        $this->addOption(
+            'm|markers', '-s',
+            'Comma-separated list of markers/tags to filter, (optional, defaults to: "TODO,FIXME")'
+        );
+        $this->addOption(
+            'v|verbose', '',
+            'Provides additional information during parsing, usually only needed for debugging purposes'
+        );
+        $this->addOption(
+            'title', '-s',
+            'Sets the title for this project; default is the DocBlox logo'
+        );
+        $this->addOption(
+            'force', '',
+            'Forces a full build of the documentation, does not increment existing documentation'
+        );
+        $this->addOption(
+            'validate', '',
+            'Validates every processed file using PHP Lint, costs a lot of performance'
+        );
+        $this->addOption(
+            'visibility', '-s',
+            'Specifies the parse visibility that should be displayed in the documentation (comma seperated e.g. "public,protected")'
+        );
     }
 
-    if (!is_dir($target))
+    /**
+    * Returns the target location where to store the structure.xml.
+    *
+    * @throws Zend_Console_Getopt_Exception
+    *
+    * @return string
+    */
+    public function getTarget()
     {
-      throw new Zend_Console_Getopt_Exception('The given location "' . $target . '" is not a folder');
-    }
+        $target = parent::getTarget();
+        $target = ($target === null)
+          ? trim(DocBlox_Core_Abstract::config()->parser->target)
+          : trim($target);
 
-    if (!is_writable($target))
-    {
-      throw new Zend_Console_Getopt_Exception(
-        'The given path "' . $target . '" either does not exist or is not writable.'
-      );
-    }
-
-    return realpath($target);
-  }
-
-  /**
-   * Retrieves a list of allowed extensions.
-   *
-   * @return string[]
-   */
-  public function getExtensions()
-  {
-    if (parent::getExtensions() !== null)
-    {
-      return explode(',', parent::getExtensions());
-    }
-
-    return DocBlox_Core_Abstract::config()->getArrayFromPath('parser/extensions/extension');
-  }
-
-  /**
-   * Returns all ignore patterns.
-   *
-   * @return array
-   */
-  public function getIgnore()
-  {
-    if (parent::getIgnore() !== null)
-    {
-      return explode(',', parent::getIgnore());
-    }
-
-    return DocBlox_Core_Abstract::config()->getArrayFromPath('ignore/item');
-  }
-
-  /**
-   * Returns all ignore patterns.
-   *
-   * @return array
-   */
-  public function getTitle()
-  {
-    if (parent::getTitle() !== null)
-    {
-      return parent::getTitle();
-    }
-
-    return DocBlox_Core_Abstract::config()->get('title');
-  }
-
-  /**
-   * Interprets the -d and -f options and retrieves all filenames.
-   *
-   * This method does take the extension option into account but _not_ the
-   * ignore list. The ignore list is handled in the parser.
-   *
-   * @todo method contains duplicate code and is too large, refactor
-   * @todo consider moving the filtering on ignore_paths here
-   *
-   * @return string[]
-   */
-  protected function parseFiles()
-  {
-    // read the filename argument in search for files (wildcards are explicitly allowed)
-    $expressions = array_unique(
-      $this->getFilename()
-        ? explode(',', $this->getFilename())
-        : DocBlox_Core_Abstract::config()->getArrayFromPath('files/file')
-    );
-
-    $files = array();
-    foreach ($expressions as $expr)
-    {
-      // search file(s) with the given expressions
-      $result = glob($expr);
-      foreach ($result as $file)
-      {
-        // if the path is not a file OR it's extension does not match the given, then do not process it.
-        if (!is_file($file) || !in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), $this->getExtensions()))
-        {
-          continue;
+        if (($target == '') || ($target == DIRECTORY_SEPARATOR)) {
+            throw new Zend_Console_Getopt_Exception('Either an empty path or root was given: ' . $target);
         }
 
-        $files[] = realpath($file);
-      }
-    }
-
-    $expressions = array_unique(
-      $this->getDirectory() || !empty($files)
-        ? explode(',', $this->getDirectory())
-        : DocBlox_Core_Abstract::config()->getArrayFromPath('files/directory')
-    );
-
-    foreach ($expressions as $directory)
-    {
-      // if the given is not a directory, skip it
-      if (!is_dir($directory))
-      {
-        continue;
-      }
-
-      // get all files recursively to the files array
-      $files_iterator = new RecursiveDirectoryIterator($directory);
-
-      /** @var SplFileInfo $file */
-      foreach (new RecursiveIteratorIterator($files_iterator) as $file)
-      {
-        // skipping dots (should any be encountered)
-        if (($file->getFilename() == '.') || ($file->getFilename() == '..'))
-        {
-          continue;
+        if (!is_dir($target)) {
+            throw new Zend_Console_Getopt_Exception('The given location "' . $target . '" is not a folder');
         }
 
-        // check if the file has the correct extension
-        if (!in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), $this->getExtensions()))
-        {
-          continue;
+        if (!is_writable($target)) {
+            throw new Zend_Console_Getopt_Exception(
+                'The given path "' . $target . '" either does not exist or is not writable.'
+            );
         }
 
-        $files[] = $file->getRealPath();
-      }
+        return realpath($target);
     }
 
-    return array_unique($files);
-  }
-
-  /**
-   * Returns the list of markers to scan for and summize in their separate page.
-   *
-   * @return string[]
-   */
-  public function getMarkers()
-  {
-    if (parent::getMarkers())
+    /**
+     * Retrieves a list of allowed extensions.
+     *
+     * @return string[]
+     */
+    public function getExtensions()
     {
-      return explode(',', parent::getMarkers());
+        if (parent::getExtensions() !== null) {
+            return explode(',', parent::getExtensions());
+        }
+
+        return DocBlox_Core_Abstract::config()->getArrayFromPath('parser/extensions/extension');
     }
 
-    return DocBlox_Core_Abstract::config()->getArrayFromPath('parser/markers/item');
-  }
-
-  /**
-   * Execute the parsing process.
-   *
-   * @throws Zend_Console_Getopt_Exception
-   *
-   * @return void
-   */
-  public function execute()
-  {
-    $files = $this->parseFiles();
-    if (count($files) < 1)
+    /**
+     * Returns all ignore patterns.
+     *
+     * @return array
+     */
+    public function getIgnore()
     {
-      throw new Zend_Console_Getopt_Exception('No parsable files were found, did you specify any using the -f or -d parameter?');
+        if (parent::getIgnore() !== null) {
+            return explode(',', parent::getIgnore());
+        }
+
+        return DocBlox_Core_Abstract::config()->getArrayFromPath('ignore/item');
     }
 
-    $parser = new DocBlox_Parser();
-    $parser->setTitle(htmlentities($this->getTitle()));
-    if ($this->getVerbose())
+    /**
+     * Returns all ignore patterns.
+     *
+     * @return array
+     */
+    public function getTitle()
     {
-      $parser->setLogLevel(DocBlox_Core_Log::DEBUG);
+        if (parent::getTitle() !== null) {
+            return parent::getTitle();
+        }
+
+        return DocBlox_Core_Abstract::config()->get('title');
     }
-    if ($this->getQuiet())
+
+    /**
+     * Interprets the -d and -f options and retrieves all filenames.
+     *
+     * This method does take the extension option into account but _not_ the
+     * ignore list. The ignore list is handled in the parser.
+     *
+     * @todo method contains duplicate code and is too large, refactor
+     * @todo consider moving the filtering on ignore_paths here
+     *
+     * @return string[]
+     */
+    protected function parseFiles()
     {
-      $parser->setLogLevel(DocBlox_Core_Log::QUIET);
+        // read the filename argument in search for files (wildcards are explicitly allowed)
+        $expressions = array_unique(
+            $this->getFilename()
+            ? explode(',', $this->getFilename())
+            : DocBlox_Core_Abstract::config()->getArrayFromPath('files/file')
+        );
+
+        $files = array();
+        foreach ($expressions as $expr) {
+            // search file(s) with the given expressions
+            $result = glob($expr);
+            foreach ($result as $file) {
+                // if the path is not a file OR it's extension does not match the given, then do not process it.
+                if (!is_file($file) || !in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), $this->getExtensions())) {
+                    continue;
+                }
+
+                $files[] = realpath($file);
+            }
+        }
+
+        $expressions = array_unique(
+            $this->getDirectory() || !empty($files)
+            ? explode(',', $this->getDirectory())
+            : DocBlox_Core_Abstract::config()->getArrayFromPath('files/directory')
+        );
+
+        foreach ($expressions as $directory) {
+            // if the given is not a directory, skip it
+            if (!is_dir($directory)) {
+                continue;
+            }
+
+            // get all files recursively to the files array
+            $files_iterator = new RecursiveDirectoryIterator($directory);
+
+            /** @var SplFileInfo $file */
+            foreach (new RecursiveIteratorIterator($files_iterator) as $file) {
+                // skipping dots (should any be encountered)
+                if (($file->getFilename() == '.') || ($file->getFilename() == '..')) {
+                    continue;
+                }
+
+                // check if the file has the correct extension
+                if (!in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), $this->getExtensions())) {
+                    continue;
+                }
+
+                $files[] = $file->getRealPath();
+            }
+        }
+
+        return array_unique($files);
     }
-    $parser->setExistingXml($this->getTarget() . '/structure.xml');
-    $parser->setIgnorePatterns($this->getIgnore());
-    $parser->setForced($this->getForce());
-    $parser->setMarkers($this->getMarkers());
-    $parser->setValidate($this->getValidate());
 
-    $parser->setPath($parser->getCommonPath($files));
+    /**
+     * Returns the list of markers to scan for and summize in their separate page.
+     *
+     * @return string[]
+     */
+    public function getMarkers()
+    {
+        if (parent::getMarkers()) {
+            return explode(',', parent::getMarkers());
+        }
 
-    // save the generate file to the path given as the 'target' option
-    file_put_contents($this->getTarget() . '/structure.xml', $parser->parseFiles($files));
-  }
+        return DocBlox_Core_Abstract::config()->getArrayFromPath('parser/markers/item');
+    }
+
+    /**
+     * Execute the parsing process.
+     *
+     * @throws Zend_Console_Getopt_Exception
+     *
+     * @return void
+     */
+    public function execute()
+    {
+        $files = $this->parseFiles();
+        if (count($files) < 1) {
+            throw new Zend_Console_Getopt_Exception(
+                'No parsable files were found, did you specify any using the -f or -d parameter?'
+            );
+        }
+
+        $parser = new DocBlox_Parser();
+        $parser->setTitle(htmlentities($this->getTitle()));
+        if ($this->getVerbose()) {
+            $parser->setLogLevel(DocBlox_Core_Log::DEBUG);
+        }
+        if ($this->getQuiet()) {
+            $parser->setLogLevel(DocBlox_Core_Log::QUIET);
+        }
+        $parser->setExistingXml($this->getTarget() . '/structure.xml');
+        $parser->setIgnorePatterns($this->getIgnore());
+        $parser->setForced($this->getForce());
+        $parser->setMarkers($this->getMarkers());
+        $parser->setValidate($this->getValidate());
+        $parser->setVisibility($this->getVisibility());
+
+        $parser->setPath($parser->getCommonPath($files));
+
+        // save the generate file to the path given as the 'target' option
+        file_put_contents($this->getTarget() . '/structure.xml', $parser->parseFiles($files));
+    }
 }

--- a/src/DocBlox/Task/Project/Run.php
+++ b/src/DocBlox/Task/Project/Run.php
@@ -13,88 +13,107 @@
  * and use that to override the default settings if present. In the configuration file can you specify the
  * same settings (and more) as the command line provides.
  *
+ * @category   DocBlox
  * @package    DocBlox
- * @subpackage Tasks
+ * @subpackage Task
  * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://docblox-project.org
  */
 class DocBlox_Task_Project_Run extends DocBlox_Task_ConfigurableAbstract
 {
-  /** @var string The name of this task including namespace */
-  protected $taskname = 'project:run';
+    /** @var string The name of this task including namespace */
+    protected $taskname = 'project:run';
 
-  /**
-   * Sets the options and description for this task.
-   *
-   * @return void
-   */
-  protected function configure()
-  {
-    $this->addOption('f|filename', '=s',
-      'Comma-separated list of files to parse. The wildcards ? and * are supported'
-    );
-    $this->addOption('d|directory', '=s',
-      'Comma-separated list of directories to (recursively) parse.'
-    );
-    $this->addOption('t|target', '-s',
-      'Path where to store the generated output (optional, defaults to "output")'
-    );
-    $this->addOption('e|extensions', '-s',
-      'Optional comma-separated list of extensions to parse, defaults to php, php3 and phtml'
-    );
-    $this->addOption('i|ignore', '-s',
-      'Comma-separated list of file(s) and directories that will be ignored. Wildcards * and ? are supported'
-    );
-    $this->addOption('m|markers', '-s',
-      'Comma-separated list of markers/tags to filter, (optional, defaults to: "TODO,FIXME")'
-    );
-    $this->addOption('v|verbose', '',
-      'Provides additional information during parsing, usually only needed for debugging purposes'
-    );
-    $this->addOption('title', '-s',
-      'Sets the title for this project; default is the DocBlox logo'
-    );
-    $this->addOption('template', '-s',
-      'Sets the template to use when generating the output'
-    );
-    $this->addOption('force', '',
-      'Forces a full build of the documentation, does not increment existing documentation'
-    );
-    $this->addOption('validate', '',
-      'Validates every processed file using PHP Lint, costs a lot of performance'
-    );
-  }
+    /**
+     * Sets the options and description for this task.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->addOption(
+            'f|filename', '=s',
+            'Comma-separated list of files to parse. The wildcards ? and * are supported'
+        );
+        $this->addOption(
+            'd|directory', '=s',
+            'Comma-separated list of directories to (recursively) parse.'
+        );
+        $this->addOption(
+            't|target', '-s',
+            'Path where to store the generated output (optional, defaults to "output")'
+        );
+        $this->addOption(
+            'e|extensions', '-s',
+            'Optional comma-separated list of extensions to parse, defaults to php, php3 and phtml'
+        );
+        $this->addOption(
+            'i|ignore', '-s',
+            'Comma-separated list of file(s) and directories that will be ignored. Wildcards * and ? are supported'
+        );
+        $this->addOption(
+            'm|markers', '-s',
+            'Comma-separated list of markers/tags to filter, (optional, defaults to: "TODO,FIXME")'
+        );
+        $this->addOption(
+            'v|verbose', '',
+            'Provides additional information during parsing, usually only needed for debugging purposes'
+        );
+        $this->addOption(
+            'title', '-s',
+            'Sets the title for this project; default is the DocBlox logo'
+        );
+        $this->addOption(
+            'template', '-s',
+            'Sets the template to use when generating the output'
+        );
+        $this->addOption(
+            'force', '',
+            'Forces a full build of the documentation, does not increment existing documentation'
+        );
+        $this->addOption(
+            'validate', '',
+            'Validates every processed file using PHP Lint, costs a lot of performance'
+        );
+        $this->addOption(
+            'visibility', '-s',
+            'Specifies the parse visibility that should be displayed in the documentation (comma seperated e.g. "public,protected")'
+        );
+    }
 
-  /**
-   * Executes the transformation process.
-   *
-   * @throws Zend_Console_Getopt_Exception
-   *
-   * @return void
-   */
-  public function execute()
-  {
-    $task = new DocBlox_Task_Project_Parse();
-    $task->setFilename($this->getFilename());
-    $task->setDirectory($this->getDirectory());
-    $task->setTarget($this->getTarget());
-    $task->setExtensions($this->getExtensions());
-    $task->setIgnore($this->getIgnore());
-    $task->setMarkers($this->getMarkers());
-    $task->setConfig($this->getConfig());
-    $task->setVerbose($this->getVerbose());
-    $task->setQuiet($this->getQuiet());
-    $task->setTitle($this->getTitle());
-    $task->setForce($this->getForce());
-    $task->setValidate($this->getValidate());
-    $task->execute();
+    /**
+     * Executes the transformation process.
+     *
+     * @throws Zend_Console_Getopt_Exception
+     *
+     * @return void
+     */
+    public function execute()
+    {
+        $task = new DocBlox_Task_Project_Parse();
+        $task->setFilename($this->getFilename());
+        $task->setDirectory($this->getDirectory());
+        $task->setTarget($this->getTarget());
+        $task->setExtensions($this->getExtensions());
+        $task->setIgnore($this->getIgnore());
+        $task->setMarkers($this->getMarkers());
+        $task->setConfig($this->getConfig());
+        $task->setVerbose($this->getVerbose());
+        $task->setQuiet($this->getQuiet());
+        $task->setTitle($this->getTitle());
+        $task->setForce($this->getForce());
+        $task->setValidate($this->getValidate());
+        $task->setVisibility($this->getVisibility());
+        $task->execute();
 
-    $transform = new DocBlox_Task_Project_Transform();
-    $transform->setTarget($task->getTarget());
-    $transform->setTemplate($this->getTemplate());
-    $transform->setSource($task->getTarget() . DIRECTORY_SEPARATOR . 'structure.xml');
-    $transform->setVerbose($task->getVerbose());
-    $transform->setQuiet($task->getQuiet());
-    $transform->execute();
-  }
+        $transform = new DocBlox_Task_Project_Transform();
+        $transform->setTarget($task->getTarget());
+        $transform->setTemplate($this->getTemplate());
+        $transform->setSource($task->getTarget() . DIRECTORY_SEPARATOR . 'structure.xml');
+        $transform->setVerbose($task->getVerbose());
+        $transform->setQuiet($task->getQuiet());
+        $transform->execute();
+    }
 
 }

--- a/tests/ui/docblox-no-params.phpt
+++ b/tests/ui/docblox-no-params.phpt
@@ -54,4 +54,5 @@ Usage:
 --template [STRING]        Sets the template to use when generating the output
 --force                    Forces a full build of the documentation, does not increment existing documentation
 --validate                 Validates every processed file using PHP Lint, costs a lot of performance
+--visibility [STRING]      Specifies the parse visibility that should be displayed in the documentation (comma seperated e.g. "public,protected")
 -c [--config] [STRING]     Configuration filename OR "none", when this option is omitted DocBlox tries to load the docblox.xml or docblox.dist.xml from the current working directory

--- a/tests/ui/docblox-project-parse.phpt
+++ b/tests/ui/docblox-project-parse.phpt
@@ -45,4 +45,5 @@ Usage:
 --title [STRING]           Sets the title for this project; default is the DocBlox logo
 --force                    Forces a full build of the documentation, does not increment existing documentation
 --validate                 Validates every processed file using PHP Lint, costs a lot of performance
+--visibility [STRING]      Specifies the parse visibility that should be displayed in the documentation (comma seperated e.g. "public,protected")
 -c [--config] [STRING]     Configuration filename OR "none", when this option is omitted DocBlox tries to load the docblox.xml or docblox.dist.xml from the current working directory

--- a/tests/unit/DocBlox/ParserTest.php
+++ b/tests/unit/DocBlox/ParserTest.php
@@ -116,4 +116,17 @@ class DocBlox_ParserTest extends PHPUnit_Framework_TestCase
     $this->fixture->getRelativeFilename(realpath(dirname(__FILE__).'/../phpunit.xml'));
   }
 
+  /**
+   * Make sure the setter can transform string to array and set correct attribute
+   *
+   * @covers DocBlox_Parser::setVisibility
+   *
+   * @return void
+   */
+  public function testSetVisibilityCorrectlySetsAttribute()
+  {
+      $this->fixture->setVisibility('public,protected,private');
+      $this->assertAttributeEquals(array('public', 'protected', 'private'), 'visibility', $this->fixture);
+  }
+
 }


### PR DESCRIPTION
 Set the visibility parse level for properties and functions as discussed in GH #93

Take into account the @access tag if used as discussed on allow an override from the docblox.xml configuration
- Rules:
  - By default everything is parsed
  - If --visibility it used then we look for those specific visibility modifiers
  - If it can match against the method level it will
  - Then it will look at the @access tag
  - If a function is defined without access modifier and no docblock comment it will be allowed through

I've also made a second commit which is PEAR coding standard changes.
