### PR TITLE
[#989]: Update monolog requirement to 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "cilex/cilex":      "~1.0",
         "symfony/validator": "~2.2",
 
-        "monolog/monolog":  "~1.4",
+        "monolog/monolog":  "~1.6",
         "twig/twig":        "~1.3",
         "dflydev/markdown": "~1.0",
 


### PR DESCRIPTION
phpDocumentor now uses the ErrorHandler of Monolog but that wasn't available
until 1.6. Given that the composer.json is locked on 1.4 we need to bump the
requirement to 1.6.
