### PR TITLE
Ease symfony/validator version constraint slightly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php":              ">=5.3.3",
 
         "cilex/cilex":      "1.*@dev",
-        "symfony/validator": ">=v2.3.0@stable",
+        "symfony/validator": "~2.2@stable",
 
         "monolog/monolog":  "1.4.*@stable",
         "twig/twig":        "1.*@stable",

--- a/tests/unit/phpDocumentor/Descriptor/MethodDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/MethodDescriptorTest.php
@@ -115,7 +115,7 @@ class MethodDescriptorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($this->fixture->getResponse());
 
-        $this->fixture->getTags()->set('return', array($mock));
+        $this->fixture->getTags()->set('return', new Collection(array($mock)));
 
         $this->assertSame($mock, $this->fixture->getResponse());
     }


### PR DESCRIPTION
Also fix a test

This enables using phpdocumentor with symfony 2.2 projects
