### PR TITLE
Change definition of summary/description break

### DIFF
--- a/docs/references/phpdoc/basic-syntax.rst
+++ b/docs/references/phpdoc/basic-syntax.rst
@@ -42,7 +42,7 @@ This is an example of a DocBlock as it can be encountered:
 Which elements can have a DocBlock
 ----------------------------------
 
-:term:`Structural Elements` can all be preceeded by a DocBlock. The following elements are counted as such:
+:term:`Structural Elements` can all be preceded by a DocBlock. The following elements are counted as such:
 
     * namespace
     * require(_once)
@@ -80,7 +80,7 @@ description will be considered as part of the summary.
 .. NOTE::
 
     A full stop means that the dot (`.`) needs to be succeeded by a new line. This way it is possible to mention
-    abbreviations, such as e.g., a version number or other texts containing dots without stopping the summary.
+    abbreviations as "e.g.", version numbers or other texts containing dots without ending the summary.
 
 Description
 ~~~~~~~~~~~


### PR DESCRIPTION
In this commit I have made the following documentation changes:
- Changed short description to summary
- Changed long description to description
- Changed example mail address
- Changed definition when a summary breaks and becomes a description
  to match PSR-5 and actual usage.

See: https://github.com/phpDocumentor/ReflectionDocBlock/issues/34#issuecomment-49510977
