### PR TITLE
Better OPcache handling

### DIFF
--- a/src/phpDocumentor/Application.php
+++ b/src/phpDocumentor/Application.php
@@ -102,13 +102,16 @@ class Application extends Cilex
         $this->setTimezone();
         ini_set('memory_limit', -1);
 
-        if (extension_loaded('Zend OPcache')) {
-            ini_set('opcache.save_comments', 1);
-            ini_set('opcache.load_comments', 1);
+        if (extension_loaded('Zend OPcache') && ini_get('opcache.enable') && ini_get('opcache.enable_cli')) {
+            if (ini_get('opcache.save_comments')) {
+                ini_set('opcache.load_comments', 1);
+            } else {
+                ini_set('opcache.enable', 0);
+            }
         }
 
-        if (extension_loaded('Zend Optimizer+')) {
-            ini_set('zend_optimizerplus.save_comments', 1);
+        if (extension_loaded('Zend Optimizer+') && ini_get('zend_optimizerplus.save_comments')) {
+            throw new \RuntimeException('Please disable zend_optimizerplus.save_comments in php.ini.');
         }
     }
 


### PR DESCRIPTION
Tested also under windows and fixes #1037 - for Zend Optimizer+ there is no option left than throw an exception because zend_optimizerplus.save_comments and zend_optimizerplus.enable are PHP_INI_SYSTEM settings.
