### PR TITLE
remove call of 'stripBinaryCharacter'.

### DIFF
--- a/src/phpDocumentor/Parser/Exporter/Xml/DocBlockExporter.php
+++ b/src/phpDocumentor/Parser/Exporter/Xml/DocBlockExporter.php
@@ -89,9 +89,8 @@ class DocBlockExporter
     protected function addLongDescription(
         \DOMElement $child, \phpDocumentor\Reflection\DocBlock $docblock
     ) {
-        $contents = $docblock->getLongDescription()->getFormattedContents();
         $node = $child->ownerDocument->createCDATASection(
-            $this->stripBinaryCharacters($contents)
+            $docblock->getLongDescription()->getFormattedContents()
         );
 
         $element = new \DOMElement('long-description');


### PR DESCRIPTION
remove call of 'stripBinaryCharacter', because
I can't have multi-byte characters in long description otherwise.
