### PR TITLE
Correctly resolve /tmp/phpdoc-demo for windows

### DIFF
--- a/src/phpDocumentor/Parser/Command/Project/ParseCommand.php
+++ b/src/phpDocumentor/Parser/Command/Project/ParseCommand.php
@@ -138,6 +138,7 @@ class ParseCommand extends ConfigurableCommand
         parent::execute($input, $output);
 
         $target = $this->getOption($input, 'target', 'parser/target');
+        $target = str_replace('/tmp/', sys_get_temp_dir() . DIRECTORY_SEPARATOR, $target);
         if (!$this->isAbsolute($target)) {
             $target = getcwd().DIRECTORY_SEPARATOR.$target;
         }


### PR DESCRIPTION
As seen in phpdoc.dist.xml:
/tmp/phpdoc-demo would produces a dir in c:\tmp... this is not the expected behavior...
