### PR TITLE
Change executable from phpdoc.php to phpdoc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ if (rand(0, 100) !== 42) {
 ```
 5. On the guest machine you can profile phpDocumentor using the docs of phpDocumentor itself. To do that
 ``` bash
-/vagrant/bin/phpdoc.php run -d /vagrant/vendor/phpdocumentor
+/vagrant/bin/phpdoc run -d /vagrant/vendor/phpdocumentor
 ```
 You should see PROFILING ENABLED when you run phpDocumentor.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ contain spaces. This is a requirement imposed by an external library (libxml)_
 
 Afterwards you are able to run phpDocumentor directly from your `vendor` directory:
 
-    $ php vendor/bin/phpdoc.php
+    $ php vendor/bin/phpdoc
 
 ### Using the PHAR
 

--- a/bin/phpdoc
+++ b/bin/phpdoc
@@ -1,0 +1,32 @@
+#!/usr/bin/env php
+<?php
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @copyright 2010-2013 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+// check whether xhprof is loaded
+$profile   = (bool)(getenv('PHPDOC_PROFILE') === 'on');
+$xhguiPath = getenv('XHGUI_PATH');
+if ($profile && $xhguiPath && extension_loaded('xhprof')) {
+    echo 'PROFILING ENABLED' . PHP_EOL;
+    include($xhguiPath . '/external/header.php');
+}
+
+// determine base include folder, if @php_dir@ contains @php_dir then
+// we did not install via PEAR
+$bootstrap_folder = (strpos('@php_dir@', '@php_dir') === 0)
+    ? __DIR__ . '/../src'
+    : '@php_dir@/phpDocumentor/src';
+
+require_once $bootstrap_folder . '/phpDocumentor/Application.php';
+$app = new phpDocumentor\Application();
+$app->run();
+
+// disable E_STRICT reporting on the end to prevent PEAR from throwing Strict warnings.
+error_reporting(error_reporting() & ~E_STRICT);

--- a/bin/phpdoc.bat
+++ b/bin/phpdoc.bat
@@ -5,4 +5,4 @@ GOTO RUN
 :USE_PEAR_PATH
 set PHPBIN=%PHP_PEAR_PHP_BIN%
 :RUN
-"%PHPBIN%" "%PHP_PEAR_BIN_DIR%\phpdoc.php" %*
+"%PHPBIN%" "%PHP_PEAR_BIN_DIR%\phpdoc" %*

--- a/bin/phpdoc.php
+++ b/bin/phpdoc.php
@@ -10,23 +10,5 @@
  * @link      http://phpdoc.org
  */
 
-// check whether xhprof is loaded
-$profile   = (bool)(getenv('PHPDOC_PROFILE') === 'on');
-$xhguiPath = getenv('XHGUI_PATH');
-if ($profile && $xhguiPath && extension_loaded('xhprof')) {
-    echo 'PROFILING ENABLED' . PHP_EOL;
-    include($xhguiPath . '/external/header.php');
-}
-
-// determine base include folder, if @php_dir@ contains @php_dir then
-// we did not install via PEAR
-$bootstrap_folder = (strpos('@php_dir@', '@php_dir') === 0)
-    ? __DIR__ . '/../src'
-    : '@php_dir@/phpDocumentor/src';
-
-require_once $bootstrap_folder . '/phpDocumentor/Application.php';
-$app = new phpDocumentor\Application();
-$app->run();
-
-// disable E_STRICT reporting on the end to prevent PEAR from throwing Strict warnings.
-error_reporting(error_reporting() & ~E_STRICT);
+trigger_error('phpDocumentor2 should be run from the phpdoc file, not phpdoc.php', E_USER_DEPRECATED);
+require_once __DIR__.'/phpdoc';

--- a/bin/utils/package.php
+++ b/bin/utils/package.php
@@ -46,7 +46,7 @@ function createPackager($original_file, $options = array())
                 'vendor/twig/twig/ext/*'
             ),
             'exceptions'        => array(
-                'bin/phpdoc.php'   => 'script',
+                'bin/phpdoc'       => 'script',
                 'bin/phpdoc.bat'   => 'script',
                 'phpdoc.dist.xml'  => 'php',
                 'LICENSE'          => 'php',
@@ -63,7 +63,7 @@ function createPackager($original_file, $options = array())
                 'vendor/phpunit/php-code-coverage/PHP/CodeCoverage/Autoload.php.in' => 'php',
             ),
             'installexceptions' => array(
-                'bin/phpdoc.php' => '/',
+                'bin/phpdoc' => '/',
                 'bin/phpdoc.bat' => '/'
             ),
             'dir_roles'         => array(
@@ -103,14 +103,14 @@ DESC
     $packagexml->setPhpDep('5.3.3');
     $packagexml->setPearinstallerDep('1.4.0');
     $packagexml->addReplacement(
-        'bin/phpdoc.php',
+        'bin/phpdoc',
         'pear-config',
         '/usr/bin/env php',
         'php_bin'
     );
     $packagexml->addGlobalReplacement('pear-config', '@php_bin@', 'php_bin');
     $packagexml->addReplacement(
-        'bin/phpdoc.php',
+        'bin/phpdoc',
         'pear-config',
         '@php_dir@',
         'php_dir'
@@ -137,10 +137,10 @@ DESC
     $packagexml->addRelease();
     $packagexml->setOSInstallCondition('windows');
     $packagexml->addInstallAs('bin/phpdoc.bat', 'phpdoc.bat');
-    $packagexml->addInstallAs('bin/phpdoc.php', 'phpdoc.php');
+    $packagexml->addInstallAs('bin/phpdoc',     'phpdoc');
 
     $packagexml->addRelease();
-    $packagexml->addInstallAs('bin/phpdoc.php', 'phpdoc');
+    $packagexml->addInstallAs('bin/phpdoc', 'phpdoc');
     $packagexml->addIgnoreToRelease('bin/phpdoc.bat');
 
     return $packagexml;

--- a/box.json
+++ b/box.json
@@ -148,7 +148,7 @@
             ]
         }
     ],
-    "main": "bin/phpdoc.php",
+    "main": "bin/phpdoc",
     "output": "phpDocumentor.phar",
     "stub": true
 }

--- a/build.xml
+++ b/build.xml
@@ -46,7 +46,7 @@
 
     <!-- Generate API documentation with phpDocumentor -->
     <target name="build:phpdoc" description="Generates API documentation">
-        <exec executable="${project.basedir}/bin/phpdoc.php" passthru="true">
+        <exec executable="${project.basedir}/bin/phpdoc" passthru="true">
             <arg line="-d ${project.basedir}/src"/>
             <arg line="-t ${project.basedir}/build/api"/>
         </exec>
@@ -149,9 +149,9 @@
     <target name="deploy:publish-demo"
             description="Generate a demo and upload it to the server">
         <delete><fileset dir="/tmp/phpdoc-demo/responsive"><include name="*"/></fileset></delete>
-        <exec command="php bin/phpdoc.php -t /tmp/phpdoc-demo/responsive --template=responsive-twig" dir="${project.basedir}" passthru="true" checkreturn="true"/>
+        <exec command="php bin/phpdoc -t /tmp/phpdoc-demo/responsive --template=responsive-twig" dir="${project.basedir}" passthru="true" checkreturn="true"/>
         <exec command="scp -r /tmp/phpdoc-demo/responsive/* ${server.username}@${server.demo}:${server.demo.path}/Responsive" passthru="true" checkreturn="true"/>
-        <exec command="php bin/phpdoc.php -t /tmp/phpdoc-demo/clean --template=clean" dir="${project.basedir}" passthru="true" checkreturn="true"/>
+        <exec command="php bin/phpdoc -t /tmp/phpdoc-demo/clean --template=clean" dir="${project.basedir}" passthru="true" checkreturn="true"/>
         <exec command="scp -r /tmp/phpdoc-demo/clean/* ${server.username}@${server.demo}:${server.demo.path}/Clean" passthru="true" checkreturn="true"/>
     </target>
 

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "config": {
         "bin-dir":"bin/"
     },
-    "bin": ["bin/phpdoc.php"],
+    "bin": ["bin/phpdoc.php", "bin/phpdoc"],
     "extra": {
         "branch-alias": {
             "dev-develop": "2.5-dev"

--- a/docs/getting-started/your-first-set-of-documentation.rst
+++ b/docs/getting-started/your-first-set-of-documentation.rst
@@ -176,12 +176,12 @@ it would be in the following form::
 
 .. hint::
 
-    When you have installed a version via composer or manually you should invoke the ``phpdoc.php`` script in
+    When you have installed a version via composer or manually you should invoke the ``phpdoc`` script in
     the ``bin`` folder of your phpDocumentor installation.
 
     Under Linux / MacOSX that would be::
 
-        $ [PHPDOC_FOLDER]/bin/phpdoc.php
+        $ [PHPDOC_FOLDER]/bin/phpdoc
 
     And under Windows that would be::
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -24,7 +24,7 @@ class FeatureContext extends BehatContext
     /** @var Process the process used to execute phpDocumentor */
     protected $process;
 
-    /** @var string path to the phpdoc binary file, including phpdoc.php */
+    /** @var string path to the phpdoc binary file, including phpdoc */
     protected $binaryPath;
 
     /**
@@ -47,7 +47,7 @@ class FeatureContext extends BehatContext
      */
     public function beforeScenario()
     {
-        $this->binaryPath = __DIR__ . '/../../bin/phpdoc.php';
+        $this->binaryPath = __DIR__ . '/../../bin/phpdoc';
         $this->process = new Process(null);
         $this->process->setWorkingDirectory($this->getTmpFolder());
     }

--- a/src/phpDocumentor/Plugin/Scrybe/README.md
+++ b/src/phpDocumentor/Plugin/Scrybe/README.md
@@ -10,7 +10,7 @@ Usage
 
 To use this plugin, all you need to do is invoke the correct command::
 
-    $ ./bin/phpdoc.php manual:to-html -t build/docs src
+    $ ./bin/phpdoc manual:to-html -t build/docs src
 
 The above command will generate HTML documentation from the markup files in the `src` folder into the `build/docs`
 folder.


### PR DESCRIPTION
All tools out there make sure that the extension `.php` is not used (i.e. phpunit, phpcs, etc). phpDocumentor is an exception which may cause confusion (we have phpdoc.php).

@tommymgr has initiated a PR in #965 that started to solve this but the PR was never merged/fully resolved. 

This PR continues his work and finalizes all necessary changes.
