### PR TITLE
As mentioned in the DocBlock $message could be an array too.

### DIFF
--- a/src/phpDocumentor/Console/Output/Output.php
+++ b/src/phpDocumentor/Console/Output/Output.php
@@ -69,10 +69,14 @@ class Output extends ConsoleOutput
      */
     public function write($message, $newline = false, $type = 0)
     {
+        $messages = (array) $message;
+
         if ($this->getLogger()) {
-            $this->getLogger()->info($this->getFormatter()->format(strip_tags($message)));
+            foreach ($messages as $message) {
+                $this->getLogger()->info($this->getFormatter()->format(strip_tags($message)));
+            }
         }
 
-        parent::write($message, $newline, $type);
+        parent::write($messages, $newline, $type);
     }
 }


### PR DESCRIPTION
Related to https://scrutinizer-ci.com/g/phpDocumentor/phpDocumentor2/inspections/ca8dcd86-abff-422b-864f-16b0b2becb3d/issues/files/src/phpDocumentor/Console/Output/Output.php?status=existing&selectedSeverities[0]=10&orderField=path&order=asc
