### PR TITLE
Insert from node if not present in graph.

### DIFF
--- a/src/DocBlox/Transformer/Writer/Graph.php
+++ b/src/DocBlox/Transformer/Writer/Graph.php
@@ -180,6 +180,14 @@ class DocBlox_Transformer_Writer_Graph extends DocBlox_Transformer_Writer_Abstra
             $from = $graph->findNode(str_replace(array('\\', '$'), '_', $from_name));
             $to = $graph->findNode(str_replace(array('\\', '$'), '_', $to_name));
 
+            if ($from === null)
+                {
+                    $from = DocBlox_GraphViz_Node::create(str_replace(array('\\', '$'), '_', $from_name));
+                    $from->setFontColor('gray');
+                    $from->setLabel(addslashes($from_name));
+                    $graph->setNode($from);
+                }
+
             if ($to === null)
             {
                 $to = DocBlox_GraphViz_Node::create(str_replace(array('\\', '$'), '_', $to_name));
@@ -209,6 +217,14 @@ class DocBlox_Transformer_Writer_Graph extends DocBlox_Transformer_Writer_Abstra
 
                 $from = $graph->findNode(str_replace(array('\\', '$'), '_', $from_name));
                 $to = $graph->findNode(str_replace(array('\\', '$'), '_', $to_name));
+
+                if ($from === null)
+                {
+                    $from = DocBlox_GraphViz_Node::create(str_replace(array('\\', '$'), '_', $from_name));
+                    $from->setFontColor('gray');
+                    $from->setLabel(addslashes($from_name));
+                    $graph->setNode($from);
+                }
 
                 if ($to === null) {
                     $to = DocBlox_GraphViz_Node::create(str_replace(array('\\', '$'), '_', $to_name));


### PR DESCRIPTION
Fixes a PHP Catchable fatal error:  Argument 1 passed to DocBlox_GraphViz_Edge::create() must be an instance of DocBlox_GraphViz_Node, null given, called in /src/DocBlox/Transformer/Writer/Graph.php on line 220 and defined in /src/DocBlox/GraphViz/Edge.php on line 44
