### PR TITLE
Param tag type ending in "[]" matches the "array" type hint

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/FunctionValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/FunctionValidator.php
@@ -212,6 +212,10 @@ class FunctionValidator extends ValidatorAbstract
             || in_array($argument->getType(), $param->getTypes())
         ) {
             return true;
+        } else if ($argument->getType() == 'array'
+            && substr($param->getType(), -2) == '[]'
+        ) {
+            return true;
         }
 
         $this->logParserError(


### PR DESCRIPTION
Fixes #419.

```
/**
 * @param (Object|array)[] $actions Aray of Object or nested arrays
 */
public function addActions(array $actions);
```

```
/**
 * @param Foo[] $foo Array of foos
 */
public function bar(array $foo);
```

Shouldn't receive warnings about mismatching param tags and type hints.
