### PR TITLE
Update template version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,15 +36,14 @@
         "phpdocumentor/reflection":          "0.1.*@stable",
         "phpdocumentor/reflection-docblock": "2.*@dev",
 
-        "phpdocumentor/unified-asset-installer":  "1.*@beta",
-        "phpdocumentor/template-clean": "1.*@beta",
-        "phpdocumentor/template-responsive-twig": "1.*@stable",
-        "phpdocumentor/template-responsive":      ">=1.1.0@stable",
-        "phpdocumentor/template-new-black":       ">=1.1.0@stable",
-        "phpdocumentor/template-zend":            ">=1.1.0@stable",
-        "phpdocumentor/template-old-ocean":       ">=1.1.0@stable",
-        "phpdocumentor/template-checkstyle":      "1.*@stable",
-        "phpdocumentor/template-xml":             ">=1.1.0@stable"
+        "phpdocumentor/template-clean":           "1.*@beta",
+        "phpdocumentor/template-responsive-twig": "~1.2@stable",
+        "phpdocumentor/template-responsive":      "~1.3@stable",
+        "phpdocumentor/template-new-black":       "~1.3@stable",
+        "phpdocumentor/template-zend":            "~1.3@stable",
+        "phpdocumentor/template-old-ocean":       "~1.3@stable",
+        "phpdocumentor/template-checkstyle":      "~1.2@stable",
+        "phpdocumentor/template-xml":             "~1.2@stable"
     },
     "minimum-stability": "dev",
     "require-dev": {


### PR DESCRIPTION
Once https://github.com/phpDocumentor/UnifiedAssetInstaller/pull/3 has been merged and tagged, and also all the phpDocumentor templates have had their corresponding pull requests merged and tagged this will be good to go.

I have not adjusted the constraints for "phpdocumentor/template-clean" as it is still in beta.

The dependency on "phpdocumentor/unified-asset-installer" has been removed as phpDocumentor does
not directly depend on it.
