### PR TITLE
Fix for the incompatibility created by ReflectionDocBlock's new Context and Location classes

### DIFF
--- a/src/phpDocumentor/Parser/Exporter/Xml/DocBlockExporter.php
+++ b/src/phpDocumentor/Parser/Exporter/Xml/DocBlockExporter.php
@@ -49,7 +49,7 @@ class DocBlockExporter
         $parent->appendChild($child);
 
         // TODO: custom attached member variable, make real
-        $child->setAttribute('line', $docblock->line_number);
+        $child->setAttribute('line', $docblock->getLocation()->getLineNumber());
 
         $this->addDescription($child, $docblock);
         $this->addLongDescription($child, $docblock);

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/ValidatorAbstract.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Validator/ValidatorAbstract.php
@@ -84,9 +84,10 @@ abstract class ValidatorAbstract extends PluginAbstract
     ) {
         $this->entityName = $name;
         $this->lineNumber = $docblock
-            ? $docblock->line_number : $source->getLineNumber();
+            ? $docblock->getLocation()->getLineNumber()
+            : $source->getLineNumber();
         $this->docblock   = $docblock;
-        $this->source      = $source;
+        $this->source     = $source;
         parent::__construct(
             $plugin->getEventDispatcher(),
             $plugin->getConfiguration(),

--- a/src/phpDocumentor/Reflection/ClassReflector/ConstantReflector.php
+++ b/src/phpDocumentor/Reflection/ClassReflector/ConstantReflector.php
@@ -12,8 +12,29 @@
 
 namespace phpDocumentor\Reflection\ClassReflector;
 
+use phpDocumentor\Reflection\BaseReflector;
 use phpDocumentor\Reflection\ConstantReflector as BaseConstantReflector;
+use phpDocumentor\Reflection\DocBlock\Context;
+use PHPParser_Node_Const;
+use PHPParser_Node_Stmt_ClassConst;
 
 class ConstantReflector extends BaseConstantReflector
 {
+    /** @var PHPParser_Node_Stmt_ClassConst */
+    protected $constant;
+
+    /**
+     * Registers the Constant Statement and Node with this reflector.
+     *
+     * @param PHPParser_Node_Stmt_Const $stmt
+     * @param PHPParser_Node_Const      $node
+     */
+    public function __construct(
+        PHPParser_Node_Stmt_ClassConst $stmt,
+        Context $context,
+        PHPParser_Node_Const $node
+    ) {
+        BaseReflector::__construct($node, $context);
+        $this->constant = $stmt;
+    }
 }

--- a/src/phpDocumentor/Reflection/FileReflector.php
+++ b/src/phpDocumentor/Reflection/FileReflector.php
@@ -12,6 +12,9 @@
 
 namespace phpDocumentor\Reflection;
 
+use phpDocumentor\Reflection\DocBlock\Location;
+use phpDocumentor\Reflection\DocBlock\Context;
+
 /**
  * Reflection class for a full file.
  *
@@ -85,6 +88,7 @@ class FileReflector extends ReflectionAbstract implements \PHPParser_NodeVisitor
 
         $this->filename = $file;
         $this->contents = file_get_contents($file);
+        $this->context = new Context();
 
         // filemtime($file) is sometimes between 0.00001 and 0.00005 seconds
         // faster but md5 is more accurate
@@ -164,7 +168,9 @@ class FileReflector extends ReflectionAbstract implements \PHPParser_NodeVisitor
             if (!empty($comments)) {
                 try {
                     $docblock = new \phpDocumentor\Reflection\DocBlock(
-                        (string) $comments[0]
+                        (string) $comments[0],
+                        null,
+                        new Location($comments[0]->getLine())
                     );
 
                     // the first DocBlock in a file documents the file if
@@ -179,11 +185,10 @@ class FileReflector extends ReflectionAbstract implements \PHPParser_NodeVisitor
                         && $docblock->hasTag('package'))
                         || !$this->isNodeDocumentable($node)
                     ) {
-                        $docblock->line_number = $comments[0]->getLine();
                         $this->doc_block = $docblock;
 
                         // remove the file level DocBlock from the node's comments
-                        $comments = array_slice($comments, 1);
+                        array_shift($comments);
                     }
                 } catch (\Exception $e) {
                     $this->log($e->getMessage(), \phpDocumentor\Plugin\Core\Log::CRIT);
@@ -250,39 +255,40 @@ class FileReflector extends ReflectionAbstract implements \PHPParser_NodeVisitor
             case 'PHPParser_Node_Stmt_Use':
                 /** @var \PHPParser_Node_Stmt_UseUse $use */
                 foreach ($node->uses as $use) {
-                    $this->namespace_aliases[$use->alias]
-                        = implode('\\', $use->name->parts);
+                    $this->context->setNamespaceAlias(
+                        $use->alias,
+                        implode('\\', $use->name->parts)
+                    );
                 }
                 break;
             case 'PHPParser_Node_Stmt_Namespace':
-                $this->current_namespace = implode('\\', $node->name->parts);
+                $this->context->setNamespace(implode('\\', $node->name->parts));
                 break;
             case 'PHPParser_Node_Stmt_Class':
-                $class = new ClassReflector($node);
-                $class->setNamespaceAliases($this->namespace_aliases);
+                $class = new ClassReflector($node, $this->context);
                 $class->parseSubElements();
                 $this->classes[] = $class;
                 break;
             case 'PHPParser_Node_Stmt_Trait':
-                $trait = new TraitReflector($node);
-                $trait->setNamespaceAliases($this->namespace_aliases);
+                $trait = new TraitReflector($node, $this->context);
                 $this->traits[] = $trait;
                 break;
             case 'PHPParser_Node_Stmt_Interface':
-                $interface = new InterfaceReflector($node);
-                $interface->setNamespaceAliases($this->namespace_aliases);
+                $interface = new InterfaceReflector($node, $this->context);
                 $interface->parseSubElements();
                 $this->interfaces[] = $interface;
                 break;
             case 'PHPParser_Node_Stmt_Function':
-                $function = new FunctionReflector($node);
-                $function->setNamespaceAliases($this->namespace_aliases);
+                $function = new FunctionReflector($node, $this->context);
                 $this->functions[] = $function;
                 break;
             case 'PHPParser_Node_Stmt_Const':
                 foreach ($node->consts as $constant) {
-                    $reflector = new ConstantReflector($node, $constant);
-                    $reflector->setNamespaceAliases($this->namespace_aliases);
+                    $reflector = new ConstantReflector(
+                        $node,
+                        $this->context,
+                        $constant
+                    );
                     $this->constants[] = $reflector;
                 }
                 break;
@@ -308,14 +314,16 @@ class FileReflector extends ReflectionAbstract implements \PHPParser_NodeVisitor
                     // we use $constant here both times since this is a
                     // FuncCall, which combines properties that are otherwise
                     // split over 2 objects
-                    $reflector = new ConstantReflector($constant, $constant);
-                    $reflector->setNamespaceAliases($this->namespace_aliases);
+                    $reflector = new ConstantReflector(
+                        $constant, 
+                        $this->context,
+                        $constant
+                    );
                     $this->constants[] = $reflector;
                 }
                 break;
             case 'PHPParser_Node_Expr_Include':
-                $include = new IncludeReflector($node);
-                $include->setNamespaceAliases($this->namespace_aliases);
+                $include = new IncludeReflector($node, $this->context);
                 $this->includes[] = $include;
                 break;
         }

--- a/src/phpDocumentor/Reflection/FunctionReflector.php
+++ b/src/phpDocumentor/Reflection/FunctionReflector.php
@@ -13,6 +13,7 @@
 namespace phpDocumentor\Reflection;
 
 use phpDocumentor\Reflection\BaseReflector;
+use phpDocumentor\Reflection\DocBlock\Context;
 
 /**
  * Provides Static Reflection for functions.
@@ -35,13 +36,16 @@ class FunctionReflector extends BaseReflector
      *
      * @param \PHPParser_Node_Stmt $node Function object coming from PHP-Parser.
      */
-    public function __construct(\PHPParser_Node_Stmt $node)
+    public function __construct(\PHPParser_Node_Stmt $node, Context $context)
     {
-        parent::__construct($node);
+        parent::__construct($node, $context);
 
         /** @var \PHPParser_Node_Param $param  */
         foreach ($node->params as $param) {
-            $reflector = new FunctionReflector\ArgumentReflector($param);
+            $reflector = new FunctionReflector\ArgumentReflector(
+                $param,
+                $context
+            );
             $this->arguments[$reflector->getName()] = $reflector;
         }
     }

--- a/src/phpDocumentor/Reflection/InterfaceReflector.php
+++ b/src/phpDocumentor/Reflection/InterfaceReflector.php
@@ -27,24 +27,26 @@ class InterfaceReflector extends BaseReflector
             switch (get_class($stmt)) {
                 case 'PHPParser_Node_Stmt_Property':
                     foreach ($stmt->props as $property) {
-                        $reflector = new ClassReflector\PropertyReflector($stmt, $property);
-                        $reflector->setNamespace($this->getNamespace());
-                        $reflector->setNamespaceAliases($this->namespace_aliases);
-                        $this->properties[] = $reflector;
+                        $this->properties[] = new ClassReflector\PropertyReflector(
+                            $stmt,
+                            $this->context,
+                            $property
+                        );
                     }
                     break;
                 case 'PHPParser_Node_Stmt_ClassMethod':
-                    $reflector = new ClassReflector\MethodReflector($stmt);
-                    $reflector->setNamespace($this->getNamespace());
-                    $reflector->setNamespaceAliases($this->namespace_aliases);
-                    $this->methods[] = $reflector;
+                    $this->methods[] = new ClassReflector\MethodReflector(
+                        $stmt,
+                        $this->context
+                    );
                     break;
                 case 'PHPParser_Node_Stmt_ClassConst':
                     foreach ($stmt->consts as $constant) {
-                        $reflector = new ClassReflector\ConstantReflector($stmt, $constant);
-                        $reflector->setNamespace($this->getNamespace());
-                        $reflector->setNamespaceAliases($this->namespace_aliases);
-                        $this->constants[] = $reflector;
+                        $this->constants[] = new ClassReflector\ConstantReflector(
+                            $stmt,
+                            $this->context,
+                            $constant
+                        );
                     }
                     break;
             }

--- a/src/phpDocumentor/Reflection/ReflectionAbstract.php
+++ b/src/phpDocumentor/Reflection/ReflectionAbstract.php
@@ -22,6 +22,13 @@ namespace phpDocumentor\Reflection;
 abstract class ReflectionAbstract
 {
     /**
+     * The context (namespace, aliases) for the reflection.
+     * 
+     * @var \phpDocumentor\Reflection\DocBlock\Context
+     */
+    protected $context = null;
+
+    /**
      * Dispatches a logging request.
      *
      * @param string $message  The message to log.

--- a/tests/unit/phpDocumentor/Reflection/BaseReflectorTest.php
+++ b/tests/unit/phpDocumentor/Reflection/BaseReflectorTest.php
@@ -11,6 +11,8 @@
  */
 namespace phpDocumentor\Reflection;
 
+use phpDocumentor\Reflection\DocBlock\Context;
+
 /**
  * Class for testing base reflector.
  *
@@ -87,7 +89,10 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
     public function testSetNameSpace()
     {
         /** @var BaseReflector $base_reflector  */
-        $base_reflector = new BaseReflectorMock($this->getMock('PHPParser_Node_Stmt'));
+        $base_reflector = new BaseReflectorMock(
+            $this->getMock('PHPParser_Node_Stmt'),
+            new Context()
+        );
         $base_reflector->setNamespace('namespace_name');
 
         $this->assertEquals('namespace_name', $base_reflector->getNameSpace());
@@ -105,7 +110,10 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
     public function testSetNameSpaceInvalidArgument()
     {
         /** @var BaseReflector $base_reflector  */
-        $base_reflector = new BaseReflectorMock($this->getMock('PHPParser_Node_Stmt'));
+        $base_reflector = new BaseReflectorMock(
+            $this->getMock('PHPParser_Node_Stmt'),
+            new Context()
+        );
         $base_reflector->setNamespace(null);
     }
 
@@ -143,7 +151,10 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
     public function testGetShortName()
     {
         $node = new NodeMock();
-        $base_reflector = new BaseReflectorMock($node);
+        $base_reflector = new BaseReflectorMock(
+            $node,
+            new Context()
+        );
 
         $this->assertEquals($node->__toString(), $base_reflector->getShortName());
 
@@ -163,14 +174,22 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
     public function testGetNamespaceAliases()
     {
         $node = new NodeMock();
-        $base_reflector = new BaseReflectorMock($node);
+        $base_reflector = new BaseReflectorMock(
+            $node,
+            new Context()
+        );
 
         $this->assertEquals(array(), $base_reflector->getNamespaceAliases());
 
-        $base_reflector->setNamespaceAliases(array('test_namespace', 'test_namespace_2'));
+        $base_reflector->setNamespaceAliases(
+            array('test_namespace', 'test_namespace_2')
+        );
 
         $this->assertCount(2, $base_reflector->getNamespaceAliases());
-        $this->assertEquals(array('test_namespace', 'test_namespace_2'), $base_reflector->getNamespaceAliases());
+        $this->assertEquals(
+            array('\test_namespace', '\test_namespace_2'),
+            $base_reflector->getNamespaceAliases()
+        );
     }
 
     /**
@@ -189,7 +208,11 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
     public function testsetNamespaceAlias()
     {
         $node = new NodeMock();
-        $base_reflector = new BaseReflectorMock($node);
+        
+        $base_reflector = new BaseReflectorMock(
+            $node,
+            new Context()
+        );
 
         $this->assertEquals(array(), $base_reflector->getNamespaceAliases());
 
@@ -198,14 +221,14 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
         $namespace_aliases = $base_reflector->getNamespaceAliases();
         $this->assertCount(1, $namespace_aliases);
         $this->assertArrayHasKey('test_alias', $namespace_aliases);
-        $this->assertEquals('test_namespace', $namespace_aliases['test_alias']);
+        $this->assertEquals('\test_namespace', $namespace_aliases['test_alias']);
 
         $base_reflector->setNamespaceAlias('test_alias', 'test_namespace_2');
 
         $namespace_aliases = $base_reflector->getNamespaceAliases();
         $this->assertCount(1, $namespace_aliases);
         $this->assertArrayHasKey('test_alias', $namespace_aliases);
-        $this->assertEquals('test_namespace_2', $namespace_aliases['test_alias']);
+        $this->assertEquals('\test_namespace_2', $namespace_aliases['test_alias']);
 
         $base_reflector->setNamespaceAlias('test_alias2', 'test_namespace');
 
@@ -213,8 +236,8 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $namespace_aliases);
         $this->assertArrayHasKey('test_alias', $namespace_aliases);
         $this->assertArrayHasKey('test_alias2', $namespace_aliases);
-        $this->assertEquals('test_namespace_2', $namespace_aliases['test_alias']);
-        $this->assertEquals('test_namespace', $namespace_aliases['test_alias2']);
+        $this->assertEquals('\test_namespace_2', $namespace_aliases['test_alias']);
+        $this->assertEquals('\test_namespace', $namespace_aliases['test_alias2']);
     }
 
     /**
@@ -227,7 +250,11 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
     public function TestGetLinenumber()
     {
         $node = new NodeMock();
-        $base_reflector = new BaseReflectorMock($node);
+        
+        $base_reflector = new BaseReflectorMock(
+            $node,
+            new Context()
+        );
 
         $this->assertEquals($node->getLine(), $base_reflector->getLinenumber());
 
@@ -247,7 +274,11 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
     public function testSetDefaultPackageName()
     {
         $node = new NodeMock();
-        $base_reflector = new BaseReflectorMock($node);
+        
+        $base_reflector = new BaseReflectorMock(
+            $node,
+            new Context()
+        );
 
         $this->assertInternalType('string', $base_reflector->getDefaultPackageName());
         $this->assertEquals('', $base_reflector->getDefaultPackageName());
@@ -267,7 +298,10 @@ class BaseReflectorTest extends \PHPUnit_Framework_TestCase
     public function testGetRepresentationOfValue()
     {
         $node = new NodeMock();
-        $base_reflector = new BaseReflectorMock($node);
+        $base_reflector = new BaseReflectorMock(
+            $node,
+            new Context()
+        );
 
         $this->assertEquals('', $base_reflector->getValueRepresentation(null));
 

--- a/tests/unit/phpDocumentor/Reflection/ClassReflectorTest.php
+++ b/tests/unit/phpDocumentor/Reflection/ClassReflectorTest.php
@@ -11,6 +11,8 @@
  */
 namespace phpDocumentor\Reflection;
 
+use phpDocumentor\Reflection\DocBlock\Context;
+
 /**
  * Class for testing PHPParser_Node_Stmt.
  *
@@ -66,7 +68,10 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
     {
         //$this->markTestSkipped();
         $node = new NodeMock2();
-        $class_reflector = new ClassReflector($node);
+        $class_reflector = new ClassReflector(
+            $node,
+            new Context()
+        );
 
         $this->assertFalse($class_reflector->isAbstract());
 
@@ -84,7 +89,10 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
     public function testIsFinal()
     {
         $node = new NodeMock2();
-        $class_reflector = new ClassReflector($node);
+        $class_reflector = new ClassReflector(
+            $node,
+            new Context()
+        );
 
         $this->assertFalse($class_reflector->isFinal());
 
@@ -102,7 +110,10 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
     public function testGetTraits()
     {
         $node = new NodeMock();
-        $class_reflector = new ClassReflectorMock($node);
+        $class_reflector = new ClassReflectorMock(
+            $node,
+            new Context()
+        );
 
         $traits = $class_reflector->getTraits();
         $this->assertInternalType('array', $traits);
@@ -125,7 +136,10 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
     public function testGetParentClass()
     {
         $node = new NodeMock();
-        $class_reflector = new ClassReflectorMock($node);
+        $class_reflector = new ClassReflectorMock(
+            $node,
+            new Context()
+        );
 
         $this->assertEquals('', $class_reflector->getParentClass());
 
@@ -144,7 +158,10 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
     public function testGetInterfaces()
     {
         $node = new NodeMock();
-        $class_reflector = new ClassReflectorMock($node);
+        $class_reflector = new ClassReflectorMock(
+            $node,
+            new Context()
+        );
 
         $this->assertEquals(array(), $class_reflector->getInterfaces());
 


### PR DESCRIPTION
Here's a fix, as requested in phpDocumentor/ReflectionDocBlock#13.

<del>__NOTE:__ I haven't throughly tested this...</del>


The unit tests of BaseReflector and ClassReflector fail, but oddly enough, they don't seem to fail due to anything related to these changes - they complain about the PHP_Parser mocks not being serializable to strings.

Other than those messages, things _seem_ fine.
