### PR TITLE
Issue 34 stop multiple reporting no method docblock

### DIFF
--- a/src/DocBlox/Parser/DocBlock/Validator/Abstract.php
+++ b/src/DocBlox/Parser/DocBlock/Validator/Abstract.php
@@ -55,7 +55,7 @@ abstract class DocBlox_Parser_DocBlock_Validator_Abstract
      *
      * @var DocBlox_Reflection_Abstract
      */
-    protected $source;
+    protected $_source;
 
     /**
      * Constructor
@@ -71,7 +71,7 @@ abstract class DocBlox_Parser_DocBlock_Validator_Abstract
         $this->_entityName = $name;
         $this->_lineNumber = $lineNumber;
         $this->_docblock   = $docblock;
-        $this->source      = $source;
+        $this->_source      = $source;
     }
 
     /**

--- a/src/DocBlox/Parser/DocBlock/Validator/File.php
+++ b/src/DocBlox/Parser/DocBlock/Validator/File.php
@@ -37,9 +37,11 @@ class DocBlox_Parser_DocBlock_Validator_File
      */
     public function isValid()
     {
-        if (!$this->_docblock || $this->_docblock->hasTag('package')) {
-            $this->logParserError('ERROR', 'No Page-level DocBlock '
-                    . 'was found in file ' . $this->source->getFilename(), $this->_lineNumber);
+        if (!$this->_docblock || !$this->_docblock->hasTag('package')) {
+            $this->logParserError(
+                'ERROR', 'No Page-level DocBlock '
+                . 'was found in file ' . $this->_source->getFilename(), $this->_lineNumber
+            );
             return false;
         }
 

--- a/src/DocBlox/Parser/DocBlock/Validator/Method.php
+++ b/src/DocBlox/Parser/DocBlock/Validator/Method.php
@@ -42,8 +42,8 @@ class DocBlox_Parser_DocBlock_Validator_Method
         if (null == $this->_docblock) {
             $this->logParserError(
                 'ERROR',
-                'No Method DocBlock '
-                . 'was found for ' . $this->_entityName, $this->_lineNumber
+                'No DocBlock was found for method '
+                . $this->_entityName, $this->_lineNumber
             );
             return false;
         }

--- a/src/DocBlox/Reflection/DocBlockedAbstract.php
+++ b/src/DocBlox/Reflection/DocBlockedAbstract.php
@@ -73,14 +73,7 @@ abstract class DocBlox_Reflection_DocBlockedAbstract extends DocBlox_Reflection_
             $this->log($e->getMessage(), Zend_Log::CRIT);
         }
 
-        $this->validateDocBlock($this->name, $docblock ? $docblock->line_number : 0, $result);
-
-        // if the object has no DocBlock _and_ is not a Closure; throw a warning
-        $type = substr(get_class($this), strrpos(get_class($this), '_') + 1);
-        if (!$result && (($type !== 'Function') && ($this->getName() !== 'Closure'))) {
-            $this->logParserError('ERROR', 'No DocBlock was found for ' . $type
-                    . ' ' . $this->getName(), $this->getLineNumber());
-        }
+        $this->validateDocBlock($this->name, $this->line_start, $result);
 
         return $result;
     }

--- a/tests/data/NoMethodDocBlock.php
+++ b/tests/data/NoMethodDocBlock.php
@@ -8,7 +8,6 @@
  * @author     Ben Selby <benmatselby@gmail.com>
  * @author     Mike van Riel <mike.vanriel@naenius.com>
  */
-
 /**
  * No method no block class
  *


### PR DESCRIPTION
Remove the duplication of reporting no docblocks this should be done in the validators
- Fixed some phpcs errors
- Updated the ! as found in https://github.com/mvriel/Docblox/commit/bbdb552c07545b348274a806eb7b3cfe0dce92c6#src/DocBlox/Parser/DocBlock/Validator/File.php-P5
