### PR TITLE
Fixed wrong errorcode if return annotation has a type of 'type'

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Descriptor/Validator/Functions/AreAllArgumentsValid.php
+++ b/src/phpDocumentor/Plugin/Core/Descriptor/Validator/Functions/AreAllArgumentsValid.php
@@ -35,7 +35,7 @@ class AreAllArgumentsValid
         if ($docBlock->hasTag('return')) {
             $returnTag = current($docBlock->getTagsByName('return'));
             if ($returnTag->getType() == 'type') {
-                return new Error(LogLevel::WARNING, 'PPC:ERR-50004', $element->getLinenumber());
+                return new Error(LogLevel::WARNING, 'PPC:ERR-50017', $element->getLinenumber());
             }
         }
 


### PR DESCRIPTION
Errorcode should be PPC:ERR-50017 instead of PPC:ERR-50004 if return-type is 'type'.
