### PR TITLE
Fix the FileDescriptor Fatals in the build

### DIFF
--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/ClassDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/ClassDescriptor.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Transformer\Router\UrlGenerator\Standard;
 
-use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor;
 use phpDocumentor\Transformer\Router\UrlGenerator\UrlGeneratorInterface;
 
 class ClassDescriptor implements UrlGeneratorInterface
@@ -19,7 +19,7 @@ class ClassDescriptor implements UrlGeneratorInterface
     /**
      * Generates a URL from the given node or returns false if unable.
      *
-     * @param string|DescriptorAbstract $node
+     * @param string|Descriptor\ClassDescriptor $node
      *
      * @return string|false
      */

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/ConstantDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/ConstantDescriptor.php
@@ -19,7 +19,7 @@ class ConstantDescriptor implements UrlGeneratorInterface
     /**
      * Generates a URL from the given node or returns false if unable.
      *
-     * @param string|Descriptor\DescriptorAbstract $node
+     * @param string|Descriptor\ConstantDescriptor $node
      *
      * @return string|false
      */

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/FileDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/FileDescriptor.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Transformer\Router\UrlGenerator\Standard;
 
-use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor;
 use phpDocumentor\Transformer\Router\UrlGenerator\UrlGeneratorInterface;
 
 class FileDescriptor implements UrlGeneratorInterface
@@ -19,7 +19,7 @@ class FileDescriptor implements UrlGeneratorInterface
     /**
      * Generates a URL from the given node or returns false if unable.
      *
-     * @param string|DescriptorAbstract $node
+     * @param string|Descriptor\FileDescriptor $node
      *
      * @return string|false
      */

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/FunctionDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/FunctionDescriptor.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Transformer\Router\UrlGenerator\Standard;
 
-use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor;
 use phpDocumentor\Transformer\Router\UrlGenerator\UrlGeneratorInterface;
 
 /**
@@ -22,7 +22,7 @@ class FunctionDescriptor implements UrlGeneratorInterface
     /**
      * Generates a URL from the given node or returns false if unable.
      *
-     * @param string|DescriptorAbstract $node
+     * @param string|Descriptor\FunctionDescriptor $node
      *
      * @return string|false
      */

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/MethodDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/MethodDescriptor.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Transformer\Router\UrlGenerator\Standard;
 
-use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor;
 use phpDocumentor\Transformer\Router\UrlGenerator\UrlGeneratorInterface;
 
 /**
@@ -22,7 +22,7 @@ class MethodDescriptor implements UrlGeneratorInterface
     /**
      * Generates a URL from the given node or returns false if unable.
      *
-     * @param string|DescriptorAbstract $node
+     * @param string|Descriptor\MethodDescriptor $node
      *
      * @return string|false
      */

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/NamespaceDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/NamespaceDescriptor.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Transformer\Router\UrlGenerator\Standard;
 
-use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor;
 use phpDocumentor\Transformer\Router\UrlGenerator\UrlGeneratorInterface;
 
 class NamespaceDescriptor implements UrlGeneratorInterface
@@ -19,7 +19,7 @@ class NamespaceDescriptor implements UrlGeneratorInterface
     /**
      * Generates a URL from the given node or returns false if unable.
      *
-     * @param string|DescriptorAbstract $node
+     * @param string|Descriptor\NamespaceDescriptor $node
      *
      * @return string|false
      */

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/PackageDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/PackageDescriptor.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Transformer\Router\UrlGenerator\Standard;
 
-use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor;
 use phpDocumentor\Transformer\Router\UrlGenerator\UrlGeneratorInterface;
 
 class PackageDescriptor implements UrlGeneratorInterface
@@ -19,7 +19,7 @@ class PackageDescriptor implements UrlGeneratorInterface
     /**
      * Generates a URL from the given node or returns false if unable.
      *
-     * @param string|DescriptorAbstract $node
+     * @param string|Descriptor\PackageDescriptor $node
      *
      * @return string|false
      */

--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/PropertyDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/PropertyDescriptor.php
@@ -11,7 +11,7 @@
 
 namespace phpDocumentor\Transformer\Router\UrlGenerator\Standard;
 
-use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor;
 use phpDocumentor\Transformer\Router\UrlGenerator\UrlGeneratorInterface;
 
 /**
@@ -22,7 +22,7 @@ class PropertyDescriptor implements UrlGeneratorInterface
     /**
      * Generates a URL from the given node or returns false if unable.
      *
-     * @param string|DescriptorAbstract $node
+     * @param string|Descriptor\PropertyDescriptor $node
      *
      * @return string|false
      */


### PR DESCRIPTION
@mvriel:

I'm making some typing assumptions in the layout of these UrlInterface classes, so be sure you're ok with the type hinting I've done, which goes beyond what was strictly necessary to get past the original Fatals.  I'm not sure that prefixing the name aliases with "Original_" accurately reflects the context of those objects, so let me know if there's a better name (e.g. "Source_" maybe?) and I'll update this PR.  Also, I'm on the fence on whether or not the @param values should be tighter than the actual method signatures are (e.g. @param OriginalClassDescriptor vs __invoke(DescriptorAbstract $node), so I can make both of those DescriptorAbstract if that seems better to you too.

After fixing the Fatals, I tried to dig further into the test errors regarding isByRef(), but that issue is more complex than my cursory glance at things can figure out.
