### PR TITLE
Fixed a bug where the namespace was added to primitive types with an array notation

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Tag/Definition.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Tag/Definition.php
@@ -386,16 +386,16 @@ class phpDocumentor_Plugin_Core_Parser_DocBlock_Tag_Definition
                 }
             }
 
-            // re-add the array notation markers
-            if ($is_array) {
-                $item .= '[]';
-            }
-
             // full paths always start with a slash
             if (isset($item[0]) && ($item[0] !== '\\')
                 && (!in_array(strtolower($item), $non_objects))
             ) {
                 $item = '\\' . $item;
+            }
+
+            // re-add the array notation markers
+            if ($is_array) {
+                $item .= '[]';
             }
         }
 


### PR DESCRIPTION
A check is done to see if the type start with a namespace. If not the namespace is added unless it is a non object (which means that the type should be present in $non_objects).

Before that the array markers were added which means that the check for $non_objects would always fail. Adding the array markers after the non objects check fixes this problem.

Example: Types that previously were shown as "\string[]" will now be visible as "string[]".
