### PR TITLE
Fix for the 3rd problem in #616

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Tag/Definition/See.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Tag/Definition/See.php
@@ -40,6 +40,8 @@ class See extends Definition
         $referral = explode('::', $this->xml['refers']);
         $referral[0] = $this->expandType($referral[0], count($referral) > 1);
         $this->xml['refers'] = implode('::', $referral);
-        $this->xml['description'] = implode('::', $referral);
+        if (trim($this->xml['description']) === '') {
+            $this->xml['description'] = implode('::', $referral);
+        }
     }
 }


### PR DESCRIPTION
The 3rd problem in #616 is that the description is never recognized.

This is because for some reason, PhpDocumentor unconditionally replaces the description with the referral. The fix here checks if the description is empty, and only if it is does it place the referral as a description.
