### PR TITLE
WIP: [#862]: Replace slashes for path with DIRECTORY_SEPARATOR

### DIFF
--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/ClassDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/ClassDescriptor.php
@@ -26,6 +26,7 @@ class ClassDescriptor implements UrlGeneratorInterface
      */
     public function __invoke($node)
     {
-        return '/classes/'.str_replace('\\', '.', ltrim($node->getFullyQualifiedStructuralElementName(), '\\')).'.html';
+        return DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR
+            . str_replace('\\', '.', ltrim($node->getFullyQualifiedStructuralElementName(), '\\')).'.html';
     }
 }

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/NamespaceDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/NamespaceDescriptor.php
@@ -33,6 +33,6 @@ class NamespaceDescriptor implements UrlGeneratorInterface
             $name = 'default';
         }
 
-        return '/namespaces/'. $name .'.html';
+        return DIRECTORY_SEPARATOR . 'namespaces' . DIRECTORY_SEPARATOR . $name .'.html';
     }
 }

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/PackageDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/PackageDescriptor.php
@@ -33,6 +33,6 @@ class PackageDescriptor implements UrlGeneratorInterface
             $name = 'default';
         }
 
-        return '/packages/'. $name .'.html';
+        return DIRECTORY_SEPARATOR . 'packages' . DIRECTORY_SEPARATOR . $name .'.html';
     }
 }


### PR DESCRIPTION
I suspect that the issue mentioned in #862 comes from the routing. The routing
uses '/' instead of directory separator and it would seem that this is not
translated to the OS' specific separator.

By replacing the '/' with DIRECTORY_SEPARATOR I hope it will solve the issue.
