### PR TITLE
Change installed path for templates when vendored

### DIFF
--- a/src/phpDocumentor/Transformer/Command/Template/ListCommand.php
+++ b/src/phpDocumentor/Transformer/Command/Template/ListCommand.php
@@ -68,7 +68,8 @@ HELP
     {
         $template_dir = dirname(__FILE__) . '/../../../../data/templates';
         if (!file_exists($template_dir)) {
-            $template_dir = dirname(__FILE__) . '/../../../../../data/templates';
+            //Vendored installation
+            $template_dir = dirname(__FILE__) . '/../../../../../../templates';
         }
 
         /** @var \RecursiveDirectoryIterator $files */


### PR DESCRIPTION
Depends on https://github.com/phpDocumentor/UnifiedAssetInstaller/pull/5
Fixes #597

On a first run installation the templates were being installed by Composer before phpDocumentor. When phpDocumentor was then installed by Composer it overwrote the templates. Subsequent updates would install the missing templates.

This change moves the template installation out of the phpDocumentor folder and in to its own `templates` directory.

The resultant vendor structure looks like this:
![image](https://f.cloud.github.com/assets/929392/898542/53434046-fb17-11e2-9dd3-8a6bd1aab2ea.png)
