### PR TITLE
Correct description for the "extensions" command line option.

### DIFF
--- a/src/phpDocumentor/Command/Project/ParseCommand.php
+++ b/src/phpDocumentor/Command/Project/ParseCommand.php
@@ -64,7 +64,8 @@ HELP
             ->addOption(
                 'extensions', 'e',
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-                'Path where to store the generated output'
+                'Comma-separated list of extensions to parse, defaults to '
+                . 'php, php3 and phtml'
             )
             ->addOption(
                 'ignore', 'i',

--- a/src/phpDocumentor/Command/Project/RunCommand.php
+++ b/src/phpDocumentor/Command/Project/RunCommand.php
@@ -88,7 +88,8 @@ HELP
             ->addOption(
                 'extensions', 'e',
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-                'Path where to store the generated output'
+                'Comma-separated list of extensions to parse, defaults to '
+                . 'php, php3 and phtml'
             )
             ->addOption(
                 'ignore', 'i',


### PR DESCRIPTION
A copy-paste error has set the description for the `extensions` option to that of the `target` option.
