### PR TITLE
Fixes #1193: Package tags don't inherit to classes

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
@@ -126,7 +126,10 @@ class FileAssembler extends AssemblerAbstract
             if ($classDescriptor) {
                 $classDescriptor->setLocation($fileDescriptor, $class->getLineNumber());
                 if (count($classDescriptor->getTags()->get('package', new Collection())) == 0) {
-                    $classDescriptor->setPackage($fileDescriptor->getTags()->get('package', new Collection()));
+                    $classDescriptor->getTags()->set(
+                        'package',
+                        $fileDescriptor->getTags()->get('package', new Collection())
+                    );
                 }
 
                 $fileDescriptor->getClasses()->set(


### PR DESCRIPTION
@bskendig reported that a class without package tag did
not fall into the package that was set on the file in which
it was contained.

After research it appeared that although interfaces and traits
correctly inherited the package tag that classes tried to use the
`setPackage` method instead of the tags collection.

The setPackage method is 'reserved' to set the Package descriptor
on a descriptor and by not setting the 'package' element in the
tags collection are other parts of the application not aware that
the class falls within a specific package.

(for the interested reader: the package descriptor is set in a
compiler pass based on the package element in the tags collection)
