### PR TITLE
#1330: Fix crash when assembling package tags

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
@@ -13,6 +13,7 @@ namespace phpDocumentor\Descriptor\Builder\Reflector;
 
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\FileDescriptor;
+use phpDocumentor\Descriptor\TagDescriptor;
 use phpDocumentor\Reflection\ClassReflector;
 use phpDocumentor\Reflection\ConstantReflector;
 use phpDocumentor\Reflection\FileReflector;
@@ -36,12 +37,23 @@ class FileAssembler extends AssemblerAbstract
     {
         $fileDescriptor = new FileDescriptor($data->getHash());
 
-        $fileDescriptor->setName(basename($data->getFilename()));
-        $fileDescriptor->setPath($data->getFilename());
-        $fileDescriptor->setSource($data->getContents());
         $fileDescriptor->setPackage(
             $this->extractPackageFromDocBlock($data->getDocBlock()) ?: $data->getDefaultPackageName()
         );
+
+        $packages = new Collection();
+        $package = $this->extractPackageFromDocBlock($data->getDocBlock());
+        if (! $package) {
+            $package = $data->getDefaultPackageName();
+        }
+        $tag = new TagDescriptor('package');
+        $tag->setDescription($package);
+        $packages->add($tag);
+        $fileDescriptor->getTags()->set('package', $packages);
+
+        $fileDescriptor->setName(basename($data->getFilename()));
+        $fileDescriptor->setPath($data->getFilename());
+        $fileDescriptor->setSource($data->getContents());
         $fileDescriptor->setIncludes(new Collection($data->getIncludes()));
         $fileDescriptor->setNamespaceAliases(new Collection($data->getNamespaceAliases()));
 

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
@@ -12,7 +12,9 @@
 namespace phpDocumentor\Descriptor\Builder\Reflector;
 
 use phpDocumentor\Descriptor\ArgumentDescriptor;
+use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\FunctionDescriptor;
+use phpDocumentor\Descriptor\TagDescriptor;
 use phpDocumentor\Reflection\FunctionReflector;
 
 /**
@@ -59,10 +61,18 @@ class FunctionAssembler extends AssemblerAbstract
      */
     protected function mapReflectorPropertiesOntoDescriptor($reflector, $descriptor)
     {
+        $packages = new Collection();
+        $package = $this->extractPackageFromDocBlock($reflector->getDocBlock());
+        if ($package) {
+            $tag = new TagDescriptor('package');
+            $tag->setDescription($package);
+            $packages->add($tag);
+        }
+        $descriptor->getTags()->set('package', $packages);
+
         $descriptor->setFullyQualifiedStructuralElementName($reflector->getName() . '()');
         $descriptor->setName($reflector->getShortName());
         $descriptor->setLine($reflector->getLinenumber());
-        $descriptor->getTags()->set('package', $this->extractPackageFromDocBlock($reflector->getDocBlock()) ? : '');
         $descriptor->setNamespace($this->getFullyQualifiedNamespaceName($reflector));
     }
 


### PR DESCRIPTION
In a recent refactoring we removed all notion of string based tags
but put them in TagDescriptors. Apparently I missed a bit of handling
of the package tags and this caused fatal errors later due to typehints.
