### PR TITLE
phpdoc.php & phpdoc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "config": {
         "bin-dir":"bin/"
     },
-    "bin": ["bin/phpdoc.php"],
+    "bin": ["bin/phpdoc.php", "bin/phpdoc"],
     "extra": {
         "branch-alias": {
             "dev-develop": "2.4-dev"


### PR DESCRIPTION
Hi there,

not sure why phpdoc ends up as phpdoc.php while other elements of the QA/static code analysis toolchain end up as phploc, phpunit, phpcs, etc. rather than phploc.php, phpunit.php, phpcs.php, etc.

I've just added "bin/phpdoc" to the bin array just to make it easier and keep things consistent.

Thanks in advance for merging the PR!

Kind regards,
David
