### PR TITLE
Exclude the features directory from code coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,16 +8,7 @@
     </testsuites>
     <filter>
         <whitelist>
-            <directory suffix=".php">.</directory>
-            <exclude>
-                <file>installer.php</file>
-                <directory suffix=".php">build</directory>
-                <directory suffix=".php">data</directory>
-                <directory suffix=".php">tests</directory>
-                <directory suffix=".php">bin</directory>
-                <directory suffix=".php">vendor</directory>
-                <directory suffix=".php">src/XHProf</directory>
-            </exclude>
+            <directory suffix=".php">src/phpDocumentor</directory>
         </whitelist>
     </filter>
     <logging>


### PR DESCRIPTION
The Behat bootstrap is being included in the code coverage report generated by PHPUnit. 
