### PR TITLE
Made the Xml writer generate a @generated-path attribute for each file.

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml.php
@@ -40,6 +40,7 @@ use phpDocumentor\Plugin\Core\Transformer\Behaviour\Tag\VarTag;
 use phpDocumentor\Reflection\BaseReflector;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Transformer\Transformation;
+use phpDocumentor\Transformer\Transformer;
 use phpDocumentor\Translator;
 
 /**
@@ -102,20 +103,29 @@ class Xml extends WriterAbstract implements Translatable
 
         $document_element->setAttribute('version', Application::$VERSION);
 
+        $transformer = $transformation->getTransformer();
         foreach ($project->getFiles() as $file) {
-            $this->buildFile($document_element, $file);
+            $this->buildFile($document_element, $file, $transformer);
         }
 
         $this->finalize();
         file_put_contents($artifact, $this->xml->saveXML());
     }
 
-    protected function buildFile(\DOMElement $parent, FileDescriptor $file)
-    {
+    protected function buildFile(
+        \DOMElement $parent,
+        FileDescriptor $file,
+        Transformer $transformer
+    ) {
         $child = new \DOMElement('file');
         $parent->appendChild($child);
 
-        $child->setAttribute('path', ltrim($file->getPath(), './'));
+        $path = ltrim($file->getPath(), './');
+        $child->setAttribute('path', $path);
+        $child->setAttribute(
+            'generated-path',
+            $transformer->generateFilename($path)
+        );
         $child->setAttribute('hash', $file->getHash());
 
         $this->buildDocBlock($child, $file);


### PR DESCRIPTION
Required by built in (and probably 3rd party) legacy templates.
