### PR TITLE
#713: XSL Templates are not found in Windows

### DIFF
--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xsl.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xsl.php
@@ -167,11 +167,11 @@ class Xsl extends WriterAbstract
      */
     protected function getXsltUriFromFilename($filename)
     {
-        // Windows requires an additional / after the scheme.
-        // If not provided then errno 22 (I/O Error: Invalid Argument) will be
-        // raised. Thanks to @FnTmLV for finding the cause.
-        // See issue #284 for more information
-        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
+        // Windows requires an additional / after the scheme. If not provided then errno 22 (I/O Error: Invalid
+        // Argument) will be raised. Thanks to @FnTmLV for finding the cause. See issue #284 for more information.
+        // An exception to the above is when running from a Phar file; in this case the stream is handled as if on
+        // linux; see issue #713 for more information on this exception.
+        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN' && ! \Phar::running()) {
             $filename = '/' . $filename;
         }
 


### PR DESCRIPTION
When running phpDocumentor from Phar the file paths are
interpreted as if on Linux; but there is an exception in
the Xsl writer where, if on windows, the path is generated
slightly different.

These two facts conflicted and resulted in XSL template
files not being found on windows when using Phar. This change
checks if the code is running as a Phar and does not apply
the exception if so.
