### PR TITLE
Use the --ARGS-- section for phpt rather than writing php code for it

### DIFF
--- a/tests/ui/multiple-packages-issue-121.phpt
+++ b/tests/ui/multiple-packages-issue-121.phpt
@@ -2,18 +2,10 @@
 phpdoc project:run -f tests/data/MultiplePackagesDocBlock.php -t build
 --FILE--
 <?php
-$_SERVER['argc']    = 8;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-f';
-$_SERVER['argv'][3] = dirname(__FILE__) . '/../data/MultiplePackagesDocBlock.php';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '--config';
-$_SERVER['argv'][7] = 'none';
-
 require_once 'tests/common/ui-include.php';
-
 ?>
+--ARGS--
+project:run -f tests/data/MultiplePackagesDocBlock.php -t build --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/no-function-docblock.phpt
+++ b/tests/ui/no-function-docblock.phpt
@@ -2,18 +2,10 @@
 phpdoc project:run -f tests/data/NoFunctionDocBlock.php -t build
 --FILE--
 <?php
-$_SERVER['argc']    = 8;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-f';
-$_SERVER['argv'][3] = dirname(__FILE__) . '/../data/NoFunctionDocBlock.php';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '--config';
-$_SERVER['argv'][7] = 'none';
-
 require_once 'tests/common/ui-include.php';
-
 ?>
+--ARGS--
+project:run -f tests/data/NoFunctionDocBlock.php -t build --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/no-method-docblock.phpt
+++ b/tests/ui/no-method-docblock.phpt
@@ -2,18 +2,10 @@
 phpdoc project:run -f tests/data/NoMethodDocBlock.php -t build
 --FILE--
 <?php
-$_SERVER['argc']    = 8;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-f';
-$_SERVER['argv'][3] = dirname(__FILE__) . '/../data/NoMethodDocBlock.php';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '--config';
-$_SERVER['argv'][7] = 'none';
-
 require_once 'tests/common/ui-include.php';
-
 ?>
+--ARGS--
+project:run -f tests/data/NoMethodDocBlock.php -t build --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/no-package-just-subpackage-tag.phpt
+++ b/tests/ui/no-package-just-subpackage-tag.phpt
@@ -2,17 +2,10 @@
 phpdoc project:run -f tests/data/NoPackageDocBlock.php -t build
 --FILE--
 <?php
-$_SERVER['argc']    = 8;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-f';
-$_SERVER['argv'][3] = dirname(__FILE__) . '/../data/NoPackageDocBlock.php';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '--config';
-$_SERVER['argv'][7] = 'none';
-
 require_once 'tests/common/ui-include.php';
 ?>
+--ARGS--
+project:run -f tests/data/NoPackageDocBlock.php -t build --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/no-property-docblock.phpt
+++ b/tests/ui/no-property-docblock.phpt
@@ -2,18 +2,10 @@
 phpdoc project:run -f tests/data/NoPropertyDocBlock.php -t build
 --FILE--
 <?php
-$_SERVER['argc']    = 8;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-f';
-$_SERVER['argv'][3] = dirname(__FILE__) . '/../data/NoPropertyDocBlock.php';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '--config';
-$_SERVER['argv'][7] = 'none';
-
 require_once 'tests/common/ui-include.php';
-
 ?>
+--ARGS--
+project:run -f tests/data/NoPropertyDocBlock.php -t build --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/no-short-descriptions-in-docblock.phpt
+++ b/tests/ui/no-short-descriptions-in-docblock.phpt
@@ -2,18 +2,10 @@
 phpdoc project:run -f tests/data/NoShortDescription.php -t build
 --FILE--
 <?php
-$_SERVER['argc']    = 8;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-f';
-$_SERVER['argv'][3] = dirname(__FILE__) . '/../data/NoShortDescription.php';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '--config';
-$_SERVER['argv'][7] = 'none';
-
 require_once 'tests/common/ui-include.php';
-
 ?>
+--ARGS--
+project:run -f tests/data/NoShortDescription.php -t build --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/no-short-descriptions-in-function-docblock.phpt
+++ b/tests/ui/no-short-descriptions-in-function-docblock.phpt
@@ -2,18 +2,10 @@
 phpdoc project:run -f tests/data/NoShortDescriptionFunction.php -t build
 --FILE--
 <?php
-$_SERVER['argc']    = 8;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-f';
-$_SERVER['argv'][3] = dirname(__FILE__) . '/../data/NoShortDescriptionFunction.php';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '--config';
-$_SERVER['argv'][7] = 'none';
-
 require_once 'tests/common/ui-include.php';
-
 ?>
+--ARGS--
+project:run -f tests/data/NoShortDescriptionFunction.php -t build --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/phpdoc-no-class-found.phpt
+++ b/tests/ui/phpdoc-no-class-found.phpt
@@ -2,17 +2,10 @@
 phpdoc project:run -f tests/data/NoClass.php -t build
 --FILE--
 <?php
-$_SERVER['argc']    = 8;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-f';
-$_SERVER['argv'][3] = dirname(__FILE__) . '/../data/NoClass.php';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '--config';
-$_SERVER['argv'][7] = 'none';
-
 require_once 'tests/common/ui-include.php';
 ?>
+--ARGS--
+project:run -f tests/data/NoClass.php -t build --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/phpdoc-no-params.phpt
+++ b/tests/ui/phpdoc-no-params.phpt
@@ -2,13 +2,10 @@
 phpdoc project:run
 --FILE--
 <?php
-$_SERVER['argc']    = 3;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '--config';
-$_SERVER['argv'][3] = 'none';
-
 require_once 'tests/common/ui-include.php';
 ?>
+--ARGS--
+project:run --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/phpdoc-parse-phar.phpt
+++ b/tests/ui/phpdoc-parse-phar.phpt
@@ -2,17 +2,10 @@
 phpdoc.php project:run -d phar://tests/data/test.phar -t build -c none
 --FILE--
 <?php
-$_SERVER['argc']    = 8;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-d';
-$_SERVER['argv'][3] = 'phar://'.dirname(__FILE__) . '/../data/test.phar';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '--config';
-$_SERVER['argv'][7] = 'none';
-
 require_once 'tests/common/ui-include.php';
 ?>
+--ARGS--
+project:run -d phar://tests/data/test.phar -t build -c none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/phpdoc-project-parse.phpt
+++ b/tests/ui/phpdoc-project-parse.phpt
@@ -2,14 +2,10 @@
 phpdoc project:parse
 --FILE--
 <?php
-$_SERVER['argc']    = 2;
-$_SERVER['argv'][1] = 'project:parse';
-$_SERVER['argv'][2] = '--config';
-$_SERVER['argv'][3] = 'none';
-
 require_once 'tests/common/ui-include.php';
-
 ?>
+--ARGS--
+project:parse --config=none
 --EXPECTF--
 phpDocumentor version %s
 

--- a/tests/ui/phpdoc-project-run-quiet.phpt
+++ b/tests/ui/phpdoc-project-run-quiet.phpt
@@ -2,18 +2,8 @@
 phpdoc project:run -f dirname(__FILE__) . '/../data/DocBlockTestFixture.php' -t dirname(__FILE__) . '/../../build/' -q
 --FILE--
 <?php
-
-$_SERVER['argc']    = 9;
-$_SERVER['argv'][1] = 'project:run';
-$_SERVER['argv'][2] = '-f';
-$_SERVER['argv'][3] = dirname(__FILE__) . '/../data/DocBlockTestFixture.php';
-$_SERVER['argv'][4] = '-t';
-$_SERVER['argv'][5] = dirname(__FILE__) . '/../../build/';
-$_SERVER['argv'][6] = '-q';
-$_SERVER['argv'][7] = '--config';
-$_SERVER['argv'][8] = 'none';
-
 require_once 'tests/common/ui-include.php';
-
 ?>
+--ARGS--
+project:run -f dirname(__FILE__) . '/../data/DocBlockTestFixdture.php' -t dirname(__FILE__) . '/../../build/' -q
 --EXPECTF--

--- a/tests/ui/phpdoc-project-transform.phpt
+++ b/tests/ui/phpdoc-project-transform.phpt
@@ -2,13 +2,10 @@
 phpdoc project:transform
 --FILE--
 <?php
-$_SERVER['argc']    = 3;
-$_SERVER['argv'][1] = 'project:transform';
-$_SERVER['argv'][2] = '--config';
-$_SERVER['argv'][3] = 'none';
-
 require_once 'tests/common/ui-include.php';
 ?>
+--ARGS--
+project:transform --config=none
 --EXPECTF--
 phpDocumentor version %s
 


### PR DESCRIPTION
I didn't know about this when I first wrote the phpt tests, so I've gone back and updated them to follow the standard. It isn't an issue if you don't want to merge these changes in.

http://qa.php.net/phpt_details.php

``` bash
$ phpunit tests/ui/
PHPUnit 3.6.10 by Sebastian Bergmann.

Configuration read from /Users/bselby/git/external/phpDocumentor2/phpunit.xml.dist

.............

Time: 01:11, Memory: 21.25Mb

OK (13 tests, 13 assertions)

Writing code coverage data to XML file, this may take a moment.

Generating code coverage report, this may take a moment.
```
