### PR TITLE
Gh 289

### DIFF
--- a/src/DocBlox/Plugin.php
+++ b/src/DocBlox/Plugin.php
@@ -60,9 +60,19 @@ class DocBlox_Plugin extends DocBlox_Plugin_Abstract
             ? $xml->options
             : array($xml->options);
 
-        foreach ($options as $option) {
-            $this->options[$option['name']] = (string)$option;
+        foreach ($options->option as $option) {
+            $key = (string)$option['name'];
+            $this->options[$key] = $option;
         }
     }
 
+    /**
+     * Return the options that have been set
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
 }

--- a/src/DocBlox/Plugin/Core/Listener.php
+++ b/src/DocBlox/Plugin/Core/Listener.php
@@ -93,22 +93,27 @@ class DocBlox_Plugin_Core_Listener extends DocBlox_Plugin_ListenerAbstract
             return;
         }
 
-        $class = 'DocBlox_Plugin_Core_Parser_DocBlock_Validator_' . $type;
-        if (@class_exists($class)) {
-            /** @var DocBlox_Plugin_Core_Parser_DocBlock_Validator_Abstract $validator  */
-            $validator = new $class(
-                $element->getName(),
-                $docblock->line_number,
-                $docblock,
-                $element
-            );
+        $validatorOptions = $this->loadConfiguration();
 
-            $validator->isValid();
+        foreach (array('Deprecated', 'Required', $type) as $validator) {
+
+            $class = 'DocBlox_Plugin_Core_Parser_DocBlock_Validator_' . $validator;
+            if (@class_exists($class)) {
+
+                $val = new $class(
+                    $element->getName(),
+                    $docblock->line_number,
+                    $docblock,
+                    $element
+                );
+
+                $val->setOptions($validatorOptions);
+                $val->isValid();
+            }
         }
     }
 
     /**
-     *
      * @docblox-event reflection.docblock.tag.export
      *
      * @param sfEvent $data
@@ -126,5 +131,53 @@ class DocBlox_Plugin_Core_Listener extends DocBlox_Plugin_ListenerAbstract
             $data['xml'],
             $data['object']
         );
+    }
+
+    /**
+     * Load the configuration from the plugin.xml file
+     *
+     * @return array
+     */
+    protected function loadConfiguration()
+    {
+        $configOptions = $this->plugin->getOptions();
+        $validatorOptions = array();
+
+        foreach (array('deprecated', 'required') as $tag) {
+            $validatorOptions[$tag] = $this->loadConfigurationByElement($configOptions, $tag);
+        }
+
+        return $validatorOptions;
+    }
+
+    /**
+     * Load the configuration for given element (deprecated/required)
+     *
+     * @param array  $configOptions The configuration from the plugin.xml file
+     * @param string $configType    Required/Deprecated for the time being
+     *
+     * @return array
+     */
+    protected function loadConfigurationByElement($configOptions, $configType)
+    {
+        $validatorOptions = array();
+
+        if (isset($configOptions[$configType]->tag)) {
+
+            foreach ($configOptions[$configType]->tag as $tag) {
+                $tagName = (string)$tag['name'];
+
+                if (isset($tag->element)) {
+                    foreach ($tag->element as $type) {
+                        $typeName = (string)$type;
+                        $validatorOptions[$typeName][] = $tagName;
+                    }
+                } else {
+                    $validatorOptions['__ALL__'][] = $tagName;
+                }
+            }
+        }
+
+        return $validatorOptions;
     }
 }

--- a/src/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Abstract.php
+++ b/src/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Abstract.php
@@ -58,6 +58,13 @@ abstract class DocBlox_Plugin_Core_Parser_DocBlock_Validator_Abstract
     protected $_source;
 
     /**
+     * Array of options that may or may not be used whilst validating
+     *
+     * @var array
+     */
+    protected $_options;
+
+    /**
      * Constructor
      *
      * @param string                           $name       Name of the "entity"
@@ -72,6 +79,20 @@ abstract class DocBlox_Plugin_Core_Parser_DocBlock_Validator_Abstract
         $this->_lineNumber = $lineNumber;
         $this->_docblock   = $docblock;
         $this->_source      = $source;
+    }
+
+    /**
+     * Set the options that may be used whilst validating the docblocks.
+     * Can contain configuration as long as each validator knows how to
+     * interrogate it
+     *
+     * @param array $options Options that may be used during validation
+     *
+     * @return void
+     */
+    public function setOptions($options)
+    {
+        $this->_options = $options;
     }
 
     /**

--- a/src/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Deprecated.php
+++ b/src/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Deprecated.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * File contains the DocBlox_Plugin_Core_Parser_DocBlock_Validator_Deprecated class
+ *
+ * PHP Version 5
+ *
+ * @category   DocBlox
+ * @package    Parser
+ * @subpackage DocBlock_Validators
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright  2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://docblox-project.org
+ */
+/**
+ * This class is responsible for validating which tags are deprecated
+ * as defined in Docblox/src/DocBlox/Plugin/Core/plugin.xml
+ *
+ * @category   DocBlox
+ * @package    Parser
+ * @subpackage DocBlock_Validators
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright  2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://docblox-project.org
+ */
+class DocBlox_Plugin_Core_Parser_DocBlock_Validator_Deprecated
+    extends DocBlox_Plugin_Core_Parser_DocBlock_Validator_Abstract
+{
+    /**
+     * Is the docblock valid based on the rules defined in plugin.xml
+     *
+     * <options>
+     *   <option name="deprecated">
+     *      <tag name="deprecated" />
+     *      <tag name="access" />
+     *   </option>
+     *   <option name="required">
+     *     <tag name="package">
+     *       <element>DocBlox_Reflection_File</element>
+     *       <element>DocBlox_Reflection_Class</element>
+     *     </tag>
+     *     <tag name="subpackage">
+     *       <element>DocBlox_Reflection_File</element>
+     *       <element>DocBlox_Reflection_Class</element>
+     *     </tag>
+     *   </option>
+     * </options>
+     *
+     * @see DocBlox_Plugin_Core_Parser_DocBlock_Validator_Abstract::isValid()
+     */
+    public function isValid()
+    {
+        $docType = get_class($this->_source);
+        if (isset($this->_options['deprecated'][$docType])) {
+            $this->validateTags($docType);
+        } else if (isset($this->_options['deprecated']['__ALL__'])) {
+            $this->validateTags('__ALL__');
+        }
+    }
+
+    /**
+     * Validate the tags based on the type of docblock being
+     * parsed etc
+     *
+     * @param string $key Access key to $this->_options['required']
+     *
+     * @return void
+     */
+    protected function validateTags($key)
+    {
+        foreach ($this->_options['deprecated'][$key] as $tag) {
+
+            if (count($this->_docblock->getTagsByName($tag)) > 0) {
+                $this->logParserError(
+                    'CRITICAL', 'Found deprecated tag "' . $tag .'" in ' . $this->_entityName, $this->_lineNumber
+                );
+            }
+        }
+    }
+}

--- a/src/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Required.php
+++ b/src/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Required.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * File contains the DocBlox_Plugin_Core_Parser_DocBlock_Validator_Required class
+ *
+ * PHP Version 5
+ *
+ * @category   DocBlox
+ * @package    Parser
+ * @subpackage DocBlock_Validators
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright  2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://docblox-project.org
+ */
+/**
+ * This class is responsible for validating which tags are required
+ * as defined in Docblox/src/DocBlox/Plugin/Core/plugin.xml
+ *
+ * @category   DocBlox
+ * @package    Parser
+ * @subpackage DocBlock_Validators
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright  2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://docblox-project.org
+ */
+class DocBlox_Plugin_Core_Parser_DocBlock_Validator_Required
+    extends DocBlox_Plugin_Core_Parser_DocBlock_Validator_Abstract
+{
+    /**
+     * Is the docblock valid based on the rules defined in plugin.xml
+     *
+     * <options>
+     *   <option name="deprecated">
+     *      <tag name="deprecated" />
+     *      <tag name="access" />
+     *   </option>
+     *   <option name="required">
+     *     <tag name="package">
+     *       <element>DocBlox_Reflection_File</element>
+     *       <element>DocBlox_Reflection_Class</element>
+     *     </tag>
+     *     <tag name="subpackage">
+     *       <element>DocBlox_Reflection_File</element>
+     *       <element>DocBlox_Reflection_Class</element>
+     *     </tag>
+     *   </option>
+     * </options>
+     *
+     * @see DocBlox_Plugin_Core_Parser_DocBlock_Validator_Abstract::isValid()
+     */
+    public function isValid()
+    {
+        $docType = get_class($this->_source);
+        if (isset($this->_options['required'][$docType])) {
+            $this->validateTags($docType);
+        } else if (isset($this->_options['required']['__ALL__'])) {
+            $this->validateTags('__ALL__');
+        }
+    }
+
+    /**
+     * Validate the tags based on the type of docblock being
+     * parsed etc
+     *
+     * @param string $key Access key to $this->_options['required']
+     *
+     * @return void
+     */
+    protected function validateTags($key)
+    {
+
+        foreach ($this->_options['required'][$key] as $tag) {
+
+            if (count($this->_docblock->getTagsByName($tag)) == 0) {
+
+                $this->logParserError(
+                    'CRITICAL', 'Not found required tag "' . $tag .'" in ' . $this->_entityName, $this->_lineNumber
+                );
+            }
+        }
+    }
+}

--- a/tests/unit/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Deprecated.php
+++ b/tests/unit/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Deprecated.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * DocBlox_Plugin_Core_Parser_DocBlock_Validator_Deprecated Test
+ *
+ * @category   DocBlox
+ * @package    Reflection
+ * @subpackage Tests
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @copyright  Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ */
+/**
+ * Test class for DocBlox_Plugin_Core_Parser_DocBlock_Validator_Deprecated
+ *
+ * @category   DocBlox
+ * @package    Reflection
+ * @subpackage Tests
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @copyright  Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ */
+class DocBlox_Plugin_Core_Parser_DocBlock_Validator_DeprecatedTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that isValid can interpret the configuration options and log parse
+     * errors as required
+     *
+     * @param array  $options     Options from the plugin.xml file
+     * @param string $entity      The entity we are validating
+     * @param int    $lineNumber  The line number of the entity
+     * @param int    $tagCount    The amount of tags found
+     * @param string $logCount    PHPUnit expects assertion string
+     * @param string $expectedLog The line we expect to be logged
+     *
+     * @covers DocBlox_Plugin_Core_Parser_DocBlock_Validator_Deprecated::isValid
+     * @covers DocBlox_Plugin_Core_Parser_DocBlock_Validator_Deprecated::validateTags
+     * @dataProvider provideDataForIsValid
+     *
+     * @return void
+     */
+    public function testIsValidCanLogErrorsDependingOnConfigurationOptions($docblock, $options, $entity, $lineNumber, $tagCount, $logCount, $expectedLog)
+    {
+        $docblock = new DocBlox_Reflection_DocBlock(
+            $docblock
+        );
+
+        $val = $this->getMock(
+            'DocBlox_Plugin_Core_Parser_DocBlock_Validator_Deprecated',
+            array('logParserError', 'debug'),
+            array($entity, $lineNumber, $docblock)
+        );
+
+        if ($logCount != 'never') {
+            $val->expects($this->$logCount())
+                ->method('logParserError')
+                ->with($this->equalTo('CRITICAL'), $this->equalTo($expectedLog), $this->equalTo($lineNumber));
+        } else {
+            $val->expects($this->$logCount())
+                ->method('logParserError');
+        }
+
+        $val->setOptions($options);
+
+        $val->isValid();
+    }
+
+    /**
+     * Data provider for testIsValidLogsErrorsForMissingRequiredTags
+     *
+     * @return array
+     */
+    public function provideDataForIsValid()
+    {
+        return array(
+            // Data Set 0
+            // Found deprecated tag, therefore logged
+            array(
+                '/**
+                  * Short description
+                  *
+                  * @deprecated
+                  */',
+                array(
+                    'deprecated' => array(
+                        '__ALL__' => array('deprecated')
+                    )
+                ),
+                'File.php',
+                1,
+                0,
+                'once',
+                'Found deprecated tag "deprecated" in File.php'
+            ),
+
+            // Data Set 1
+            // Didn't find deprecated tag, therefore not logged
+            array(
+                '/**
+                  * Short description
+                  *
+                  */',
+                array(
+                    'deprecated' => array(
+                        '__ALL__' => array('deprecated')
+                    )
+                ),
+                'File.php',
+                1,
+                0,
+                'never',
+                ''
+            ),
+
+            // Data Set 2
+            // Found deprecated tag, therefore logged
+            array(
+                '/**
+                  * Short description
+                  *
+                  * @deprecated
+                  */',
+                array(
+                    'deprecated' => array(
+                        'DocBlox_Plugin_Core_Parser_DocBlock_Validator_Deprecated' => array('deprecated')
+                    )
+                ),
+                'File.php',
+                1,
+                0,
+                'once',
+                'Found deprecated tag "deprecated" in File.php'
+            ),
+
+            // Data Set 3
+            // Didn't find deprecated tag, therefore not logged
+            array(
+                '/**
+                  * Short description
+                  *
+                  */',
+                array(
+                    'deprecated' => array(
+                        'DocBlox_Plugin_Core_Parser_DocBlock_Validator_Deprecated' => array('deprecated')
+                    )
+                ),
+                'File.php',
+                1,
+                0,
+                'never',
+                ''
+            ),
+        );
+    }
+}

--- a/tests/unit/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Required.php
+++ b/tests/unit/DocBlox/Plugin/Core/Parser/DocBlock/Validator/Required.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * DocBlox_Plugin_Core_Parser_DocBlock_Validator_Required Test
+ *
+ * @category   DocBlox
+ * @package    Reflection
+ * @subpackage Tests
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @copyright  Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ */
+/**
+ * Test class for DocBlox_Plugin_Core_Parser_DocBlock_Validator_Required
+ *
+ * @category   DocBlox
+ * @package    Reflection
+ * @subpackage Tests
+ * @author     Ben Selby <benmatselby@gmail.com>
+ * @copyright  Copyright (c) 2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ */
+class DocBlox_Plugin_Core_Parser_DocBlock_Validator_RequiredTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that isValid can interpret the configuration options and log parse
+     * errors as required
+     *
+     * @param array  $options     Options from the plugin.xml file
+     * @param string $entity      The entity we are validating
+     * @param int    $lineNumber  The line number of the entity
+     * @param int    $tagCount    The amount of tags found
+     * @param string $logCount    PHPUnit expects assertion string
+     * @param string $expectedLog The line we expect to be logged
+     *
+     * @covers DocBlox_Plugin_Core_Parser_DocBlock_Validator_Required::isValid
+     * @covers DocBlox_Plugin_Core_Parser_DocBlock_Validator_Required::validateTags
+     * @dataProvider provideDataForIsValid
+     *
+     * @return void
+     */
+    public function testIsValidCanLogErrorsDependingOnConfigurationOptions($docblock, $options, $entity, $lineNumber, $tagCount, $logCount, $expectedLog)
+    {
+        $docblock = new DocBlox_Reflection_DocBlock(
+            $docblock
+        );
+
+        $val = $this->getMock(
+            'DocBlox_Plugin_Core_Parser_DocBlock_Validator_Required',
+            array('logParserError', 'debug'),
+            array($entity, $lineNumber, $docblock)
+        );
+
+        if ($logCount != 'never') {
+            $val->expects($this->$logCount())
+                ->method('logParserError')
+                ->with($this->equalTo('CRITICAL'), $this->equalTo($expectedLog), $this->equalTo($lineNumber));
+        } else {
+            $val->expects($this->$logCount())
+                ->method('logParserError');
+        }
+
+        $val->setOptions($options);
+
+        $val->isValid();
+    }
+
+    /**
+     * Data provider for testIsValidLogsErrorsForMissingRequiredTags
+     *
+     * @return array
+     */
+    public function provideDataForIsValid()
+    {
+        return array(
+            // Data Set 0
+            // Cannot find tag that is required, therefore logged
+            array(
+                '/**
+                  * Short description without access tag
+                  *
+                  *
+                  */',
+                array(
+                    'required' => array(
+                        '__ALL__' => array('access')
+                    )
+                ),
+                'File.php',
+                1,
+                0,
+                'once',
+                'Not found required tag "access" in File.php'
+            ),
+
+            // Data Set 1
+            // Find tag that is required, therefore not logged
+            array(
+                '/**
+                  * Short description with access tag
+                  *
+                  * @access
+                  */',
+                array(
+                    'required' => array(
+                        '__ALL__' => array('access')
+                    )
+                ),
+                'File.php',
+                1,
+                0,
+                'never',
+                ''
+            ),
+
+            // Data Set 2
+            // Find tag that is required for certain type, therefore not logged
+            array(
+                '/**
+                  * Short description with access tag
+                  *
+                  * @access
+                  */',
+                array(
+                    'required' => array(
+                        'DocBlox_Plugin_Core_Parser_DocBlock_Validator_Required' => array('access')
+                    )
+                ),
+                'File.php',
+                1,
+                0,
+                'never',
+                ''
+            ),
+
+            // Data Set 3
+            // Cannot find tag that is required for certain type, therefore logged
+            array(
+                '/**
+                  * Short description without access tag
+                  *
+                  */',
+                array(
+                    'required' => array(
+                        'DocBlox_Plugin_Core_Parser_DocBlock_Validator_Required' => array('access')
+                    )
+                ),
+                'File.php',
+                1,
+                0,
+                'once',
+                'Not found required tag "access" in File.php'
+            ),
+        );
+    }
+}


### PR DESCRIPTION
The ability to define in plugin.xml for Core whether or not tags are required/deprecated based on certain docblock elements or globally
- GH-289

I've taken on board what Sebastian mentioned and changed docblock to element in the xml.. I've also removed all of the config from the standard plugin.xml as this is optionally extra, rather than default.. The only thing with this is, we need to document it in the manual, so if you can point me in the direction where we can document it, if the patch is approved I can write it up.

The structure needs to be:

```
  <options>
    <option name="deprecated">
       <tag name="deprecated" />
       <tag name="access" />
    </option>
    <option name="required">
      <tag name="package">
        <element>DocBlox_Reflection_File</element>
        <element>DocBlox_Reflection_Class</element>
      </tag>
      <tag name="subpackage">
        <element>DocBlox_Reflection_File</element>
        <element>DocBlox_Reflection_Class</element>
      </tag>
    </option>
 </options>
```

Whereby if no `<element>` is defined, then the configuration is for the global state, but if `<element>` is defined then the tag is only deprecated/required for the stated element
