### PR TITLE
#1087: Fully support `@see`

### DIFF
--- a/src/phpDocumentor/Compiler/Linker/Linker.php
+++ b/src/phpDocumentor/Compiler/Linker/Linker.php
@@ -13,9 +13,13 @@ namespace phpDocumentor\Compiler\Linker;
 
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\ClassDescriptor;
+use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\FileDescriptor;
+use phpDocumentor\Descriptor\InterfaceDescriptor;
+use phpDocumentor\Descriptor\NamespaceDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\TraitDescriptor;
 
 /**
  * The linker contains all rules to replace FQSENs in the ProjectDescriptor with aliases to objects.
@@ -37,8 +41,7 @@ class Linker implements CompilerPassInterface
 {
     const COMPILER_PRIORITY = 10000;
 
-    /** @var ClassDescriptor|FileDescriptor|null */
-    private $lastContainer = null;
+    const CONTEXT_MARKER = '@context';
 
     /** @var DescriptorAbstract[] */
     protected $elementList = array();
@@ -68,6 +71,19 @@ class Linker implements CompilerPassInterface
     }
 
     /**
+     * Executes the linker.
+     *
+     * @param ProjectDescriptor $project Representation of the Object Graph that can be manipulated.
+     *
+     * @return void
+     */
+    public function execute(ProjectDescriptor $project)
+    {
+        $this->setObjectAliasesList($project->getIndexes()->elements->getAll());
+        $this->substitute($project);
+    }
+
+    /**
      * Returns the list of substitutions for the linker.
      *
      * @return string[]
@@ -90,20 +106,133 @@ class Linker implements CompilerPassInterface
     }
 
     /**
-     * Attempts to find a Descriptor object alias with the FQSEN of the element it represents.
+     * Substitutes the given item or its children's FQCN with an object alias.
      *
-     * @param string $fqsen
+     * This method may do either of the following depending on the item's type
      *
-     * @return DescriptorAbstract|null
+     * String
+     *     If the given item is a string then this method will attempt to find an appropriate Class, Interface or
+     *     TraitDescriptor object and return that. See {@see findAlias()} for more information on the normalization
+     *     of these strings.
+     *
+     * Array or Traversable
+     *     Iterate through each item, pass each key's contents to a new call to substitute and replace the key's
+     *     contents if the contents is not an object (objects automatically update and saves performance).
+     *
+     * Object
+     *     Determines all eligible substitutions using the substitutions property, construct a getter and retrieve
+     *     the field's contents. Pass these contents to a new call of substitute and use a setter to replace the field's
+     *     contents if anything other than null is returned.
+     *
+     * This method will return null if no substitution was possible and all of the above should not update the parent
+     * item when null is passed.
+     *
+     * @param string|object|\Traversable|array $item
+     * @param DescriptorAbstract|null          $container A descriptor that acts as container for all elements
+     *     underneath or null if there is no current container.
+     *
+     * @return null|string|DescriptorAbstract
      */
-    public function findAlias($fqsen)
+    public function substitute($item, $container = null)
     {
-        // if the fqsen is 'self' or '$this' of this element is in a class then we use that container as reference
-        if (($fqsen == 'self' || $fqsen == '$this') && $this->lastContainer instanceof ClassDescriptor) {
-            return $this->lastContainer;
+        $result = null;
+
+        if (is_string($item)) {
+            $result = $this->findAlias($item, $container);
+        } elseif (is_array($item) || $item instanceof \Traversable) {
+            $isModified = false;
+            foreach ($item as $key => $element) {
+                $isModified = true;
+
+                $element = $this->substitute($element, $container);
+                if ($element !== null) {
+                    $item[$key] = $element;
+                }
+            }
+            if ($isModified) {
+                $result = $item;
+            }
+        } elseif (is_object($item)) {
+            $hash = spl_object_hash($item);
+            if (isset($this->processedObjects[$hash])) {
+                // if analyzed; just return
+                return null;
+            }
+
+            $newContainer = ($this->isDescriptorContainer($item)) ? $item : $container;
+
+            $this->processedObjects[$hash] = true;
+
+            $objectClassName = get_class($item);
+            $fieldNames = isset($this->substitutions[$objectClassName])
+                ? $this->substitutions[$objectClassName]
+                : array();
+
+            foreach ($fieldNames as $fieldName) {
+                $fieldValue = $this->findFieldValue($item, $fieldName);
+                $response = $this->substitute($fieldValue, $newContainer);
+
+                // if the returned response is not an object it must be grafted on the calling object
+                if ($response !== null) {
+                    $setter = 'set'.ucfirst($fieldName);
+                    $item->$setter($response);
+                }
+            }
         }
 
-        return isset($this->elementList[$fqsen]) ? $this->elementList[$fqsen] : null;
+        return $result;
+    }
+
+    /**
+     * Attempts to find a Descriptor object alias with the FQSEN of the element it represents.
+     *
+     * This method will try to fetch an element after normalizing the provided FQSEN. The FQSEN may contain references
+     * (bindings) that can only be resolved during linking (such as `self`) or it may contain a context marker
+     * {@see CONTEXT_MARKER}.
+     *
+     * If there is a context marker then this method will see if a child of the given container exists that matches the
+     * element following the marker. If such a child does not exist in the current container then the namespace is
+     * queried if a child exists there that matches.
+     *
+     * For example:
+     *
+     *     Given the Fqsen `@context::myFunction()` and the lastContainer `\My\Class` will this method first check
+     *     to see if `\My\Class::myFunction()` exists; if it doesn't it will then check if `\My\myFunction()` exists.
+     *
+     * If neither element exists then this method assumes it is an undocumented class/trait/interface and change the
+     * given FQSEN by returning the namespaced element name (thus in the example above that would be
+     * `\My\myFunction()`). The calling method {@see substitute()} will then replace the value of the field containing
+     * the context marker with this normalized string.
+     *
+     * @param string $fqsen
+     * @param DescriptorAbstract|null $container
+     *
+     * @return DescriptorAbstract|string|null
+     */
+    public function findAlias($fqsen, $container = null)
+    {
+        $fqsen = $this->replacePseudoTypes($fqsen, $container);
+
+        if ($this->isContextMarkerInFqsen($fqsen) && $container instanceof DescriptorAbstract) {
+            // first exchange `@context::element` for `\My\Class::element` and if it exists, return that
+            $classMember = $this->fetchElementByFqsen($this->getTypeWithClassAsContext($fqsen, $container));
+            if ($classMember) {
+                return $classMember;
+            }
+
+            // otherwise exchange `@context::element` for `\My\element` and if it exists, return that
+            $namespaceContext = $this->getTypeWithNamespaceAsContext($fqsen, $container);
+            $namespaceMember  = $this->fetchElementByFqsen($namespaceContext);
+            if ($namespaceMember) {
+                return $namespaceMember;
+            }
+
+            // Otherwise we assume it is an undocumented class/interface/trait and return `\My\element` so
+            // that the name containing the marker may be replaced by the class reference as string
+            return $namespaceContext;
+        }
+
+        return $this->fetchElementByFqsen($fqsen);
     }
 
     /**
@@ -122,96 +251,105 @@ class Linker implements CompilerPassInterface
     }
 
     /**
-     * Substitutes the given item or its children's FQCN with an object alias.
+     * Returns true if the given Descriptor is a container type.
      *
-     * This method may do either of the following depending on the item's type
+     * @param DescriptorAbstract|mixed $item
      *
-     * String
-     *     If the given item is a string then this method will attempt to find an appropriate Class, Interface or
-     *     TraitDescriptor object and return that.
-     *
-     * Array or Traversable
-     *     Iterate through each item, pass each key's contents to a new call to substitute and replace the key's
-     *     contents if the contents is not an object (objects automatically update and saves performance).
-     *
-     * Object
-     *     Determines all eligible substitutions using the substitutions property, construct a getter and retrieve
-     *     the field's contents. Pass these contents to a new call of substitute and use a setter to replace the field's
-     *     contents if anything other than null is returned.
-     *
-     * This method will return null if no substitution was possible and all of the above should not update the parent
-     * item when null is passed.
-     *
-     * @param string|object|\Traversable|array $item
-     *
-     * @return null|string|DescriptorAbstract
+     * @return bool
      */
-    public function substitute($item)
+    protected function isDescriptorContainer($item)
     {
-        $result = null;
-
-        if (is_string($item)) {
-            $result = $this->findAlias($item);
-        } elseif (is_array($item) || $item instanceof \Traversable) {
-            $isModified = false;
-            foreach ($item as $key => $element) {
-                $isModified = true;
-
-                $element = $this->substitute($element);
-                if ($element !== null) {
-                    $item[$key] = $element;
-                }
-            }
-            if ($isModified) {
-                $result = $item;
-            }
-        } elseif (is_object($item)) {
-            $hash = spl_object_hash($item);
-            if (isset($this->processedObjects[$hash])) {
-                // if analyzed; just return
-                return null;
-            }
-
-            if ($item instanceof FileDescriptor || $item instanceof ClassDescriptor) {
-                $this->lastContainer = $item;
-            }
-
-            $this->processedObjects[$hash] = true;
-
-            $objectClassName = get_class($item);
-            $fieldNames = isset($this->substitutions[$objectClassName])
-                ? $this->substitutions[$objectClassName]
-                : array();
-
-            foreach ($fieldNames as $fieldName) {
-                $fieldValue = $this->findFieldValue($item, $fieldName);
-                $response = $this->substitute($fieldValue);
-
-                // if the returned response is not an object it must be grafted on the calling object
-                if ($response !== null) {
-                    $setter = 'set'.ucfirst($fieldName);
-                    $item->$setter($response);
-                }
-            }
-
-            if ($item instanceof FileDescriptor || $item instanceof ClassDescriptor) {
-                $this->lastContainer = null;
-            }
-        }
-
-        return $result;
+        return $item instanceof FileDescriptor
+            || $item instanceof NamespaceDescriptor
+            || $item instanceof ClassDescriptor
+            || $item instanceof TraitDescriptor
+            || $item instanceof InterfaceDescriptor;
     }
 
     /**
-     * Executes the linker.
+     * Replaces pseudo-types, such as `self`, into a normalized version based on the last container that was
+     * encountered.
      *
-     * @param ProjectDescriptor $project Representation of the Object Graph that can be manipulated.
+     * @param string $fqsen
+     * @param DescriptorAbstract|null $container
      *
-     * @return void
+     * @return string
      */
-    public function execute(ProjectDescriptor $project)
+    protected function replacePseudoTypes($fqsen, $container)
     {
-        $this->setObjectAliasesList($project->getIndexes()->elements->getAll());
-        $this->substitute($project);
+        $pseudoTypes = array('self', '$this');
+        foreach ($pseudoTypes as $pseudoType) {
+            if ((strpos($fqsen, $pseudoType . '::') === 0 || $fqsen === $pseudoType) && $container) {
+                $fqsen = $container->getFullyQualifiedStructuralElementName()
+                    . substr($fqsen, strlen($pseudoType));
+            }
+        }
+
+        return $fqsen;
+    }
+
+    /**
+     * Returns true if the context marker is found in the given FQSEN.
+     *
+     * @param string $fqsen
+     *
+     * @return bool
+     */
+    protected function isContextMarkerInFqsen($fqsen)
+    {
+        return strpos($fqsen, self::CONTEXT_MARKER) !== false;
+    }
+
+    /**
+     * Normalizes the given FQSEN as if the context marker represents a class/interface/trait as parent.
+     *
+     * @param string $fqsen
+     * @param DescriptorAbstract $container
+     *
+     * @return string
+     */
+    protected function getTypeWithClassAsContext($fqsen, DescriptorAbstract $container)
+    {
+        if (!$container instanceof ClassDescriptor
+            && !$container instanceof InterfaceDescriptor
+            && !$container instanceof TraitDescriptor
+        ) {
+            return $fqsen;
+        }
+
+        $containerFqsen = $container->getFullyQualifiedStructuralElementName();
+
+        return str_replace(self::CONTEXT_MARKER . '::', $containerFqsen . '::', $fqsen);
+    }
+
+    /**
+     * Normalizes the given FQSEN as if the context marker represents a class/interface/trait as parent.
+     *
+     * @param string             $fqsen
+     * @param DescriptorAbstract $container
+     *
+     * @return string
+     */
+    protected function getTypeWithNamespaceAsContext($fqsen, DescriptorAbstract $container)
+    {
+        $namespace = $container instanceof NamespaceDescriptor ? $container : $container->getNamespace();
+        $fqnn = $namespace instanceof NamespaceDescriptor
+            ? $namespace->getFullyQualifiedStructuralElementName()
+            : $namespace;
+
+        return str_replace(self::CONTEXT_MARKER . '::', $fqnn . '\\', $fqsen);
+    }
+
+    /**
+     * Attempts to find an element with the given Fqsen in the list of elements for this project and returns null if
+     * it cannot find it.
+     *
+     * @param string $fqsen
+     *
+     * @return DescriptorAbstract|null
+     */
+    protected function fetchElementByFqsen($fqsen)
+    {
+        return isset($this->elementList[$fqsen]) ? $this->elementList[$fqsen] : null;
     }
 }

--- a/src/phpDocumentor/Transformer/Router/StandardRouter.php
+++ b/src/phpDocumentor/Transformer/Router/StandardRouter.php
@@ -55,6 +55,14 @@ class StandardRouter extends RouterAbstract
         $this[] = new Rule(function ($node) { return ($node instanceof FunctionDescriptor); }, $functionGenerator);
         $this[] = new Rule( function ($node) { return ($node instanceof PropertyDescriptor); }, $propertyGenerator);
 
+        // if this is a link to an external page; return that URL
+        $this[] = new Rule(
+            function ($node) {
+                return is_string($node) && (substr($node, 0, 7) == 'http://' || substr($node, 0, 7) == 'https://');
+            },
+            function ($node) { return $node; }
+        );
+
         // do not generate a file for every unknown type
         $this[] = new Rule(function () { return true; }, function () { return false; });
         // @codingStandardsIgnoreEnd

--- a/src/phpDocumentor/Transformer/ServiceProvider.php
+++ b/src/phpDocumentor/Transformer/ServiceProvider.php
@@ -55,7 +55,14 @@ class ServiceProvider extends \stdClass implements ServiceProviderInterface
         // parameters
         $app['linker.substitutions'] = array(
             'phpDocumentor\Descriptor\ProjectDescriptor'      => array('files'),
-            'phpDocumentor\Descriptor\FileDescriptor'         => array('tags', 'classes', 'interfaces', 'traits'),
+            'phpDocumentor\Descriptor\FileDescriptor'         => array(
+                'tags',
+                'classes',
+                'interfaces',
+                'traits',
+                'functions',
+                'constants'
+            ),
             'phpDocumentor\Descriptor\ClassDescriptor'        => array(
                 'tags',
                 'parent',
@@ -77,6 +84,7 @@ class ServiceProvider extends \stdClass implements ServiceProviderInterface
                 'methods',
                 'usedTraits',
             ),
+            'phpDocumentor\Descriptor\FunctionDescriptor'     => array('tags', 'arguments'),
             'phpDocumentor\Descriptor\MethodDescriptor'       => array('tags', 'arguments'),
             'phpDocumentor\Descriptor\ArgumentDescriptor'     => array('types'),
             'phpDocumentor\Descriptor\PropertyDescriptor'     => array('tags', 'types'),


### PR DESCRIPTION
In our documentation we have included that `@see` should be able to cope with
URLs, references to FQSEN's but also that a function/method name without anything
in front of it may either refer to a method in the current class, or a function
in the current namespace.

This type of relation was not supported by phpDocumentor because of the decoupled
nature of its architecture. In order to properly support this I have introduced a
meta type called `@context` that is translated in the linked to either the current
class or the current namespace.

So for example:

```
`@see myFunction()` on a method in a class either refers to a method of said
class if it exists; or if it doesn't it refers to a function in the namespace
of the class.
```
