### PR TITLE
Namespace prefix parameter for namespace converter plugin

### DIFF
--- a/src/phpDocumentor/Plugin/LegacyNamespaceConverter/LegacyNamespaceFilter.php
+++ b/src/phpDocumentor/Plugin/LegacyNamespaceConverter/LegacyNamespaceFilter.php
@@ -29,6 +29,9 @@ class LegacyNamespaceFilter extends AbstractFilter
     /** @var ProjectDescriptorBuilder $builder */
     protected $builder;
 
+    /** @var string */
+    private $namespacePrefix='';
+
     /**
      * Initializes this filter with an instance of the builder to retrieve the latest ProjectDescriptor from.
      *
@@ -52,7 +55,8 @@ class LegacyNamespaceFilter extends AbstractFilter
     public function filter($value)
     {
         if ($value) {
-            $value->setNamespace($this->namespaceFromLegacyNamespace($value->getNamespace(), $value->getName()));
+            $namespace = $value->getNamespace()=='' ? '\\' . $this->namespacePrefix : $value->getNamespace();
+            $value->setNamespace($this->namespaceFromLegacyNamespace($namespace, $value->getName()));
             $value->setName($this->classNameFromLegacyNamespace($value->getName()));
         }
 
@@ -95,5 +99,15 @@ class LegacyNamespaceFilter extends AbstractFilter
         }
 
         return $className;
+    }
+
+    /**
+     * Set a prefix for all elements without an namespace
+     *
+     * @param string $prefix
+     */
+    public function setNamespacePrefix($prefix)
+    {
+        $this->namespacePrefix = $prefix;
     }
 }

--- a/src/phpDocumentor/Plugin/LegacyNamespaceConverter/README.md
+++ b/src/phpDocumentor/Plugin/LegacyNamespaceConverter/README.md
@@ -2,8 +2,9 @@ Legacy Namespace Converter Plugin
 =================================
 
 This plugin will convert legacy/[PEAR-style namespaces](http://pear.php.net/manual/en/standards.naming.php) to real namespaces for phpDocumentor.
+For example the class name `My_Special_ClassName` will be transformed into the class `ClassName` with namespace `My\Special`.
 
-Example configuration file::
+Example configuration file:
 
     <?xml version="1.0" encoding="UTF-8" ?>
     <phpdocumentor>
@@ -12,4 +13,11 @@ Example configuration file::
       </plugins>
     </phpdocumentor>
 
+If your legacy class names did not contain a vendor prefix and you are mixing with [PSR-4-style](http://www.php-fig.org/psr/psr-4/) classes, you might want to add a vendor prefix to your legacy classes by configuring this plugin.  
+You can archive this by configuring the parameter *NamespacePrefix*:
 
+        ..
+        <plugin path="LegacyNamespaceConverter">
+          <parameter key="NamespacePrefix">VendorName</parameter>
+        </plugin>
+        ..

--- a/src/phpDocumentor/Plugin/LegacyNamespaceConverter/ServiceProvider.php
+++ b/src/phpDocumentor/Plugin/LegacyNamespaceConverter/ServiceProvider.php
@@ -13,6 +13,8 @@ namespace phpDocumentor\Plugin\LegacyNamespaceConverter;
 
 use Cilex\Application;
 use Cilex\ServiceProviderInterface;
+use phpDocumentor\Configuration;
+use phpDocumentor\Plugin\Plugin;
 use phpDocumentor\Descriptor\Filter\Filter;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 
@@ -31,6 +33,21 @@ use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
  */
 class ServiceProvider implements ServiceProviderInterface
 {
+
+    /** @var Plugin */
+    private $plugin;
+
+    /**
+     * Construct plugin with a the relevant configuration
+     *
+     * @param Plugin $plugin
+     **/
+    public function __construct(Plugin $plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+
     /**
      * Registers services on the given app.
      *
@@ -52,6 +69,13 @@ class ServiceProvider implements ServiceProviderInterface
     private function addNamespaceFilter(ProjectDescriptorBuilder $builder, Filter $filterManager)
     {
         $filter = new LegacyNamespaceFilter($builder);
+
+        // parse parameters
+        foreach ($this->plugin->getParameters() as $param) {
+            if ($param->getKey() == 'NamespacePrefix') {
+                $filter->setNamespacePrefix($param->getValue());
+            }
+        }
 
         $filterManager->attach('phpDocumentor\Descriptor\ConstantDescriptor', $filter);
         $filterManager->attach('phpDocumentor\Descriptor\FunctionDescriptor', $filter);

--- a/src/phpDocumentor/Plugin/LegacyNamespaceConverter/Tests/LegacyNamespaceFilterTest.php
+++ b/src/phpDocumentor/Plugin/LegacyNamespaceConverter/Tests/LegacyNamespaceFilterTest.php
@@ -115,6 +115,44 @@ class LegacyNamespaceFilterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers phpDocumentor\Plugin\LegacyNamespaceConverter\LegacyNamespaceFilter::filter
+     */
+    public function testPrefixedNamespace()
+    {
+        $this->filter->setNamespacePrefix('Vendor');
+
+        $descriptor = $this->createDescriptorMock();
+        $descriptor->shouldReceive('getName')->andReturn('ClassName');
+        $descriptor->shouldReceive('getNamespace')->andReturn('');
+
+        $descriptor->shouldReceive('setName')->with('ClassName')->once();
+        $descriptor->shouldReceive('setNamespace')->with('\\Vendor')->once();
+
+        $this->filter->filter($descriptor);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @covers phpDocumentor\Plugin\LegacyNamespaceConverter\LegacyNamespaceFilter::filter
+     */
+    public function testPrefixedNamespaceWithNamespacedClassWillNotBeModified()
+    {
+        $this->filter->setNamespacePrefix('Vendor');
+
+        $descriptor = $this->createDescriptorMock();
+        $descriptor->shouldReceive('getName')->andReturn('ClassName');
+        $descriptor->shouldReceive('getNamespace')->andReturn('\\');
+
+        $descriptor->shouldReceive('setName')->with('ClassName')->once();
+        $descriptor->shouldReceive('setNamespace')->with('\\')->once();
+
+        $this->filter->filter($descriptor);
+
+        $this->assertTrue(true);
+    }
+
+    /**
      * Creates a mocked Descriptor.
      *
      * @return m\MockInterface|DescriptorAbstract


### PR DESCRIPTION
This PR adds the parameter _NamespacePrefix_ to the LegacyNamespaceConverter Plugin.
It is useful to have this option in scenarios where legacy namespaces without vendor prefixes co-exist together with PSR-4-style namespaces (with vendor prefixes).

e.g. `Fancy_LegacyClass` can be prefixed with `My` and will end up in the same namespace together with `My\Fancy\NewClass`

Feel free to review and comment. Thanks!
