### PR TITLE
Use the directory separator in the copy function

### DIFF
--- a/src/phpDocumentor/Transformer/Transformer.php
+++ b/src/phpDocumentor/Transformer/Transformer.php
@@ -411,10 +411,10 @@ class Transformer extends TransformerAbstract
 
         while (false !== ($file = readdir($dir))) {
             if (($file != '.') && ($file != '..')) {
-                if (is_dir($src . '/' . $file)) {
-                    $this->copyRecursive($src . '/' . $file, $dst . '/' . $file);
+                if (is_dir($src . DIRECTORY_SEPARATOR . $file)) {
+                    $this->copyRecursive($src . DIRECTORY_SEPARATOR . $file, $dst . DIRECTORY_SEPARATOR . $file);
                 } else {
-                    copy($src . '/' . $file, $dst . '/' . $file);
+                    copy($src . DIRECTORY_SEPARATOR . $file, $dst . DIRECTORY_SEPARATOR . $file);
                 }
             }
         }


### PR DESCRIPTION
Without the directory separator in the copy function it will fail to use Graphviz on Windows. And also the whole build will fail.
There would be an error like this:
<i>Warning: copy(C:\Users\Dominik\Documents\Eclipse\git\doc\img/icons/method.png): failed to open stream: Invalid argument in C:\xampp\php\pear\PhpDocumentor\src\phpDocumentor\Transformer\Transformer.php on line 420</i>
