### PR TITLE
lock mockery on version because of a bc break

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "require-dev": {
         "behat/behat":        "~2.4",
         "phpunit/phpunit":    "~3.7",
-        "mockery/mockery":    "0.9.*@dev",
+        "mockery/mockery":    "dev-master#1b3b265a904cab6f28b72684d7d62abade836e25",
         "mikey179/vfsStream": "~1.2",
         "squizlabs/php_codesniffer": "~1.4",
         "symfony/expression-language": "~2.4"


### PR DESCRIPTION
Like @mvriel and I discovered in this run https://travis-ci.org/phpDocumentor/phpDocumentor2/jobs/32365154 something must be broken when a composer update was ran. 

Some research resulted in a mockery version which let the test pass. Our conclusion is that something must be broken in mockery. 
