### PR TITLE
Avoiding assertTrue(true)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<phpunit bootstrap="tests/common/bootstrap.php" colors="true" strict="true">
+<phpunit bootstrap="tests/common/bootstrap.php" colors="true" strict="true" beStrictAboutTestsThatDoNotTestAnything="false">
     <testsuites>
         <testsuite name="phpDocumentor">
             <directory>./tests/unit/</directory>

--- a/src/phpDocumentor/Plugin/LegacyNamespaceConverter/Tests/LegacyNamespaceFilterTest.php
+++ b/src/phpDocumentor/Plugin/LegacyNamespaceConverter/Tests/LegacyNamespaceFilterTest.php
@@ -42,8 +42,6 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\LegacyNamespace')->once();
 
         $this->filter->filter($descriptor);
-
-        $this->assertTrue(true);
     }
 
     /**
@@ -59,8 +57,6 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\LegacyNamespace\Sub')->once();
 
         $this->filter->filter($descriptor);
-
-        $this->assertTrue(true);
     }
 
     /**
@@ -76,8 +72,6 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\\NewNamespace\\LegacyNamespace')->once();
 
         $this->filter->filter($descriptor);
-
-        $this->assertTrue(true);
     }
 
     /**
@@ -93,8 +87,6 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\\NewNamespace')->once();
 
         $this->filter->filter($descriptor);
-
-        $this->assertTrue(true);
     }
 
     /**
@@ -110,8 +102,6 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\\')->once();
 
         $this->filter->filter($descriptor);
-
-        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Command/CommandTest.php
+++ b/tests/unit/phpDocumentor/Command/CommandTest.php
@@ -44,9 +44,6 @@ class CommandTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->setHelperSet($helperSet);
-
-        // Assert; Mockery does all assertions. For PHPUnit we must have an assertion
-        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
@@ -97,9 +97,6 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         // execute test.
         $linker->substitute($object);
-
-        // mark test as successful due to asserts in Mockery
-        $this->assertTrue(true);
     }
 
     /**
@@ -149,9 +146,6 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         // execute test.
         $linker->substitute($object);
-
-        // mark test as successful due to asserts in Mockery
-        $this->assertTrue(true);
     }
 
     /**
@@ -185,9 +179,6 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         // execute test.
         $linker->substitute($object);
-
-        // mark test as successful due to asserts in Mockery
-        $this->assertTrue(true);
     }
 
     /**
@@ -221,9 +212,6 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         // execute test.
         $linker->substitute($object);
-
-        // mark test as successful due to asserts in Mockery
-        $this->assertTrue(true);
     }
 
     /**
@@ -264,9 +252,6 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         //findFieldvalue() should NOT be called
         $result = $mock->substitute($item);
-
-        // mark test as successful due to asserts in Mockery
-        $this->assertTrue(true);
     }
 
     /**
@@ -295,9 +280,6 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
         $mock->shouldDeferMissing();
         $mock->shouldReceive('substitute')->with($descriptor);
         $mock->execute($descriptor);
-
-        // mark test as successful due to asserts in Mockery
-        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
@@ -52,8 +52,6 @@ class DebugTest extends \PHPUnit_Framework_TestCase
 
         $fixture = new Debug($loggerMock, $analyzerMock);
         $fixture->execute($projectDescriptorMock);
-
-        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
@@ -436,8 +436,6 @@ class ClassDescriptorTest extends \PHPUnit_Framework_TestCase
         $methodDescriptor->shouldReceive('setPackage')->with($package);
 
         $mock->setPackage($package);
-
-        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Parser/FileTest.php
+++ b/tests/unit/phpDocumentor/Parser/FileTest.php
@@ -67,8 +67,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
-
-        $this->assertTrue(true);
     }
 
     /**
@@ -87,8 +85,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
-
-        $this->assertTrue(true);
     }
 
     /**
@@ -108,8 +104,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
-
-        $this->assertTrue(true);
     }
 
     /**
@@ -129,8 +123,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
-
-        $this->assertTrue(true);
     }
 
     /**
@@ -150,8 +142,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
-
-        $this->assertTrue(true);
     }
 
     /**
@@ -172,8 +162,6 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
-
-        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/DocBlockConverterTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/DocBlockConverterTest.php
@@ -104,9 +104,6 @@ class DocBlockConverterTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->convert($parent, $descriptor);
-
-        // Assert
-        $this->assertTrue(true);
     }
 
     /**


### PR DESCRIPTION
Turned the "useless test" flag off since we are using mockery which led us to
use a lot of $this->assertTrue(true) to avoid phpunit strict errors. Dropped
the current ones spread out in the tests and made the change to the dist file.
