### PR TITLE
Don't use single type notation for mixed type arrays

### DIFF
--- a/docs/PSR.md
+++ b/docs/PSR.md
@@ -632,7 +632,7 @@ Example:
 /**
  * Initializes this class with the given options.
  *
- * @param string[] $options {
+ * @param array $options {
  *     @type boolean $required Whether this element is required
  *     @type string  $label    The display name for this element
  * }
@@ -1230,7 +1230,7 @@ an option array with 2 elements: 'required' and 'label'.
 /**
  * Initializes this class with the given options.
  *
- * @param string[] $options {
+ * @param array $options {
  *     @type boolean $required Whether this element is required
  *     @type string  $label    The display name for this element
  * }


### PR DESCRIPTION
Two locations in the PSR use `string[]` to specify the type of an array that is documented to contain both `string` and `boolean` elements.
