### PR TITLE
fixed broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Please consult the documentation to see the format and supported options.
 Documentation
 -------------
 
-For more detailed information you can check our online documentation at [http://phpdoc.org/docs/](http://phpdoc.org/docs/).
+For more detailed information you can check our online documentation at [http://phpdoc.org/docs/latest/index.html](http://phpdoc.org/docs/latest/index.html).
 
 Known issues
 ------------


### PR DESCRIPTION
Link to http://phpdoc.org/docs/ results in a 404.
