### PR TITLE
#1211: Loading a single plugin is not possible

### DIFF
--- a/src/phpDocumentor/Application.php
+++ b/src/phpDocumentor/Application.php
@@ -117,6 +117,11 @@ class Application extends Cilex
     {
         $config = $this['config']->toArray();
 
+        // work around for Zend\Config if only one item is present in the plugins array.
+        if (isset($config['plugins']['plugin']['path'])) {
+            $config['plugins']['plugin'] = array($config['plugins']['plugin']);
+        }
+
         if (!isset($config['plugins']['plugin'][0]['path'])) {
             $this->register(new Plugin\Core\ServiceProvider());
             $this->register(new Plugin\Scrybe\ServiceProvider());


### PR DESCRIPTION
Due to a bug in Zend Config it is not possible to distinguish between
a single value and an array of values when using the same array keys.

There is a workaround for this bug by adding extra checks but this was
not added to the loading of plugins. This commit adds this workaround
so it becomes possible to load a single plugin.
