### PR TITLE
Removed type hint.

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xsl.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xsl.php
@@ -188,7 +188,7 @@ class Xsl extends WriterAbstract
      */
     public function setProcessorParameters(
         TransformationObject $transformation,
-        \XSLTProcessor $proc
+        $proc
     ) {
         foreach ($this->xsl_variables as $key => $variable) {
             // XSL does not allow both single and double quotes in a string


### PR DESCRIPTION
Cannot generate docs when using \XSLTCache in favour of \XSLTProcessor.
