### PR TITLE
Return non-zero exit codes when there is an application failure

### DIFF
--- a/src/DocBlox/Core/Application.php
+++ b/src/DocBlox/Core/Application.php
@@ -50,6 +50,13 @@ class DocBlox_Core_Application
     {
       echo 'ERROR: '.$e->getMessage().PHP_EOL.PHP_EOL;
       echo $task->getUsageMessage();
+      // exit with the exception's code or 1 if null/0
+      $exit = $e->getCode();
+      if (!$exit)
+      {
+        $exit = 1;
+      }
+      exit($exit);
     }
   }
 


### PR DESCRIPTION
docblox always exits 0 indicating success. This fix enables non-zero exit codes on failure so that you can properly check for failure in ant and other automated build tools
