### PR TITLE
Fixed a fatal error: PackageInterface now inherits from NamespaceInterface

### DIFF
--- a/src/phpDocumentor/Descriptor/Interfaces/NamespaceInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/NamespaceInterface.php
@@ -6,7 +6,7 @@ use phpDocumentor\Descriptor\Collection;
 interface NamespaceInterface extends BaseInterface, ContainerInterface
 {
     /**
-     * @return NamespaceInterface
+     * @return static
      */
     public function getParent();
 

--- a/src/phpDocumentor/Descriptor/Interfaces/PackageInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/PackageInterface.php
@@ -1,17 +1,6 @@
 <?php
 namespace phpDocumentor\Descriptor\Interfaces;
 
-use phpDocumentor\Descriptor\Collection;
-
-interface PackageInterface extends BaseInterface, ContainerInterface
+interface PackageInterface extends BaseInterface, ContainerInterface, NamespaceInterface
 {
-    /**
-     * @return PackageInterface
-     */
-    public function getParent();
-
-    /**
-     * @return Collection
-     */
-    public function getChildren();
 }


### PR DESCRIPTION
I was trying out the new PhpDocumentor, and the first thing that hit me was a fatal error (can't say I'm surprised to be honest... big changes and all...).

After some digging around, it seems the getParent() method was inherited twice by PackageDescriptor, and despite the fact its being overwritten, the very fact that two unrelated interfaces require the same method name seems to freak PHP (5.3.8; the one on my machine) out. Making them related is the easiest way to fix this.

Note: The travis errors seem to be unrelated to any of this.
