### PR TITLE
Update phpdoc.dist.xml loading issue

### DIFF
--- a/src/phpDocumentor/Configuration/Loader.php
+++ b/src/phpDocumentor/Configuration/Loader.php
@@ -112,7 +112,7 @@ class Loader
         $config = $this->serializer->deserialize(file_get_contents($templatePath), $class, 'xml');
         $customUserConfigPath = $customUserConfigPath ? : $defaultUserConfigPath;
 
-        if ($customUserConfigPath !== null) {
+        if ($customUserConfigPath !== null && is_readable($customUserConfigPath)) {
             $userConfigFile = $this->serializer->deserialize(file_get_contents($customUserConfigPath), $class, 'xml');
 
             $config = $this->merger->run($config, $userConfigFile);


### PR DESCRIPTION
When ran phpdoc without parameters it can't load phpdoc.dist.xml directly and show a "No parsable files were found" Exception.
Change userConfig file path search to take dist even if the user do not give a specific parameter.
