### PR TITLE
Remove duplicate dollar sign for inherited variables

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Transformer/Behaviour/Inherit/Node/PropertyNode.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Behaviour/Inherit/Node/PropertyNode.php
@@ -119,7 +119,7 @@ class PropertyNode extends NodeAbstract
             $parent_class_name = $this->class->getFQCN();
         }
 
-        return $parent_class_name . '::$' . $this->getName();
+        return $parent_class_name . '::' . $this->getName();
     }
 
     /**


### PR DESCRIPTION
You don't need to add a dollar sign when concatenating the class and variable names, this will only lead to output like `parent_class::$$variable`. The dollar sign for properties is already in the structure.xml
