### PR TITLE
Include of Image/Graphviz.php moved

### DIFF
--- a/src/DocBlox/Core/Application.php
+++ b/src/DocBlox/Core/Application.php
@@ -27,7 +27,6 @@ class DocBlox_Core_Application
    */
   public function main()
   {
-    require_once 'Image/GraphViz.php';
     require_once 'markdown.php';
 
     $runner = new DocBlox_Task_Runner(($_SERVER['argc'] == 1) ? false : $_SERVER['argv'][1], 'project:run');

--- a/src/DocBlox/Transformer/Writer/Graph.php
+++ b/src/DocBlox/Transformer/Writer/Graph.php
@@ -29,6 +29,8 @@ class DocBlox_Transformer_Writer_Graph extends DocBlox_Transformer_Writer_Abstra
      */
     public function transform(DOMDocument $structure, DocBlox_Transformer_Transformation $transformation)
     {
+        require_once 'Image/GraphViz.php';
+        
         // NOTE: the -V flag sends output using STDERR and STDOUT
         exec('dot -V 2>&1', $output, $error);
         if ($error != 0) {


### PR DESCRIPTION
Small pull request; because the Phing integration code will not call DocBlox/Core/Application.php, Image/Graphviz.php will not be loaded. To make sure that does happen, I moved the require_once to DocBlox/Transformer/Writer/Graph.php.

groetjes,

Michiel
