### PR TITLE
Comma separated options aren't parsed out

### DIFF
--- a/src/phpDocumentor/Command/ConfigurableCommand.php
+++ b/src/phpDocumentor/Command/ConfigurableCommand.php
@@ -68,11 +68,13 @@ class ConfigurableCommand extends Command
      *     no option is provided.
      * @param mixed|null                                      $default
      *     Default value used if there is no configuration option or path set
+     * @param bool                                            $comma_separated
+     *     Could the value be a comma separated string requiring splitting
      *
      * @return string
      */
     public function getOption(InputInterface $input, $name, $config_path = null,
-        $default = null
+        $default = null, $comma_separated = false
     ) {
         $value = $input->getOption($name);
 
@@ -91,6 +93,12 @@ class ConfigurableCommand extends Command
             return (is_array($value) && $default === null)
                 ? array()
                 : $default;
+        }
+
+        // split comma separated values
+        if ($comma_separated && (!is_array($value) || count($value) == 1)) {
+            $value = (array) $value;
+            $value = explode(',', $value[0]);
         }
 
         return $value;

--- a/src/phpDocumentor/Command/Project/ParseCommand.php
+++ b/src/phpDocumentor/Command/Project/ParseCommand.php
@@ -222,7 +222,7 @@ HELP
         $parser->setExistingXml($target);
         $parser->setForced($input->getOption('force'));
         $parser->setMarkers(
-            (array)$this->getOption($input, 'markers', 'parser/markers/item')
+            $this->getOption($input, 'markers', 'parser/markers/item', null, true)
         );
         $parser->setIgnoredTags($input->getOption('ignore-tags'));
         $parser->setValidate($input->getOption('validate'));
@@ -280,13 +280,13 @@ HELP
     {
         $files = new \phpDocumentor\Fileset\Collection();
         $files->setAllowedExtensions(
-            (array)$this->getOption(
+            $this->getOption(
                 $input, 'extensions', 'parser/extensions/extension',
-                array('php', 'php3', 'phtml')
+                array('php', 'php3', 'phtml'), true
             )
         );
         $files->setIgnorePatterns(
-            (array)$this->getOption($input, 'ignore', 'files/ignore', array())
+            $this->getOption($input, 'ignore', 'files/ignore', array(), true)
         );
         $files->setIgnoreHidden(
             $this->getOption(
@@ -299,11 +299,11 @@ HELP
             ) == 'on'
         );
         $files->addFiles(
-            (array)$this->getOption($input, 'filename', 'files/file', array())
+            $this->getOption($input, 'filename', 'files/file', array(), true)
         );
 
         $files->addDirectories(
-            (array)$this->getOption($input, 'directory', 'files/directory', array())
+            $this->getOption($input, 'directory', 'files/directory', array(), true)
         );
 
         return $files;


### PR DESCRIPTION
The options that used to accept a comma separated list of multiple values no longer work as the commas are ignored. Currently these options will only accept multiple values via multiple uses of the option.

Options that previously accepted comma separated lists to explode:
- filename
- directory
- extensions
- markers
- ignore
- ignore-tags

See issue #473 for report of ignored files option.

One solution could be to check if the option has only been set once and split on comma if so, e.g.

``` php
$filenames = $this->getOption($input, 'filename', 'files/file', array());
if (count($filenames) == 1)
    $filenames = explode(',', $filenames[0]);
$files->addFiles($filenames);
```

Possibly adding a flag to getOption() and doing it in there so that count()/explode() check isn't repeated all over the place.
