### PR TITLE
Fixes #1326, fatal error occurs when running Twig in 5.3

### DIFF
--- a/src/phpDocumentor/Plugin/Twig/Extension.php
+++ b/src/phpDocumentor/Plugin/Twig/Extension.php
@@ -168,6 +168,7 @@ class Extension extends \Twig_Extension implements ExtensionInterface
     {
         $parser = \Parsedown::instance();
         $translator = $this->translator;
+        $routeRenderer = $this->routeRenderer;
 
         return array(
             'markdown' => new \Twig_SimpleFilter(
@@ -188,8 +189,8 @@ class Extension extends \Twig_Extension implements ExtensionInterface
             ),
             'route' => new \Twig_SimpleFilter(
                 'route',
-                function ($value, $presentation = 'normal') {
-                    return $this->routeRenderer->render($value, $presentation);
+                function ($value, $presentation = 'normal') use ($routeRenderer) {
+                    return $routeRenderer->render($value, $presentation);
                 }
             ),
             'sort' => new \Twig_SimpleFilter(


### PR DESCRIPTION
In on of the Twig filters was a $this pointer used but in PHP 5.3 $this
is an invalid pointer in a closure. By assigning the routeRenderer
outside the closure and then importing it using a use statement will the
code run again in PHP 5.3
