### PR TITLE
Reduced complexity and shorten long method

### DIFF
--- a/src/phpDocumentor/Descriptor/FileDescriptor.php
+++ b/src/phpDocumentor/Descriptor/FileDescriptor.php
@@ -314,9 +314,9 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
     {
         $errors = $this->getErrors();
 
-        $clInTr = $this->getClasses()->merge($this->getInterfaces())->merge($this->getTraits());
+        $types = $this->getClasses()->merge($this->getInterfaces())->merge($this->getTraits());
 
-        $elements = $this->getFunctions()->merge($this->getConstants())->merge($clInTr);
+        $elements = $this->getFunctions()->merge($this->getConstants())->merge($types);
 
         foreach ($elements as $element) {
             if (!$element) {
@@ -326,7 +326,7 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
             $errors = $errors->merge($element->getErrors());
         }
 
-        foreach ($clInTr as $element) {
+        foreach ($types as $element) {
             if (!$element) {
                 continue;
             }


### PR DESCRIPTION
Related to https://scrutinizer-ci.com/g/phpDocumentor/phpDocumentor2/code-structure/develop/operation/phpDocumentor%5CDescriptor%5CFileDescriptor%3A%3AgetAllErrors
