### PR TITLE
Revert "Avoiding assertTrue(true)"

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<phpunit bootstrap="tests/common/bootstrap.php" colors="true" strict="true" beStrictAboutTestsThatDoNotTestAnything="false">
+<phpunit bootstrap="tests/common/bootstrap.php" colors="true" strict="true">
     <testsuites>
         <testsuite name="phpDocumentor">
             <directory>./tests/unit/</directory>

--- a/src/phpDocumentor/Plugin/LegacyNamespaceConverter/Tests/LegacyNamespaceFilterTest.php
+++ b/src/phpDocumentor/Plugin/LegacyNamespaceConverter/Tests/LegacyNamespaceFilterTest.php
@@ -42,6 +42,8 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\LegacyNamespace')->once();
 
         $this->filter->filter($descriptor);
+
+        $this->assertTrue(true);
     }
 
     /**
@@ -57,6 +59,8 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\LegacyNamespace\Sub')->once();
 
         $this->filter->filter($descriptor);
+
+        $this->assertTrue(true);
     }
 
     /**
@@ -72,6 +76,8 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\\NewNamespace\\LegacyNamespace')->once();
 
         $this->filter->filter($descriptor);
+
+        $this->assertTrue(true);
     }
 
     /**
@@ -87,6 +93,8 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\\NewNamespace')->once();
 
         $this->filter->filter($descriptor);
+
+        $this->assertTrue(true);
     }
 
     /**
@@ -102,6 +110,8 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
         $descriptor->shouldReceive('setNamespace')->with('\\')->once();
 
         $this->filter->filter($descriptor);
+
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Command/CommandTest.php
+++ b/tests/unit/phpDocumentor/Command/CommandTest.php
@@ -44,6 +44,9 @@ class CommandTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->setHelperSet($helperSet);
+
+        // Assert; Mockery does all assertions. For PHPUnit we must have an assertion
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
@@ -97,6 +97,9 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         // execute test.
         $linker->substitute($object);
+
+        // mark test as successful due to asserts in Mockery
+        $this->assertTrue(true);
     }
 
     /**
@@ -146,6 +149,9 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         // execute test.
         $linker->substitute($object);
+
+        // mark test as successful due to asserts in Mockery
+        $this->assertTrue(true);
     }
 
     /**
@@ -179,6 +185,9 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         // execute test.
         $linker->substitute($object);
+
+        // mark test as successful due to asserts in Mockery
+        $this->assertTrue(true);
     }
 
     /**
@@ -212,6 +221,9 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         // execute test.
         $linker->substitute($object);
+
+        // mark test as successful due to asserts in Mockery
+        $this->assertTrue(true);
     }
 
     /**
@@ -252,6 +264,9 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
 
         //findFieldvalue() should NOT be called
         $result = $mock->substitute($item);
+
+        // mark test as successful due to asserts in Mockery
+        $this->assertTrue(true);
     }
 
     /**
@@ -280,6 +295,9 @@ class LinkerTest extends \PHPUnit_Framework_TestCase
         $mock->shouldDeferMissing();
         $mock->shouldReceive('substitute')->with($descriptor);
         $mock->execute($descriptor);
+
+        // mark test as successful due to asserts in Mockery
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
@@ -52,6 +52,8 @@ class DebugTest extends \PHPUnit_Framework_TestCase
 
         $fixture = new Debug($loggerMock, $analyzerMock);
         $fixture->execute($projectDescriptorMock);
+
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
@@ -436,6 +436,8 @@ class ClassDescriptorTest extends \PHPUnit_Framework_TestCase
         $methodDescriptor->shouldReceive('setPackage')->with($package);
 
         $mock->setPackage($package);
+
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Parser/FileTest.php
+++ b/tests/unit/phpDocumentor/Parser/FileTest.php
@@ -67,6 +67,8 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
+
+        $this->assertTrue(true);
     }
 
     /**
@@ -85,6 +87,8 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
+
+        $this->assertTrue(true);
     }
 
     /**
@@ -104,6 +108,8 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
+
+        $this->assertTrue(true);
     }
 
     /**
@@ -123,6 +129,8 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
+
+        $this->assertTrue(true);
     }
 
     /**
@@ -142,6 +150,8 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
+
+        $this->assertTrue(true);
     }
 
     /**
@@ -162,6 +172,8 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->parse(__FILE__, $builder);
+
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/DocBlockConverterTest.php
+++ b/tests/unit/phpDocumentor/Plugin/Core/Transformer/Writer/Xml/DocBlockConverterTest.php
@@ -104,6 +104,9 @@ class DocBlockConverterTest extends \PHPUnit_Framework_TestCase
 
         // Act
         $this->fixture->convert($parent, $descriptor);
+
+        // Assert
+        $this->assertTrue(true);
     }
 
     /**


### PR DESCRIPTION
Reverts phpDocumentor/phpDocumentor2#1363

I have to revert these changes because the beStrictAboutTestsThatDoNotTestAnything setting was introduced in PHPUnit 4 and we still use 3.7.

Since I do not know what will break exactly I cannot upgrade to PHPUnit 4 at the moment
