### PR TITLE
Correct namespace for DocBlock validators

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Listener.php
+++ b/src/phpDocumentor/Plugin/Core/Listener.php
@@ -102,11 +102,11 @@ class Listener extends ListenerAbstract
 
         foreach (array('Deprecated', 'Required', $type) as $validator) {
 
-            $class = 'phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator\\'
+            $class = 'phpDocumentor\Plugin\Core\Parser\DocBlock\Validator\\'
                 . $validator.'Validator';
 
             if (class_exists($class)) {
-                /** @var Parser\DocBlock\Tag\Validator\ValidatorAbstract $val */
+                /** @var Parser\DocBlock\Validator\ValidatorAbstract $val */
                 $val = new $class(
                     $this->plugin,
                     $element->getName(),

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/ClassValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/ClassValidator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * File contains the
- * \phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator\ClassValidator class.
+ * \phpDocumentor\Plugin\Core\Parser\DocBlock\Validator\ClassValidator class.
  *
  * PHP Version 5
  *
@@ -15,7 +15,7 @@
  * @link       http://phpdoc.org
  */
 
-namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator;
+namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Validator;
 
 /**
  * This class is responsible for validating the class docbloc

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/DeprecatedValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/DeprecatedValidator.php
@@ -15,7 +15,7 @@
  * @link       http://phpdoc.org
  */
 
-namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator;
+namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Validator;
 
 /**
  * This class is responsible for validating which tags are deprecated

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/FileValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/FileValidator.php
@@ -15,7 +15,7 @@
  * @link       http://phpdoc.org
  */
 
-namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator;
+namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Validator;
 
 /**
  * This class is responsible for validating the file docbloc

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/FunctionValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/FunctionValidator.php
@@ -14,7 +14,7 @@
  * @link       http://phpdoc.org
  */
 
-namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator;
+namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Validator;
 
 /**
  * This class is responsible for validating a function's docblock.

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/MethodValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/MethodValidator.php
@@ -15,7 +15,7 @@
  * @link       http://phpdoc.org
  */
 
-namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator;
+namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Validator;
 
 /**
  * This class is responsible for validating the method doc block

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/PropertyValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/PropertyValidator.php
@@ -15,7 +15,7 @@
  * @link       http://phpdoc.org
  */
 
-namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator;
+namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Validator;
 
 /**
  * This class is responsible for validating a properties docblock.

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/RequiredValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/RequiredValidator.php
@@ -15,7 +15,7 @@
  * @link       http://phpdoc.org
  */
 
-namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator;
+namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Validator;
 
 /**
  * This class is responsible for validating which tags are required

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/ValidatorAbstract.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/ValidatorAbstract.php
@@ -14,7 +14,7 @@
  * @link       http://phpdoc.org
  */
 
-namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Validator;
+namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Validator;
 
 use \phpDocumentor\Plugin\PluginAbstract;
 


### PR DESCRIPTION
The validator classes are located in

```
phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/*php
```

yet the namespace in each file includes "Tag" too.

This works because the composer autoloader is being set up with a classmap linking class names to files instead of just relying on on-the-fly file resolution.

After applying this patch the composer autoloader has to be rebuilt for the validators to work.
