### PR TITLE
Fix for the main problem discussed at #280

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/PropertyValidator.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/PropertyValidator.php
@@ -51,7 +51,7 @@ class PropertyValidator extends ValidatorAbstract
 
         if ('' === $this->docblock->getShortDescription()) {
             foreach($this->docblock->getTagsByName('var') as $varTag) {
-                if ('' !== $varTag->getContent()) {
+                if ('' !== $varTag->getDescription()) {
                     return true;
                 }
             }


### PR DESCRIPTION
With this, no error is triggered if a property contains a @var tag with non-empty content.
