### PR TITLE
Fixes #1196: Files cannot be copied with FileIO

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/FileIo.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/FileIo.php
@@ -11,6 +11,12 @@
 
 namespace phpDocumentor\Plugin\Core\Transformer\Writer;
 
+use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Transformer\Exception;
+use phpDocumentor\Transformer\Transformation;
+use phpDocumentor\Transformer\Writer\WriterAbstract;
+use Symfony\Component\Filesystem\Filesystem;
+
 /**
  * Writer containing file system operations.
  *
@@ -19,11 +25,6 @@ namespace phpDocumentor\Plugin\Core\Transformer\Writer;
  *
  * * copy, copies a file or directory to the destination given in $artifact
  */
-use phpDocumentor\Descriptor\ProjectDescriptor;
-use phpDocumentor\Transformer\Exception;
-use phpDocumentor\Transformer\Transformation;
-use phpDocumentor\Transformer\Writer\WriterAbstract;
-
 class FileIo extends WriterAbstract
 {
     /** @var \phpDocumentor\Transformer\Transformation */
@@ -75,7 +76,11 @@ class FileIo extends WriterAbstract
             throw new Exception('Unable to write to: ' . dirname($transformation->getArtifact()));
         }
 
-        $filesystem = new \Symfony\Component\Filesystem\Filesystem;
-        $filesystem->mirror($path, $transformation->getArtifact());
+        $filesystem = new Filesystem();
+        if (is_file($path)) {
+            $filesystem->copy($path, $transformation->getArtifact());
+        } else {
+            $filesystem->mirror($path, $transformation->getArtifact());
+        }
     }
 }


### PR DESCRIPTION
The FileIO writer was altered to remove duplication and re-use library
code to reduce maintenance but a side-effect was that files could
no longer be copied.

This commit implements the solution as suggested by @marcimat and
re-enables the copying of files.
