### PR TITLE
Remove extraneous lines from null keyword example

### DIFF
--- a/docs/PSR.md
+++ b/docs/PSR.md
@@ -1935,11 +1935,6 @@ The following keywords are recognized by this PSR:
             return null;
         }
 
-        return null;
-    }
-    ```
-
-
 11. 'callable', the element to which this type applies is a pointer to a
     function call. This may be any type of callable as defined in the PHP manual
     about [pseudo-types][PHP_PSEUDO] or the section on [callable][PHP_CALLABLE].


### PR DESCRIPTION
There are a few extra lines in one of the examples for null.
