### PR TITLE
BUILD - restore /dev/null around installation steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ before_script:
  - sudo apt-get -qq install graphviz > /dev/null
  - composer install --dev -q
  - pyrus channel-discover pear.phing.info > /dev/null
- - pyrus channel-discover pear.netpirates.net
+ - pyrus channel-discover pear.netpirates.net > /dev/null
  - pyrus install pear/PHP_CodeSniffer > /dev/null
  - pyrus install pear.phing.info/phing > /dev/null
- - pyrus install phpunit/phpcpd 
+ - pyrus install phpunit/phpcpd > /dev/null
  - phpenv rehash > /dev/null
 
 notifications:


### PR DESCRIPTION
Now that discovering theseer's netpirate channel will allow phpcpd to install, the /dev/null redirects can return to those installation steps.
