### PR TITLE
Fix #551: Remove POSIX collation element start

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Transformer/Behaviour/Tag/LicenseTag.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Behaviour/Tag/LicenseTag.php
@@ -71,7 +71,7 @@ class LicenseTag extends \phpDocumentor\Transformer\Behaviour\BehaviourAbstract
             // FIXME: migrate to '#^' . PHPDOC::LINK_REGEX . '(\s+(?P<text>.+))
             // ?$#u' once that const exists
             if (preg_match(
-                '#^(?i)\b(?P<url>(?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.]'
+                '#^(?i)\b(?P<url>(?:https?://|www\d{0,3}\.|[a-z0-9.\-]+\.'
                 .'[a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+'
                 .'(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|'
                 .'[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))(\s+(?P<text>.+))?$#u',


### PR DESCRIPTION
The License regular expression contains a character class containing
only a dot (`[.]`). In newer versions of POSIX this is recognized as the start
of a collating element. This causes issues in systems using a newer version of
POSIX as described in issue #551.

By replacing the character class containing the dot with an escaped dot we
circumvent this issue.

Thanks to @rvanvelzen for this solution.
