### PR TITLE
fix transformations/template tag handling: getConfigValueFromPath returns array of strings

### DIFF
--- a/src/phpDocumentor/Command/Project/TransformCommand.php
+++ b/src/phpDocumentor/Command/Project/TransformCommand.php
@@ -185,9 +185,7 @@ TEXT
             $value = $this->getConfigValueFromPath('transformations/template');
             if ($value) {
                 foreach ($value as $template) {
-                    if (is_array($template)) {
-                        $templates[] = $template['name'];
-                    }
+                    $templates[] = $template;
                 }
             }
         }


### PR DESCRIPTION
I tried specifying a template in the XML using:

```
<transformations>
  <template name="old-ocean"/>
</transformations>
```

but the default responsive template was still used. I looked at the code and did some selective var_dumps, found that the return value of getConfigValueFromPath is an array of strings rather than an array of arrays.
