### PR TITLE
Default template was copying folders and files from the project to the documentation folders

### DIFF
--- a/data/themes/default/template.xml
+++ b/data/themes/default/template.xml
@@ -5,8 +5,8 @@
   <copyright>Mike van Riel / Naenius 2011</copyright>
   <transformations>
     <transformation query="copy" writer="FileIo" source="ajax_search.php" artifact="ajax_search.php"/>
-    <transformation query="copy" writer="FileIo" source="js" artifact="js"/>
-    <transformation query="copy" writer="FileIo" source="images" artifact="images"/>
+    <transformation query="copy" writer="FileIo" source="../data/js" artifact="js"/>
+    <transformation query="copy" writer="FileIo" source="../data/images" artifact="images"/>
     <transformation query="copy" writer="FileIo" source="themes/default/css" artifact="css"/>
     <transformation query="copy" writer="FileIo" source="themes/default/images" artifact="images"/>
     <transformation query="" writer="Search" source="" artifact="."/>


### PR DESCRIPTION
Hey Mike, 

I have changed the default template.xml so it does not copy files from my project to the docs folder, when copying the default js and images folders. These folders where exactly named as the project folders 'js and images' for example. Which made jQuery crash the template.
