### PR TITLE
Update packaging script and generate new package file

### DIFF
--- a/bin/utils/package.php
+++ b/bin/utils/package.php
@@ -124,11 +124,11 @@ DESC
 
 echo 'phpDocumentor PEAR Packager v1.0'.PHP_EOL;
 
-if ($argc < 3) {
+if ($argc < 4) {
     echo <<<HELP
 
 Usage:
-  php package.php [version] [stability] [make|nothing]
+  php package.php [version] [api-version] [stability] [make|nothing]
 
 Description:
   The phpDocumentor packager generates a package.xml file and accompanying package.
@@ -143,13 +143,13 @@ HELP;
 
 $packager = createPackager('../../package.xml');
 
-$packager->setAPIVersion($argv[1]);
 $packager->setReleaseVersion($argv[1]);
-$packager->setReleaseStability($argv[2]);
-$packager->setAPIStability($argv[2]);
+$packager->setAPIVersion($argv[2]);
+$packager->setReleaseStability($argv[3]);
+$packager->setAPIStability($argv[3]);
 
 $packager->generateContents();
-if (isset($argv[3]) && ($argv[3] == 'make')) {
+if (isset($argv[4]) && ($argv[4] == 'make')) {
     $packager->writePackageFile();
 } else {
     $packager->debugPackageFile();

--- a/package.xml
+++ b/package.xml
@@ -24,9 +24,9 @@ phpDocumentor is build to be PHP 5.3 compatible, fast, having a low memory consu
   <active>yes</active>
  </lead>
  <date>2012-09-28</date>
- <time>22:12:08</time>
+ <time>22:28:44</time>
  <version>
-  <release>2.0.0</release>
+  <release>2.0.0a10</release>
   <api>2.0.0</api>
  </version>
  <stability>
@@ -9203,9 +9203,6 @@ Please see the CHANGELOG in the root of the application for the latest changes
    <file baseinstalldir="/phpDocumentor" name="README.md" role="data">
     <tasks:replace from="@php_bin@" to="php_bin" type="pear-config" />
    </file>
-   <file baseinstalldir="/phpDocumentor" name="test.php" role="php">
-    <tasks:replace from="@php_bin@" to="php_bin" type="pear-config" />
-   </file>
   </dir> <!-- / -->
  </contents>
  <dependencies>
@@ -9238,7 +9235,7 @@ Please see the CHANGELOG in the root of the application for the latest changes
  <changelog>
   <release>
    <version>
-    <release>2.0.0</release>
+    <release>2.0.0a10</release>
     <api>2.0.0</api>
    </version>
    <stability>


### PR DESCRIPTION
Prior to deployment must a new package.xml be generated and
there was some data missing / redundant. Such as the mail address
of Chuck was missing, PEAR was a dependency and the version number
could use a dumbed down version.
