### PR TITLE
Refactored xml generation for tag classes

### DIFF
--- a/src/DocBlox/Reflection/DocBlock/Tag/Link.php
+++ b/src/DocBlox/Reflection/DocBlock/Tag/Link.php
@@ -16,7 +16,7 @@
  * @author    Ben Selby <benmatselby@gmail.com>
  * @copyright Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
  */
-class DocBlox_Reflection_DocBlock_Tag_Link extends DocBlox_Reflection_DocBlock_Tag
+class DocBlox_Reflection_DocBlock_Tag_Link extends DocBlox_Reflection_DocBlock_Tag implements DocBlox_Reflection_DocBlock_Tag_TagInterface
 {
     /** @var string */
     protected $link = '';
@@ -67,5 +67,17 @@ class DocBlox_Reflection_DocBlock_Tag_Link extends DocBlox_Reflection_DocBlock_T
     public function setLink($link)
     {
         $this->link = $link;
+    }
+
+   /**
+    * Implements DocBlox_Reflection_DocBlock_Tag_TagInterface
+    * 
+    * @param SimpleXMLElement $xml Relative root of xml document
+    */
+    public function __toXml(SimpleXMLElement $xml)
+    {
+        parent::__toXml($xml);
+
+        $xml['link'] = $this->getLink();
     }
 }

--- a/src/DocBlox/Reflection/DocBlock/Tag/Param.php
+++ b/src/DocBlox/Reflection/DocBlock/Tag/Param.php
@@ -14,7 +14,7 @@
  * @package    Static_Reflection
  * @author     Mike van Riel <mike.vanriel@naenius.com>
  */
-class DocBlox_Reflection_DocBlock_Tag_Param extends DocBlox_Reflection_DocBlock_Tag
+class DocBlox_Reflection_DocBlock_Tag_Param extends DocBlox_Reflection_DocBlock_Tag implements DocBlox_Reflection_DocBlock_Tag_TagInterface
 {
   /** @var string */
   protected $type = null;
@@ -94,5 +94,43 @@ class DocBlox_Reflection_DocBlock_Tag_Param extends DocBlox_Reflection_DocBlock_
   public function setVariableName($name)
   {
     $this->variableName = $name;
+  }
+
+  /**
+   * Implements DocBlox_Reflection_DocBlock_Tag_TagInterface
+   * 
+   * @param SimpleXMLElement $xml Relative root of xml document
+   */
+  public function __toXml(SimpleXMLElement $xml)
+  {
+      parent::__toXml($xml);
+
+      foreach($this->getTypes() as $type)
+      {
+          if ($type == '')
+          {
+              continue;
+          }
+
+          $type = trim($this->docblock->expandType($type));
+
+          // strip ampersands
+          $name = str_replace('&', '', $type);
+          $type_object = $xml->addChild('type', $name);
+
+          // register whether this variable is by reference by checking the first and last character
+          $type_object['by_reference'] = ((substr($type, 0, 1) === '&') || (substr($type, -1) === '&'))
+              ? 'true'
+              : 'false';
+      }
+
+      $xml['type'] = $this->docblock->expandType($this->getType());
+
+      if (trim($this->getVariableName()) == '')
+      {
+          // TODO: get the name from the argument list
+      }
+
+      $xml['variable'] = $this->getVariableName();
   }
 }

--- a/src/DocBlox/Reflection/DocBlock/Tag/Return.php
+++ b/src/DocBlox/Reflection/DocBlock/Tag/Return.php
@@ -14,7 +14,7 @@
  * @package    Static_Reflection
  * @author     Mike van Riel <mike.vanriel@naenius.com>
  */
-class DocBlox_Reflection_DocBlock_Tag_Return extends DocBlox_Reflection_DocBlock_Tag
+class DocBlox_Reflection_DocBlock_Tag_Return extends DocBlox_Reflection_DocBlock_Tag_Param
 {
   /** @var string */
   protected $type = null;

--- a/src/DocBlox/Reflection/DocBlock/Tag/TagInterface.php
+++ b/src/DocBlox/Reflection/DocBlock/Tag/TagInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * DocBlox
+ *
+ * @category   DocBlox
+ * @package    Static_Reflection
+ * @copyright  Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ */
+
+/**
+ * Reflection class for a DocBloxk Tag declaration.
+ *
+ * @category   DocBlox
+ * @package    Static_Reflection
+ * @author     Herman J. Radtke III <hermanradtke@gmail.com>
+ */
+interface DocBlox_Reflection_DocBlock_Tag_TagInterface
+{
+    /**
+     * Represent a tag instance in xml format.
+     * 
+     * @param SimpleXMLElement $xml Relative root of xml document
+     */
+    public function __toXml(SimpleXMLElement $xml);
+}
+

--- a/src/DocBlox/Reflection/DocBlock/Tag/Var.php
+++ b/src/DocBlox/Reflection/DocBlock/Tag/Var.php
@@ -14,7 +14,7 @@
  * @package    Static_Reflection
  * @author     Mike van Riel <mike.vanriel@naenius.com>
  */
-class DocBlox_Reflection_DocBlock_Tag_Var extends DocBlox_Reflection_DocBlock_Tag_Param
+class DocBlox_Reflection_DocBlock_Tag_Var extends DocBlox_Reflection_DocBlock_Tag_Param implements DocBlox_Reflection_DocBlock_Tag_TagInterface
 {
   /**
    * Parses a tag and populates the member variables.
@@ -46,5 +46,17 @@ class DocBlox_Reflection_DocBlock_Tag_Var extends DocBlox_Reflection_DocBlock_Ta
     }
 
     $this->description = implode(' ', $content);
+  }
+
+  /**
+   * Implements DocBlox_Reflection_DocBlock_Tag_TagInterface
+   * 
+   * @param SimpleXMLElement $xml Relative root of xml document
+   */
+  public function __toXml(SimpleXMLElement $xml)
+  {
+    parent::__toXml($xml);
+
+    $xml['description'] = trim($this->getDescription());
   }
 }


### PR DESCRIPTION
Refactored the generation of tag xml information by making all tag classes implement an interface that uses the standard __toXml fucntion.

I ran this against zf2 and it was very close to master:
2011-05-12T11:31:37-07:00 INFO (6): [30.28mb]: Elapsed time to parse all files: 375.19s
2011-05-12T11:31:37-07:00 INFO (6): [30.28mb]: Peak memory usage: 110.53M
