### PR TITLE
Autoload classmap declaration breaking initial Composer builds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "psr-0":{
             "phpDocumentor": "src/"
         },
-        "classmap": ["vendor/pear-symfony", "src/phpDocumentor"]
+        "classmap": ["src/phpDocumentor"]
     },
     "repositories":[
         { "type":"composer", "url":"http://packages.zendframework.com"},


### PR DESCRIPTION
This line causes an Exception and failure of all autoload classmap files for Composer.

A few months back, the Composer folks added autoloading information for PEAR dependencies automatically via https://github.com/composer/composer/commit/4b2283e41c7ce8c67c135208b41aba91b39cc0a0 .  They have since refactored the code, but PEAR auto-autoloading seems to be there to stay.  There is no need to specify the classmap for pear-symfony any longer.  Additionally, the "hardcoding" of a vendor directory breaks the intended flexibility of Composer, given that a user is able to change the name and location of the "vendor" directory via their local composer.json file.
