### PR TITLE
Modified installer.php to accept flags for php path, proxy host

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,14 @@ contain spaces. This is a requirement imposed by an external library (libxml)_
 
 2. Run the installer:
 
+       `mkdir tmp && cd tmp # Optional, but recommended.`
        `php installer.php`
+
+    installer.php accepts the following options:
+
+    `--php='...'` Specify a PHP command line to run (e.g. `--php='php -d detect_unicode=Off'`).  
+    `--proxy='...'` Specify a proxy URL to use for HTTP calls.  
+    `--dev` Retrieve the develop branch version of phpDocumentor2.
 
 3. Set up your binaries to use phpDocumentor from any location:
 


### PR DESCRIPTION
I ran in to a situation where I needed to pass flags to the "php" called by installer.php, and could not change the php.ini. I've modified installer.php to accept the --php="..." flag and moved the "dev" and "proxy" support to getopt as well.

I just noticed the guidelines link. I did not create this in a separate branch, I'm afraid. I will use a separate branch in future updates.
