### PR TITLE
Fixes #1229: @method tag in a trait causes Exception

### DIFF
--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -74,7 +74,7 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
         /** @var Tag\MethodDescriptor $methodTag */
         foreach ($methodTags as $methodTag) {
             $method = new MethodDescriptor();
-            $method->setName($methodTag->getVariableName());
+            $method->setName($methodTag->getMethodName());
             $method->setDescription($methodTag->getDescription());
 
             $methods->add($method);


### PR DESCRIPTION
In the TraitDescriptor we assembled a MethodDescriptor when an `@method`
tag is used. But instead of reading the Method Name we tried to get a
property name from the `@method` tag definition.

Because this method is not present an exception was generated. This
commit fixes the issue by using the correct method to get the method
name.

Refers to #1229
