### PR TITLE
Potential fix for loading parent classes during inheritance processing.

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Transformer/Behaviour/Inherit/Node/ClassNode.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Behaviour/Inherit/Node/ClassNode.php
@@ -330,7 +330,7 @@ class ClassNode extends NodeAbstract
      */
     protected function reflectExternalClass($parent_class_name)
     {
-        if (@class_exists($parent_class_name)) {
+        if (class_exists($parent_class_name, FALSE)) {
             $refl = new \ReflectionClass($parent_class_name);
 
             /** @var \ReflectionMethod $method */


### PR DESCRIPTION
Small fix concerning how parent classes are resolved by the ClassNode during behaviour processing.
When calling php's class_exists function with the 'autoload' parameter set to true (default value),
fatal errors that occur within the scope of the triggered autoload are swallowed atm.
The phpdoc.php process then silently dies, making it hard to track down what happened.
In my case I wanted to generate api doc for classes that extend the Agavi framework and Phing.
The autoloading for both libraries is bootstrapped outside of the phpdoc.php script's scope
and therefore their classes can not be resolved at phpdoc runtime leading to fatal errors when trying to autoload.
Imho not suppressing class_exists errors and not triggering autoloading should to the job here?
Correct me, if I am missing something here :)
