### PR TITLE
Bugfix for: PHP Warning:  vsprintf() expects parameter 2 to be array, string given

### DIFF
--- a/src/phpDocumentor/Parser/Command/Project/ParseCommand.php
+++ b/src/phpDocumentor/Parser/Command/Project/ParseCommand.php
@@ -192,7 +192,7 @@ class ParseCommand extends ConfigurableCommand
             $progress->finish();
         }
 
-        $output->write($this->__('PPCPP:LOG-STORECACHE', $this->getCache()->getOptions()->getCacheDir()));
+        $output->write($this->__('PPCPP:LOG-STORECACHE', (array) $this->getCache()->getOptions()->getCacheDir()));
         $mapper->save($projectDescriptor);
 
         $output->writeln($this->__('PPCPP:LOG-OK'));


### PR DESCRIPTION
The cache dir is passed as parameter to the translate method as string, while an array is expected.

PHP  10. phpDocumentor\Parser\Command\Project\ParseCommand->__() /usr/share/php/phpDocumentor/src/phpDocumentor/Parser/Command/Project/ParseCommand.php:195
PHP  11. vsprintf() /usr/share/php/phpDocumentor/src/phpDocumentor/Parser/Command/Project/ParseCommand.php:320
