### PR TITLE
Fix #846; check whether a const or method is set

### DIFF
--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -260,7 +260,10 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
         parent::setPackage($package);
 
         foreach ($this->getConstants() as $constant) {
-            $constant->setPackage($package);
+            // TODO #840: Workaround; for some reason there are NULLs in the constants array.
+            if ($constant) {
+                $constant->setPackage($package);
+            }
         }
 
         foreach ($this->getProperties() as $property) {
@@ -271,7 +274,10 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
         }
 
         foreach ($this->getMethods() as $method) {
-            $method->setPackage($package);
+            // TODO #840: Workaround; for some reason there are NULLs in the methods array.
+            if ($method) {
+                $method->setPackage($package);
+            }
         }
     }
 }


### PR DESCRIPTION
During the setting of a package will all child elements also be set;
sometimes one of those children is not a descriptor (addressed in #840)
and must the setting be skipped in this case.
