### PR TITLE
Fixed the syntax of template:generate in documentation

### DIFF
--- a/docs/manual/for-template-builders/building-your-own-branding-using-templates.rst
+++ b/docs/manual/for-template-builders/building-your-own-branding-using-templates.rst
@@ -21,7 +21,7 @@ I will give a step-by-step description how to create your own branding:
    the path as the XSL Writer (or actually libxsl) cannot handle that.
 2. invoke the following command::
 
-       $ phpdoc template:generate -t <target path> -n <template name>
+       $ phpdoc template:generate -t <target path> --name <template name>
 
    ..
 


### PR DESCRIPTION
In the "Building your own branding using templates" documentation page I fixed the syntax of template:generate command.
