### PR TITLE
Install mongodb and xhprof with pecl

### DIFF
--- a/.puppet/modules/phpdocumentor/manifests/setup.pp
+++ b/.puppet/modules/phpdocumentor/manifests/setup.pp
@@ -6,10 +6,16 @@ class phpdocumentor::setup {
     include php
     include apache
     php::module { "xsl": }
-    php::module { "mongo": }
     php::module { "intl": }
     php::module { "xdebug": }
-    php::module { "xhprof": }
+    class { "php::pear": }
+    php::pecl::module { "xhprof":
+      use_package     => 'false',
+      preferred_state => 'beta',
+    }
+    php::pecl::module { "mongo":
+      use_package     => 'false',
+    }    
 
     class { 'composer':
       command_name => 'composer',


### PR DESCRIPTION
Trying to install mongo and xhprof packages with apt-get on the latest box file is broken.

Using pecl for this is a more consistent approach and should work no matter what version of the box file is used. 

This fix will also stop puppet errors when users new developers run vagrant up or vagrant provision. 
