### PR TITLE
Please add a tag called "runtime" to the doctrine

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Tag/Definition/Definition.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Tag/Definition/Definition.php
@@ -145,6 +145,9 @@ class Definition extends ParserAbstract
             case 'link':
                 $def = new Link($namespace, $namespace_aliases, $xml, $tag);
                 break;
+            case 'runtime':
+                $def = new Link($namespace, $namespace_aliases, $xml, $tag);
+                break;
             case 'author':
             case 'version':
             case 'since':

--- a/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Tag/Definition/Runtime.php
+++ b/src/phpDocumentor/Plugin/Core/Parser/DocBlock/Tag/Definition/Runtime.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5
+ *
+ * @category   phpDocumentor
+ * @package    Parser
+ * @subpackage Tag_Definitions
+ * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright  2010-2011 Mike van Riel / Naenius. (http://www.naenius.com)
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://phpdoc.org
+ */
+
+namespace phpDocumentor\Plugin\Core\Parser\DocBlock\Tag\Definition;
+
+/**
+ * Definition for the @param tag; adds a attribute called `variable`.
+ *
+ * @category   phpDocumentor
+ * @package    Parser
+ * @subpackage Tag_Definitions
+ * @author     Mike van Riel <mike.vanriel@naenius.com>
+ * @license    http://www.opensource.org/licenses/mit-license.php MIT
+ * @link       http://phpdoc.org
+ */
+class Runtime extends Definition
+{
+}


### PR DESCRIPTION
There shall be one tag that shows the runtime of a method with Landau-Symbols.
