### PR TITLE
Fixing "phpdocumentor/reflection-docblock": "~2.0@dev" dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpdocumentor/graphviz":            "1.*@beta",
         "phpdocumentor/fileset":             "1.*@beta",
         "phpdocumentor/reflection":          "~1.0",
-        "phpdocumentor/reflection-docblock": "~2.0.*@dev",
+        "phpdocumentor/reflection-docblock": "2.0.*@dev",
 
         "phpdocumentor/template-abstract":        "~1.2",
         "phpdocumentor/template-clean":           "~1.0",


### PR DESCRIPTION
Attempting to fix this error:

phpdocumentor/phpdocumentor dev-develop requires phpdocumentor/reflection-docblock ~2.0@dev -> no matching package found.
