### PR TITLE
#1253: Transformation crashes on typehint

### DIFF
--- a/src/phpDocumentor/Plugin/Twig/Extension.php
+++ b/src/phpDocumentor/Plugin/Twig/Extension.php
@@ -205,7 +205,11 @@ class Extension extends \Twig_Extension implements ExtensionInterface
             ),
             'sort' => new \Twig_SimpleFilter(
                 'sort_*',
-                function ($direction, Collection $collection) {
+                function ($direction, $collection) {
+                    if (!$collection instanceof Collection) {
+                        return $collection;
+                    }
+
                     $iterator = $collection->getIterator();
                     $iterator->uasort(
                         function ($a, $b) use ($direction) {


### PR DESCRIPTION
The `sort_asc` filter crashes if the provided value is not of type Collection.
Although we do not expect this to be passed should the filter not crash. As such
I have changed the call to just return the current value if it is not a collection
