### PR TITLE
Unittests for Core\descriptor\Validator\Constraint\Classes

### DIFF
--- a/tests/unit/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Classes/HasPackageWithSubpackageTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Classes/HasPackageWithSubpackageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @author    Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright 2010-2012 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes;
+
+
+/**
+ * Test class for \phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes\HasPackageWithSubpackage.
+ *
+ * @covers phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes\HasPackageWithSubpackage
+ */
+class HasPackageWithSubpackageTest extends \PHPUnit_Framework_TestCase
+{
+	public function testGetTargetsClassConstraint()
+	{
+		$constraint = new HasPackageWithSubpackage();
+		
+		$this->assertEquals(array(HasPackageWithSubpackage::CLASS_CONSTRAINT), $constraint->getTargets());
+	}
+}

--- a/tests/unit/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Classes/HasSinglePackageTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Classes/HasSinglePackageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @author    Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright 2010-2012 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes;
+
+
+/**
+ * Test class for \phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes\HasSinglePackage.
+ *
+ * @covers phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes\HasSinglePackage
+ */
+class HasSinglePackageTest extends \PHPUnit_Framework_TestCase
+{
+	public function testGetTargetsClassConstraint()
+	{
+		$constraint = new HasSinglePackage();
+		
+		$this->assertEquals(array(HasSinglePackage::CLASS_CONSTRAINT), $constraint->getTargets());
+	}
+}

--- a/tests/unit/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Classes/HasSinglePackageValidatorTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Classes/HasSinglePackageValidatorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @author    Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright 2010-2012 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes;
+
+use Mockery\MockInterface;
+use Mockery as m;
+use phpDocumentor\Descriptor\FileDescriptor;
+use phpDocumentor\Descriptor\Collection;
+use Symfony\Component\Validator\ExecutionContextInterface;
+
+/**
+ * Test class for \phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes\HasSinglePackageValidator.
+ *
+ * @covers phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes\HasSinglePackageValidator
+ */
+class HasSinglePackageValidatorTest extends \PHPUnit_Framework_TestCase
+{
+	/**
+	 * @var HasSinglePackageValidator
+	 */
+	protected $validator;
+	
+	/**
+	 * 
+	 * @var HasSinglePackage
+	 */
+	protected $constraint;
+	
+	/**
+	 * @var MockInterface | FileDescriptor
+	 */
+	protected $fileDescriptor;
+	
+	/**
+	 * 
+	 * @var MockInterface | ExecutionContextInterface
+	 */
+	protected $context;
+	
+	public function setUp()
+	{
+		
+		$this->constraint = new HasSinglePackage();
+		$this->fileDescriptor = m::mock('phpDocumentor\Descriptor\FileDescriptor');
+		$this->context = m::mock('Symfony\Component\Validator\ExecutionContextInterface');
+		
+		$this->validator = new HasSinglePackageValidator();
+		$this->validator->initialize($this->context);
+	}
+	
+	
+	/**
+	 * @expectedException Symfony\Component\Validator\Exception\ConstraintDefinitionException
+	 */
+	public function testValidateWithBadInput()
+	{
+	
+		$this->validator->validate(new \stdClass(), $this->constraint);
+		
+	}
+	
+	public function testValidateHappyPath()
+	{
+		$packageCollection = new Collection(array('x', 'y'));
+		$tagCollection = new Collection(array('package' => $packageCollection));
+		
+		$this->fileDescriptor->shouldReceive('getTags')->andReturn($tagCollection)->once();
+		
+		$this->context->shouldReceive('addViolationAt')->once()->with('package', $this->constraint->message);
+		
+		$this->validator->validate($this->fileDescriptor, $this->constraint);
+
+		$this->assertTrue(true);
+	}
+	
+	public function testValidateSinglePackage()
+	{
+		$packageCollection = new Collection(array('x'));
+		$tagCollection = new Collection(array('package' => $packageCollection));
+		
+		$this->fileDescriptor->shouldReceive('getTags')->andReturn($tagCollection)->once();
+	
+		$this->context->shouldReceive('addViolationAt')->never();
+
+		$this->validator->validate($this->fileDescriptor, $this->constraint);
+		$this->assertTrue(true);
+	}
+}

--- a/tests/unit/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Classes/HasSingleSubpackageTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Descriptor/Validator/Constraints/Classes/HasSingleSubpackageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @author    Mike van Riel <mike.vanriel@naenius.com>
+ * @copyright 2010-2012 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes;
+
+
+/**
+ * Test class for \phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes\HasSingleSubpackage.
+ *
+ * @covers phpDocumentor\Plugin\Core\Descriptor\Validator\Constraints\Classes\HasSingleSubpackage
+ */
+class HasSingleSubpackageTest extends \PHPUnit_Framework_TestCase
+{
+	public function testGetTargetsClassConstraint()
+	{
+		$constraint = new HasSingleSubpackage();
+		
+		$this->assertEquals(array(HasSingleSubpackage::CLASS_CONSTRAINT), $constraint->getTargets());
+	}
+}


### PR DESCRIPTION
Written during amsterdamPHP TestFest
I've written 4 Unit Tests
I left out HasSinglePackageWithSubpackageValidator and
HasSingleSubpackageValidator
