### PR TITLE
Correct an interface name in Twig plugin.

### DIFF
--- a/src/phpDocumentor/Plugin/Twig/Writer/Twig.php
+++ b/src/phpDocumentor/Plugin/Twig/Writer/Twig.php
@@ -291,7 +291,7 @@ class Twig extends WriterAbstract implements Routable
 
             // to support 'normal' Twig extensions we check the interface to determine what instantiation to do.
             $implementsInterface = in_array(
-                'phpDocumentor\Plugin\Core\Twig\ExtensionInterface',
+                'phpDocumentor\Plugin\Twig\ExtensionInterface',
                 class_implements($extensionValue)
             );
 


### PR DESCRIPTION
Due to the Twig refactoring in his own plugin, the interface name has changed.
