### PR TITLE
#1232: Routing crashes on magic property in trait

### DIFF
--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -76,6 +76,7 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
             $method = new MethodDescriptor();
             $method->setName($methodTag->getMethodName());
             $method->setDescription($methodTag->getDescription());
+            $method->setParent($this);
 
             $methods->add($method);
         }
@@ -125,6 +126,7 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
             $property->setName($propertyTag->getVariableName());
             $property->setDescription($propertyTag->getDescription());
             $property->setTypes($propertyTag->getTypes());
+            $property->setParent($this);
 
             $properties->add($property);
         }


### PR DESCRIPTION
Magic methods and properties are dynamically added by the TraitDescriptor. It is
these new Method and PropertyDescriptors that are fed into the routing system to
generate a link to them. Apparently we had missed setting a parent (to which class
a property or method is related) to these magic methods and properties.

By adding a parent during generation we get the desired behaviour again
