### PR TITLE
Interface inheritance

### DIFF
--- a/src/phpDocumentor/Parser/Exporter/Xml/ClassExporter.php
+++ b/src/phpDocumentor/Parser/Exporter/Xml/ClassExporter.php
@@ -55,6 +55,19 @@ class ClassExporter
         $child->setAttribute('final', $class->isFinal() ? 'true' : 'false');
         $child->setAttribute('abstract', $class->isAbstract() ? 'true' : 'false');
 
+        $child->appendChild(
+            new \DOMElement('extends', $class->getParentClass())
+        );
+
+        $interfaces = method_exists($class, 'getInterfaces')
+            ? $class->getInterfaces()
+            : $class->getParentInterfaces();
+        foreach ($interfaces as $interface) {
+            $child->appendChild(
+                new \DOMElement('implements', $interface)
+            );
+        }
+
         $object = new InterfaceExporter();
         $object->export($child, $class, $child);
     }

--- a/src/phpDocumentor/Parser/Exporter/Xml/InterfaceExporter.php
+++ b/src/phpDocumentor/Parser/Exporter/Xml/InterfaceExporter.php
@@ -54,17 +54,10 @@ class InterfaceExporter
         $child->appendChild(
             new \DOMElement('full_name', $interface->getName())
         );
-        $child->appendChild(
-            new \DOMElement('extends', $interface->getParentClass())
-        );
 
-        $interfaces = method_exists($interface, 'getInterfaces')
-            ? $interface->getInterfaces()
-            : $interface->getParentInterfaces();
-
-        foreach ($interfaces as $parent_interface) {
+        foreach ($interface->getParentInterfaces() as $parent_interface) {
             $child->appendChild(
-                new \DOMElement('implements', $parent_interface)
+                new \DOMElement('extends', $parent_interface)
             );
         }
 

--- a/src/phpDocumentor/Reflection/ClassReflector.php
+++ b/src/phpDocumentor/Reflection/ClassReflector.php
@@ -78,4 +78,24 @@ class ClassReflector extends InterfaceReflector
     {
         return $this->traits;
     }
+
+    public function getParentClass()
+    {
+        return $this->node->extends ? (string)$this->node->extends : '';
+    }
+
+    /**
+     * BC Break: used to be getParentInterfaces
+     */
+    public function getInterfaces()
+    {
+        $names = array();
+        if ($this->node->implements) {
+            /** @var \PHPParser_Node_Name */
+            foreach ($this->node->implements as $node) {
+                $names[] = (string)$node;
+            }
+        }
+        return $names;
+    }
 }

--- a/src/phpDocumentor/Reflection/InterfaceReflector.php
+++ b/src/phpDocumentor/Reflection/InterfaceReflector.php
@@ -14,7 +14,7 @@ namespace phpDocumentor\Reflection;
 
 class InterfaceReflector extends BaseReflector
 {
-    /** @var \PHPParser_Node_Stmt_Class */
+    /** @var \PHPParser_Node_Stmt */
     protected $node;
     protected $constants = array();
     protected $properties = array();
@@ -46,20 +46,14 @@ class InterfaceReflector extends BaseReflector
         }
     }
 
-    public function getParentClass()
-    {
-        return $this->node->extends ? (string)$this->node->extends : '';
-    }
-
-    /**
-     * BC Break: used to be getParentInterfaces
-     */
-    public function getInterfaces()
+    public function getParentInterfaces()
     {
         $names = array();
-        if ($this->node->implements) {
+        if ($this->node instanceof \PHPParser_Node_Stmt_Interface
+            && $this->node->extends
+        ) {
             /** @var \PHPParser_Node_Name */
-            foreach ($this->node->implements as $node) {
+            foreach ($this->node->extends as $node) {
                 $names[] = (string)$node;
             }
         }


### PR DESCRIPTION
Currently interface inheritance doesn't work correctly. Parsing a file containing an interface that extends another produces the following error:

```
PHP Notice:  Array to string conversion in InterfaceReflector.php on line 51
```

This is because interfaces can do multiple inheritance so `$this->node->extends` is an array for interfaces.

The changes here allow for (multiple) interface inheritance. Class specific behaviour is also pulled out of the interface exporter; interfaces cannot implement anything and they don't have parent classes.
