### PR TITLE
Fixes:  Notice: Uninitialized string offset: 0 in /usr/share/php/phpDocu...

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Transformer/Behaviour/AddLinkInformation.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Behaviour/AddLinkInformation.php
@@ -124,7 +124,10 @@ class phpDocumentor_Plugin_Core_Transformer_Behaviour_AddLinkInformation extends
             case 'see':
             case 'inherited_from':
                 $name = $element->getAttribute('refers');
-                if ($name[0] !== '\\') {
+                if (empty($name)) {
+                    $name = $element->nodeValue;
+                }
+                else if ($name[0] !== '\\') {
                     $name = '\\' . $name;
                 }
                 break;


### PR DESCRIPTION
This fixes a notice if the class that is being extended does not exist in the local source tree.
