### PR TITLE
Allow symfony/event-dispatcher > 2.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "monolog/monolog":  "1.4.*@stable",
         "twig/twig":        "1.*@stable",
 
-        "symfony/event-dispatcher": "2.1.*@stable",
+        "symfony/event-dispatcher": "~2.1@stable",
         "jms/serializer":           "0.12.*@dev",
 
         "zendframework/zend-stdlib":         "2.1.*@stable",


### PR DESCRIPTION
This enables having phpDocumentor as a requirement in a symfony 2.2
application.
The API for EventDispatcher did not change between 2.1 and 2.2

I ran the tests with v2.19 and v2.2.1 of the symfony/event-dispatcher and had the same result for both (1 error, 1 failure which appear unrelated to this change)
