### PR TITLE
Keep long description trimmed after formatting

### DIFF
--- a/src/DocBlox/Reflection/DocBlock/LongDescription.php
+++ b/src/DocBlox/Reflection/DocBlock/LongDescription.php
@@ -86,7 +86,7 @@ class DocBlox_Reflection_DocBlock_LongDescription implements Reflector
       $result = Markdown($result);
     }
 
-    return $result;
+    return trim($result);
   }
 
   /**


### PR DESCRIPTION
If long description is formatted, markdown happens to append a newline at the end.

This is a problem if we check if description is empty in template, when != '' is not true anymore.
