### PR TITLE
If no --target option passed then transformation output in current directory

### DIFF
--- a/src/phpDocumentor/Command/Project/RunCommand.php
+++ b/src/phpDocumentor/Command/Project/RunCommand.php
@@ -218,7 +218,7 @@ HELP
         }
 
         $target = $input->getOption('target');
-        if (!is_dir($target)) {
+        if (!is_null($target) && !is_dir($target)) {
             $target = dirname($target);
         }
 


### PR DESCRIPTION
If no --target option passed then dirname($target) shouldn't be run. dirname(null) produces the empty string which causes the transform command to put its output in the current directory instead of the one specified in the config file.

```
php bin/phpdoc.php -d foo
```

with a value for transformer/target specified in phpdoc.xml.
