### PR TITLE
Fix fatal error when using config file

### DIFF
--- a/src/phpDocumentor/Command/ConfigurableCommand.php
+++ b/src/phpDocumentor/Command/ConfigurableCommand.php
@@ -71,7 +71,8 @@ class ConfigurableCommand extends Command
         }
 
         if ($config_file) {
-            $this->container['config'] = $this->container->share(
+            $container = $this->getContainer();
+            $container['config'] = $container->share(
                 function () use ($config_file) {
                     $files = array(__DIR__ . '/../../../data/phpdoc.tpl.xml');
                     if ($config_file !== 'none') {


### PR DESCRIPTION
When using a xml file in the command line the program gives a fatal error as the $container is undefined
