### PR TITLE
Added support for ignoring whole directories, without wildcards

### DIFF
--- a/src/DocBlox/Task/Project/Parse.php
+++ b/src/DocBlox/Task/Project/Parse.php
@@ -268,6 +268,7 @@ class DocBlox_Task_Project_Parse extends DocBlox_Task_ConfigurableAbstract
         }
         $parser->setExistingXml($this->getTarget() . '/structure.xml');
         $parser->setIgnorePatterns($this->getIgnore());
+        $parser->setExtensions($this->getExtensions());
         $parser->setForced($this->getForce());
         $parser->setMarkers($this->getMarkers());
         $parser->setValidate($this->getValidate());


### PR DESCRIPTION
We have some paths that we want to ignore entirely -- third party files. The wildcard method looks like it would only ignore one level of directories (-i /foo/bar/baz/\* would allow /foo/bar/baz/frank/index.php).

This code adds automatic detection of file and directory ignores (based on path extension).
