### PR TITLE
Add support for "globs" in configuration file.

### DIFF
--- a/src/phpDocumentor/Command/Project/ParseCommand.php
+++ b/src/phpDocumentor/Command/Project/ParseCommand.php
@@ -315,10 +315,15 @@ HELP
         );
         $added_files = array();
         foreach ($file_options as $glob) {
-            foreach (glob($glob) as $file) {
-                $file = realpath($file);
-                if (!empty($file)) {
-                    $added_files[] = $file;
+            $matches = glob($glob);
+            if (is_array($matches)) {
+                foreach ($matches as $file) {
+                    if (!empty($file)) {
+                        $file = realpath($file);
+                        if (!empty($file)) {
+                            $added_files[] = $file;
+                        }
+                    }
                 }
             }
         }
@@ -329,10 +334,15 @@ HELP
         );
         $added_directories = array();
         foreach ($directory_options as $glob) {
-            foreach (glob($glob, GLOB_ONLYDIR) as $dir) {
-                $dir = realpath($dir);
-                if (!empty($dir)) {
-                    $added_directories[] = $dir;
+            $matches = glob($glob, GLOB_ONLYDIR);
+            if (is_array($matches)) {
+                foreach ($matches as $dir) {
+                    if (!empty($dir)) {
+                        $dir = realpath($dir);
+                        if (!empty($dir)) {
+                            $added_directories[] = $dir;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
The documentation implies that you can use file globs in both
<file> and <directory> entries, such as "bin/*".  However, the
parser runs each entry through `realpath()`, which fails to find
a real file or directory with the globbed name.

Instead, first use `glob()` to find all files or directories
matching the glob, and then run those through `realpath()`.

This change enables the documentation examples (`bin/*`, `tes??`,
and `test/*`) to work properly.
