### PR TITLE
More structure.xml fixes

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml.php
@@ -638,7 +638,7 @@ class Xml extends WriterAbstract implements Translatable
         
         $child->setAttribute(
             'description',
-            htmlspecialchars(trim($description), ENT_QUOTES, 'UTF-8')
+            str_replace('&', '&amp;', trim($description))
         );
 
         if (method_exists($tag, 'getTypes')) {
@@ -657,18 +657,21 @@ class Xml extends WriterAbstract implements Translatable
             $child->setAttribute('type', rtrim($typeString, '|'));
         }
         if (method_exists($tag, 'getVariableName')) {
-            $child->setAttribute('variable', $tag->getVariableName());
+            $child->setAttribute(
+                'variable',
+                str_replace('&', '&amp;', $tag->getVariableName())
+            );
         }
         if (method_exists($tag, 'getReference')) {
             $child->setAttribute(
                 'link',
-                htmlspecialchars($tag->getReference(), ENT_QUOTES, 'UTF-8')
+                str_replace('&', '&amp;', $tag->getReference())
             );
         }
         if (method_exists($tag, 'getLink')) {
             $child->setAttribute(
                 'link',
-                htmlspecialchars($tag->getLink(), ENT_QUOTES, 'UTF-8')
+                str_replace('&', '&amp;', $tag->getLink())
             );
         }
     }


### PR DESCRIPTION
With this, as before:
- `@link`, `@see` and their derivatives generate a "link" attribute.
- `@version` and its derivatives have the version vector prepended to the description.

(both of these affect legacy templates like new-black for example)

EDIT: Also added links to type tags and changed htmlspecialchars() to just a str_replace() of "&". Otherwise, the descriptions end up containing stuff like "&quot;".
