### PR TITLE
Added an additional type check

### DIFF
--- a/src/phpDocumentor/Plugin/Twig/Extension.php
+++ b/src/phpDocumentor/Plugin/Twig/Extension.php
@@ -174,7 +174,13 @@ class Extension extends \Twig_Extension implements ExtensionInterface
 
                     foreach ($value as $path) {
                         $rule     = $routers->match($path);
-                        $url      = $rule ? ltrim($rule->generate($path), '/') : false;
+                        $generatedUrl = $rule->generate($path);
+
+                        if ($generatedUrl === false) {
+                            $url = false;
+                        } else {
+                            $url = $rule ? ltrim($generatedUrl, '/') : false;
+                        }
 
                         if ($url
                             && $url[0] != '/'


### PR DESCRIPTION
It seems like $rule->generate($path) can also be of type false; however, ltrim() does only seem to accept string.
