### PR TITLE
WIP: Move bin/phpdoc.php to bin/phpdoc

### DIFF
--- a/bin/phpdoc
+++ b/bin/phpdoc
@@ -1,0 +1,43 @@
+#!/usr/bin/env php
+<?php
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @copyright 2010-2013 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+// check whether xhprof is loaded
+$profile = (bool)(getenv('PHPDOC_PROFILE') === 'on');
+if ($profile && extension_loaded('xhprof')) {
+    xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);
+}
+
+// determine base include folder, if @php_dir@ contains @php_dir then
+// we did not install via PEAR
+$bootstrap_folder = (strpos('@php_dir@', '@php_dir') === 0)
+    ? __DIR__ . '/../src'
+    : '@php_dir@/phpDocumentor/src';
+
+require_once $bootstrap_folder . '/phpDocumentor/Application.php';
+$app = new phpDocumentor\Application();
+$app->run();
+
+if (true === $profile) {
+    include_once 'XHProf/utils/xhprof_lib.php';
+    include_once 'XHProf/utils/xhprof_runs.php';
+
+    $xhprof_data = xhprof_disable();
+    if ($xhprof_data !== null) {
+        $xhprof_runs = new XHProfRuns_Default();
+        $run_id = $xhprof_runs->save_run($xhprof_data, 'phpdoc');
+        $profiler_url = sprintf('index.php?run=%s&source=%s', $run_id, 'phpdoc');
+        echo 'Profile can be found at: ' . $profiler_url . PHP_EOL;
+    }
+}
+
+// disable E_STRICT reporting on the end to prevent PEAR from throwing Strict warnings.
+error_reporting(error_reporting() & ~E_STRICT);

--- a/bin/phpdoc.bat
+++ b/bin/phpdoc.bat
@@ -5,4 +5,4 @@ GOTO RUN
 :USE_PEAR_PATH
 set PHPBIN=%PHP_PEAR_PHP_BIN%
 :RUN
-"%PHPBIN%" "%PHP_PEAR_BIN_DIR%\phpdoc.php" %*
+"%PHPBIN%" "%PHP_PEAR_BIN_DIR%\phpdoc" %*

--- a/bin/phpdoc.php
+++ b/bin/phpdoc.php
@@ -1,43 +1,5 @@
 #!/usr/bin/env php
 <?php
-/**
- * phpDocumentor
- *
- * PHP Version 5.3
- *
- * @copyright 2010-2013 Mike van Riel / Naenius (http://www.naenius.com)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT
- * @link      http://phpdoc.org
- */
 
-// check whether xhprof is loaded
-$profile = (bool)(getenv('PHPDOC_PROFILE') === 'on');
-if ($profile && extension_loaded('xhprof')) {
-    xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);
-}
-
-// determine base include folder, if @php_dir@ contains @php_dir then
-// we did not install via PEAR
-$bootstrap_folder = (strpos('@php_dir@', '@php_dir') === 0)
-    ? __DIR__ . '/../src'
-    : '@php_dir@/phpDocumentor/src';
-
-require_once $bootstrap_folder . '/phpDocumentor/Application.php';
-$app = new phpDocumentor\Application();
-$app->run();
-
-if (true === $profile) {
-    include_once 'XHProf/utils/xhprof_lib.php';
-    include_once 'XHProf/utils/xhprof_runs.php';
-
-    $xhprof_data = xhprof_disable();
-    if ($xhprof_data !== null) {
-        $xhprof_runs = new XHProfRuns_Default();
-        $run_id = $xhprof_runs->save_run($xhprof_data, 'phpdoc');
-        $profiler_url = sprintf('index.php?run=%s&source=%s', $run_id, 'phpdoc');
-        echo 'Profile can be found at: ' . $profiler_url . PHP_EOL;
-    }
-}
-
-// disable E_STRICT reporting on the end to prevent PEAR from throwing Strict warnings.
-error_reporting(error_reporting() & ~E_STRICT);
+trigger_error('phpDocumentor2 should be run from the phpdoc file, not phpdoc.php', E_USER_DEPRECATED);
+require_once __DIR__.'/phpdoc';

--- a/bin/utils/package.php
+++ b/bin/utils/package.php
@@ -46,7 +46,7 @@ function createPackager($original_file, $options = array())
                 'vendor/twig/twig/ext/*'
             ),
             'exceptions'        => array(
-                'bin/phpdoc.php'   => 'script',
+                'bin/phpdoc'       => 'script',
                 'bin/phpdoc.bat'   => 'script',
                 'phpdoc.dist.xml'  => 'php',
                 'LICENSE'          => 'php',
@@ -63,7 +63,7 @@ function createPackager($original_file, $options = array())
                 'vendor/phpunit/php-code-coverage/PHP/CodeCoverage/Autoload.php.in' => 'php',
             ),
             'installexceptions' => array(
-                'bin/phpdoc.php' => '/',
+                'bin/phpdoc' => '/',
                 'bin/phpdoc.bat' => '/'
             ),
             'dir_roles'         => array(
@@ -103,14 +103,14 @@ DESC
     $packagexml->setPhpDep('5.3.3');
     $packagexml->setPearinstallerDep('1.4.0');
     $packagexml->addReplacement(
-        'bin/phpdoc.php',
+        'bin/phpdoc',
         'pear-config',
         '/usr/bin/env php',
         'php_bin'
     );
     $packagexml->addGlobalReplacement('pear-config', '@php_bin@', 'php_bin');
     $packagexml->addReplacement(
-        'bin/phpdoc.php',
+        'bin/phpdoc',
         'pear-config',
         '@php_dir@',
         'php_dir'
@@ -137,10 +137,10 @@ DESC
     $packagexml->addRelease();
     $packagexml->setOSInstallCondition('windows');
     $packagexml->addInstallAs('bin/phpdoc.bat', 'phpdoc.bat');
-    $packagexml->addInstallAs('bin/phpdoc.php', 'phpdoc.php');
+    $packagexml->addInstallAs('bin/phpdoc',     'phpdoc');
 
     $packagexml->addRelease();
-    $packagexml->addInstallAs('bin/phpdoc.php', 'phpdoc');
+    $packagexml->addInstallAs('bin/phpdoc', 'phpdoc');
     $packagexml->addIgnoreToRelease('bin/phpdoc.bat');
 
     return $packagexml;

--- a/build.xml
+++ b/build.xml
@@ -152,7 +152,7 @@
     <target name="deploy:publish-demo"
             description="Generate a demo and upload it to the server">
         <delete><fileset dir="/tmp/phpdoc-demo/responsive"><include name="*"/></fileset></delete>
-        <exec command="php bin/phpdoc.php -t /tmp/phpdoc-demo/responsive" dir="${project.basedir}" passthru="true" checkreturn="true"/>
+        <exec command="php bin/phpdoc -t /tmp/phpdoc-demo/responsive" dir="${project.basedir}" passthru="true" checkreturn="true"/>
         <exec command="scp -r /tmp/phpdoc-demo/responsive/* ${server.username}@${server.demo}:${server.demo.path}" passthru="true" checkreturn="true"/>
     </target>
 

--- a/composer.json
+++ b/composer.json
@@ -56,5 +56,5 @@
     "config": {
         "bin-dir":"bin/"
     },
-    "bin": ["bin/phpdoc.php"]
+    "bin": ["bin/phpdoc"]
 }

--- a/docs/manual/for-users/getting-started/running-the-application.rst
+++ b/docs/manual/for-users/getting-started/running-the-application.rst
@@ -11,12 +11,12 @@ whenever we ask you to run a command it would be in the following form::
     $ phpdoc
 
 When you have installed a version via the installer you should invoke the
-``phpdoc.php`` script in the ``bin`` folder of your phpDocumentor installation
+``phpdoc`` script in the ``bin`` folder of your phpDocumentor installation
 unless you have added a symlink as described in the chapter :doc:`../installation`.
 
 Under Linux / MacOSX that would be::
 
-    $ [PHPDOC_FOLDER]/bin/phpdoc.php
+    $ [PHPDOC_FOLDER]/bin/phpdoc
 
 And under Windows that would be::
 

--- a/docs/manual/for-users/installation/troubleshooting.rst
+++ b/docs/manual/for-users/installation/troubleshooting.rst
@@ -7,7 +7,7 @@ I want to install phpDocumentor without internet access
 At http://pear.phpdoc.org you can find compressed archives that can be used to do an offline install using PEAR, or
 when you do not have PEAR on the designated machine you can uncompress the archive in your installation path.
 
-The binary's path is ``<installation_path>/bin/phpdoc.php``.
+The binary's path is ``<installation_path>/bin/phpdoc``.
 
 I get the following error: preg_match(): Compilation failed: support for \P, \p, and \X has not been compiled
 -------------------------------------------------------------------------------------------------------------

--- a/features/bootstrap/ExecutionContext.php
+++ b/features/bootstrap/ExecutionContext.php
@@ -78,7 +78,7 @@ class ExecutionContext extends BehatContext
      */
     public function iRunPhpdocumentorAgainstNoFilesOrDirectories()
     {
-        $this->iRun("php bin/phpdoc.php -t build --config=none --force");
+        $this->iRun("php bin/phpdoc -t build --config=none --force");
     }
 
     /**
@@ -96,7 +96,7 @@ class ExecutionContext extends BehatContext
     public function iRunPhpDocumentorAgainstTheFile($file_path)
     {
         $this->iRun(
-            "php bin/phpdoc.php -f $file_path -t build --config=none --force"
+            "php bin/phpdoc -f $file_path -t build --config=none --force"
         );
     }
 
@@ -116,7 +116,7 @@ class ExecutionContext extends BehatContext
     {
         $file = tempnam(sys_get_temp_dir(), 'pdb');
         file_put_contents($file, $code);
-        $this->iRun("php bin/phpdoc.php -f $file -t build --config=none --force $extraParameters");
+        $this->iRun("php bin/phpdoc -f $file -t build --config=none --force $extraParameters");
         unlink($file);
     }
 
@@ -133,7 +133,7 @@ class ExecutionContext extends BehatContext
     public function iRunPhpDocumentorAgainstTheFileUsingOption($file_path, $options)
     {
         $this->iRun(
-            "php bin/phpdoc.php -f $file_path -t build --config=none "
+            "php bin/phpdoc -f $file_path -t build --config=none "
             ."--force $options"
         );
     }
@@ -150,7 +150,7 @@ class ExecutionContext extends BehatContext
     public function iRunPhpDocumentorAgainstTheDirectory($folder_path)
     {
         $this->iRun(
-            "php bin/phpdoc.php -d $folder_path -t build --config=none --force"
+            "php bin/phpdoc -d $folder_path -t build --config=none --force"
         );
     }
 

--- a/src/phpDocumentor/PharCompiler.php
+++ b/src/phpDocumentor/PharCompiler.php
@@ -197,7 +197,7 @@ class PharCompiler
     protected function getCliStub()
     {
         return "<?php " . $this->getLicense()
-            . " require_once __DIR__.'/bin/phpdoc.php'; __HALT_COMPILER();";
+            . " require_once __DIR__.'/bin/phpdoc'; __HALT_COMPILER();";
     }
 
     /**


### PR DESCRIPTION
### Rationale

The convention for vendor binaries in composer is to omit the `php` file extension.
This pull request has been opened so that it may be considered in time for the imminent release of `2.0.0` stable
### Changes

This change implements that. The old `bin/phpdoc.php` file is retained for backwards compatibility but now triggers an `E_USER_DEPRECATED` warning.
### Notes

The configurations for PEAR and PHAR builds has been altered but **HAS NOT BEEN TESTED**
These changes have been tested with a composer installation on a *nix system.

Please consider this pull request a work in progress
### Todo
- [ ] Test Windows support for PEAR builds
- [ ] Test *nix support for PEAR build
- [ ] Test *nix support for PHAR build
