### PR TITLE
Get documentation for class properties

### DIFF
--- a/src/phpDocumentor/Reflection/ClassReflector/PropertyReflector.php
+++ b/src/phpDocumentor/Reflection/ClassReflector/PropertyReflector.php
@@ -106,4 +106,27 @@ class PropertyReflector extends BaseReflector
     {
         return $this->property->type & \PHPParser_Node_Stmt_Class::MODIFIER_FINAL;
     }
+
+    /**
+     * Returns the parsed DocBlock.
+     *
+     * @return \phpDocumentor\Reflection\DocBlock|null
+     */
+    public function getDocBlock()
+    {
+        $doc_block = null;
+        if ((string)$this->property->getDocComment()) {
+            $doc_block = new \phpDocumentor\Reflection\DocBlock(
+                (string)$this->property->getDocComment()
+            );
+            $doc_block->line_number = $this->property->getLine();
+        }
+
+        $this->dispatch(
+            'reflection.docblock-extraction.post',
+            array('docblock' => $doc_block)
+        );
+
+        return $doc_block;
+    }
 }


### PR DESCRIPTION
PHP-Parser puts property documentation on the PHPParser_Node_Stmt_Property node rather than on every PHPParser_Node_Stmt_PropertyProperty child node. Currently the PropertyReflector uses the getDocBlock() method from the BaseReflector which attempts to get documentation from `$this->node` (PropertyProperty). This needs to be overridden to use `$this->property` instead.
