### PR TITLE
Use actual line numbers for DocBlock

### DIFF
--- a/src/phpDocumentor/Reflection/BaseReflector.php
+++ b/src/phpDocumentor/Reflection/BaseReflector.php
@@ -55,14 +55,14 @@ abstract class BaseReflector extends ReflectionAbstract
     public function getDocBlock()
     {
         $doc_block = null;
-        if ((string)$this->node->getDocComment()) {
+        if ($comment = $this->node->getDocComment()) {
             try {
                 $doc_block = new \phpDocumentor\Reflection\DocBlock(
-                    (string)$this->node->getDocComment(),
+                    (string)$comment,
                     $this->getNamespace(),
                     $this->getNamespaceAliases()
                 );
-                $doc_block->line_number = $this->node->getLine();
+                $doc_block->line_number = $comment->getLine();
             } catch (\Exception $e) {
                 $this->log($e->getMessage(), 2);
             }

--- a/src/phpDocumentor/Reflection/ClassReflector/PropertyReflector.php
+++ b/src/phpDocumentor/Reflection/ClassReflector/PropertyReflector.php
@@ -115,14 +115,14 @@ class PropertyReflector extends BaseReflector
     public function getDocBlock()
     {
         $doc_block = null;
-        if ((string)$this->property->getDocComment()) {
+        if ($comment = $this->property->getDocComment()) {
             try {
                 $doc_block = new \phpDocumentor\Reflection\DocBlock(
-                    (string)$this->property->getDocComment(),
+                    (string)$comment,
                     $this->getNamespace(),
                     $this->getNamespaceAliases()
                 );
-                $doc_block->line_number = $this->node->getLine();
+                $doc_block->line_number = $comment->getLine();
             } catch (\Exception $e) {
                 $this->log($e->getMessage(), 2);
             }

--- a/src/phpDocumentor/Reflection/FileReflector.php
+++ b/src/phpDocumentor/Reflection/FileReflector.php
@@ -163,7 +163,7 @@ class FileReflector extends ReflectionAbstract implements \PHPParser_NodeVisitor
                     || !$node instanceof \PHPParser_Node_Stmt_Class
                         && $docblock->hasTag('package')
                 ) {
-                    $docblock->line_number = 0;
+                    $docblock->line_number = $comments[0]->getLine();
                     $this->doc_block = $docblock;
 
                     // remove the file level DocBlock from the node's comments


### PR DESCRIPTION
PHPParser now provides line numbers for comments. This can be used instead of the line number of the parent node or the hardcoded value of 0 for file level documentation.
