### PR TITLE
Get vendor-phpunit to execute from composer installation

### DIFF
--- a/tests/common/bootstrap.php
+++ b/tests/common/bootstrap.php
@@ -11,5 +11,8 @@
  */
 
 
+/**
+ * @uses \phpDocumentor\Bootstrap
+ */
 require_once __DIR__ . '/../../src/phpDocumentor/Bootstrap.php';
 \phpDocumentor\Bootstrap::createInstance()->initialize();


### PR DESCRIPTION
Had to remove that include_path-ish PHPUnit require_once in order to get vendor/phpunit to execute successfully.
