### PR TITLE
Refactored Transformer and TransformCommand

### DIFF
--- a/src/phpDocumentor/Event/EventAbstract.php
+++ b/src/phpDocumentor/Event/EventAbstract.php
@@ -48,7 +48,7 @@ abstract class EventAbstract extends Event
      *
      * @param object $subject
      *
-     * @return EventAbstract
+     * @return static
      */
     public static function createInstance($subject)
     {

--- a/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
@@ -4,52 +4,45 @@
  *
  * PHP Version 5.3
  *
- * @author    Mike van Riel <mike.vanriel@naenius.com>
- * @copyright 2010-2012 Mike van Riel / Naenius (http://www.naenius.com)
+ * @copyright 2010-2014 Mike van Riel / Naenius (http://www.naenius.com)
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
 
 namespace phpDocumentor\Transformer\Event;
 
+use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Event\EventAbstract;
 
 /**
  * Event that happens prior to the execution of all transformations.
- *
- * @author    Mike van Riel <mike.vanriel@naenius.com>
- * @copyright 2010-2012 Mike van Riel / Naenius (http://www.naenius.com)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT
  */
 class PreTransformEvent extends EventAbstract
 {
-    /** @var \DOMDocument */
-    protected $source;
+    /** @var ProjectDescriptor */
+    private $project;
 
     /**
-     * Sets the source DOMDocument into this event.
+     * Returns the descriptor describing the project.
      *
-     * This DOMDocument contains the entire Abstract Syntax Tree and may be used
-     * to extract information from or alter information in.
-     *
-     * @param \DOMDocument $source
-     *
-     * @return PreTransformEvent for a fluent interface
+     * @return ProjectDescriptor
      */
-    public function setSource($source)
+    public function getProject()
     {
-        $this->source = $source;
-
-        return $this;
+        return $this->project;
     }
 
     /**
-     * Returns the Abstract Syntax Tree.
+     * Returns the descriptor describing the project.
      *
-     * @return \DOMDocument
+     * @param ProjectDescriptor $project
+     *
+     * @return $this
      */
-    public function getSource()
+    public function setProject($project)
     {
-        return $this->source;
+        $this->project = $project;
+
+        return $this;
     }
 }

--- a/src/phpDocumentor/Transformer/Event/PreTransformationEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PreTransformationEvent.php
@@ -21,6 +21,8 @@ class PreTransformationEvent extends EventAbstract
     /** @var \DOMDocument remembers the XML-based AST so that it can be used from the listener */
     protected $source;
 
+    protected $transformation;
+
     /**
      * Sets the Abstract Syntax Tree as DOMDocument.
      *
@@ -43,5 +45,23 @@ class PreTransformationEvent extends EventAbstract
     public function getSource()
     {
         return $this->source;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTransformation()
+    {
+        return $this->transformation;
+    }
+
+    /**
+     * @param mixed $transformation
+     */
+    public function setTransformation($transformation)
+    {
+        $this->transformation = $transformation;
+
+        return $this;
     }
 }

--- a/src/phpDocumentor/Transformer/Event/WriterInitializationEvent.php
+++ b/src/phpDocumentor/Transformer/Event/WriterInitializationEvent.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @copyright 2010-2014 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Transformer\Event;
+
+use phpDocumentor\Event\EventAbstract;
+use phpDocumentor\Transformer\Writer\WriterAbstract;
+
+class WriterInitializationEvent extends EventAbstract
+{
+    /** @var WriterAbstract */
+    protected $writer;
+
+    /**
+     * Sets the currently parsed writer in this event.
+     *
+     * @param WriterAbstract $writer
+     *
+     * @return $this
+     */
+    public function setWriter($writer)
+    {
+        $this->writer = $writer;
+
+        return $this;
+    }
+
+    /**
+     * Returns the event that is currently being parsed.
+     *
+     * @return WriterAbstract
+     */
+    public function getWriter()
+    {
+        return $this->writer;
+    }
+}

--- a/src/phpDocumentor/Transformer/Transformer.php
+++ b/src/phpDocumentor/Transformer/Transformer.php
@@ -11,6 +11,9 @@
 
 namespace phpDocumentor\Transformer;
 
+use phpDocumentor\Transformer\Event\WriterInitializationEvent;
+use phpDocumentor\Transformer\Writer\Initializable;
+use phpDocumentor\Transformer\Writer\WriterAbstract;
 use Psr\Log\LogLevel;
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\ProjectDescriptor;
@@ -27,6 +30,13 @@ use phpDocumentor\Transformer\Event\PreTransformationEvent;
  */
 class Transformer implements CompilerPassInterface
 {
+    const EVENT_PRE_TRANSFORMATION = 'transformer.transformation.pre';
+    const EVENT_POST_TRANSFORMATION = 'transformer.transformation.post';
+    const EVENT_PRE_INITIALIZATION = 'transformer.writer.initialization.pre';
+    const EVENT_POST_INITIALIZATION = 'transformer.writer.initialization.post';
+    const EVENT_PRE_TRANSFORM = 'transformer.transform.pre';
+    const EVENT_POST_TRANSFORM = 'transformer.transform.post';
+
     /** @var integer represents the priority in the Compiler queue. */
     const COMPILER_PRIORITY = 5000;
 
@@ -36,11 +46,8 @@ class Transformer implements CompilerPassInterface
     /** @var Template\Collection $templates */
     protected $templates;
 
-    /** @var Writer\Collection $writers */
+    /** @var Writer\Collection|WriterAbstract[] $writers */
     protected $writers;
-
-    /** @var Behaviour\Collection|null $behaviours */
-    protected $behaviours = null;
 
     /** @var Transformation[] $transformations */
     protected $transformations = array();
@@ -66,28 +73,6 @@ class Transformer implements CompilerPassInterface
     }
 
     /**
-     * Sets the collection of behaviours that are applied before the actual transformation process.
-     *
-     * @param Behaviour\Collection $behaviours
-     *
-     * @return void
-     */
-    public function setBehaviours(Behaviour\Collection $behaviours)
-    {
-        $this->behaviours = $behaviours;
-    }
-
-    /**
-     * Retrieves the collection of behaviours that should occur before the transformation process.
-     *
-     * @return Behaviour\Collection|null
-     */
-    public function getBehaviours()
-    {
-        return $this->behaviours;
-    }
-
-    /**
      * Sets the target location where to output the artifacts.
      *
      * @param string $target The target location where to output the artifacts.
@@ -105,17 +90,13 @@ class Transformer implements CompilerPassInterface
                 $path = realpath($target);
             } else {
                 throw new \InvalidArgumentException(
-                    'Target directory ('
-                    . $target .
-                    ') does not exist and could not be created'
+                    'Target directory (' . $target . ') does not exist and could not be created'
                 );
             }
         }
 
         if (!is_dir($path) || !is_writable($path)) {
-            throw new \InvalidArgumentException(
-                'Given target (' . $target . ') is not a writable directory'
-            );
+            throw new \InvalidArgumentException('Given target (' . $target . ') is not a writable directory');
         }
 
         $this->target = $path;
@@ -150,39 +131,16 @@ class Transformer implements CompilerPassInterface
      */
     public function execute(ProjectDescriptor $project)
     {
-        Dispatcher::getInstance()->dispatch('transformer.transform.pre', PreTransformEvent::createInstance($this));
-
-        if ($this->getBehaviours() instanceof Behaviour\Collection) {
-            $this->log(sprintf('Applying %d behaviours', count($this->getBehaviours())));
-            $this->getBehaviours()->process($project);
-        }
+        Dispatcher::getInstance()->dispatch(
+            self::EVENT_PRE_TRANSFORM,
+            PreTransformEvent::createInstance($this)->setProject($project)
+        );
 
         $transformations = $this->getTemplates()->getTransformations();
-        $this->log(sprintf('Applying %d transformations', count($transformations)));
-        foreach ($transformations as $transformation) {
-            $this->log(
-                '  Writer ' . $transformation->getWriter()
-                . ($transformation->getQuery() ? (' using query "' . $transformation->getQuery() . '"') : '')
-                . ' on '.$transformation->getArtifact()
-            );
+        $this->initializeWriters($project, $transformations);
+        $this->transformProject($project, $transformations);
 
-            $transformation->setTransformer($this);
-
-            /** @var Writer\WriterAbstract $writer  */
-            $writer = $this->writers[$transformation->getWriter()];
-
-            Dispatcher::getInstance()->dispatch(
-                'transformer.transformation.pre',
-                PreTransformationEvent::createInstance($this)
-            );
-            $writer->transform($project, $transformation);
-            Dispatcher::getInstance()->dispatch(
-                'transformer.transformation.post',
-                PostTransformationEvent::createInstance($this)
-            );
-        }
-
-        Dispatcher::getInstance()->dispatch('transformer.transform.post', PostTransformEvent::createInstance($this));
+        Dispatcher::getInstance()->dispatch(self::EVENT_POST_TRANSFORM, PostTransformEvent::createInstance($this));
 
         $this->log('Finished transformation process');
     }
@@ -243,5 +201,117 @@ class Transformer implements CompilerPassInterface
             DebugEvent::createInstance($this)
                 ->setMessage($message)
         );
+    }
+
+    /**
+     * Initializes all writers that are used during this transformation.
+     *
+     * @param ProjectDescriptor $project
+     * @param Transformation[]  $transformations
+     *
+     * @return void
+     */
+    private function initializeWriters(ProjectDescriptor $project, $transformations)
+    {
+        $isInitialized = array();
+        foreach ($transformations as $transformation) {
+            $writerName = $transformation->getWriter();
+
+            if (in_array($writerName, $isInitialized)) {
+                continue;
+            }
+
+            $isInitialized[] = $writerName;
+            $writer = $this->writers[$writerName];
+            $this->initializeWriter($writer, $project);
+        }
+    }
+
+    /**
+     * Initializes the given writer using the provided project meta-data.
+     *
+     * This method wil call for the initialization of each writer that supports an initialization routine (as defined by
+     * the `Initializable` interface).
+     *
+     * In addition to this, the following events emitted for each writer that is present in the collected list of
+     * transformations, even those that do not implement the `Initializable` interface.
+     *
+     * Emitted events:
+     *
+     * - transformer.writer.initialization.pre, before the initialization of a single writer.
+     * - transformer.writer.initialization.post, after the initialization of a single writer.
+     *
+     * @param WriterAbstract    $writer
+     * @param ProjectDescriptor $project
+     *
+     * @uses Dispatcher to emit the events surrounding an initialization.
+     *
+     * @return void
+     */
+    private function initializeWriter(WriterAbstract $writer, ProjectDescriptor $project)
+    {
+        $event = WriterInitializationEvent::createInstance($this)->setWriter($writer);
+        Dispatcher::getInstance()->dispatch(self::EVENT_PRE_INITIALIZATION, $event);
+
+        if ($writer instanceof Initializable) {
+            $writer->initialize($project);
+        }
+
+        Dispatcher::getInstance()->dispatch(self::EVENT_POST_INITIALIZATION, $event);
+    }
+
+    /**
+     * Applies all given transformations to the provided project.
+     *
+     * @param ProjectDescriptor $project
+     * @param Transformation[]  $transformations
+     *
+     * @return void
+     */
+    private function transformProject(ProjectDescriptor $project, $transformations)
+    {
+        foreach ($transformations as $transformation) {
+            $transformation->setTransformer($this);
+            $this->applyTransformationToProject($transformation, $project);
+        }
+    }
+
+    /**
+     * Applies the given transformation to the provided project.
+     *
+     * This method will attempt to find an appropriate writer for the given transformation and invoke that with the
+     * transformation and project so that an artifact can be generated that matches the intended transformation.
+     *
+     * In addition this method will emit the following events:
+     *
+     * - transformer.transformation.pre, before the project has been transformed with this transformation.
+     * - transformer.transformation.post, after the project has been transformed with this transformation
+     *
+     * @param Transformation $transformation
+     * @param ProjectDescriptor $project
+     *
+     * @uses Dispatcher to emit the events surrounding a transformation.
+     *
+     * @return void
+     */
+    private function applyTransformationToProject(Transformation $transformation, ProjectDescriptor $project)
+    {
+        $this->log(
+            sprintf(
+                '  Writer %s %s on %s',
+                $transformation->getWriter(),
+                ($transformation->getQuery() ? ' using query "' . $transformation->getQuery() . '"' : ''),
+                $transformation->getArtifact()
+            )
+        );
+
+        $preTransformationEvent = PreTransformationEvent::createInstance($this)->setTransformation($transformation);
+        Dispatcher::getInstance()->dispatch(self::EVENT_PRE_TRANSFORMATION, $preTransformationEvent);
+
+        $writer = $this->writers[$transformation->getWriter()];
+        $writer->transform($project, $transformation);
+
+        $postTransformationEvent = PostTransformationEvent::createInstance($this);
+        Dispatcher::getInstance()->dispatch(self::EVENT_POST_TRANSFORMATION, $postTransformationEvent);
     }
 }

--- a/src/phpDocumentor/Transformer/Writer/Initializable.php
+++ b/src/phpDocumentor/Transformer/Writer/Initializable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace phpDocumentor\Transformer\Writer;
+
+use phpDocumentor\Descriptor\ProjectDescriptor;
+
+interface Initializable
+{
+    public function initialize(ProjectDescriptor $projectDescriptor);
+}

--- a/tests/unit/phpDocumentor/Transformer/Event/PreTransformEventTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Event/PreTransformEventTest.php
@@ -4,12 +4,14 @@
  *
  * PHP Version 5.3
  *
- * @copyright 2010-2013 Mike van Riel / Naenius (http://www.naenius.com)
+ * @copyright 2010-2014 Mike van Riel / Naenius (http://www.naenius.com)
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
 
 namespace phpDocumentor\Transformer\Event;
+
+use Mockery as m;
 
 /**
  * Tests the functionality for the PreTransformEvent class.
@@ -19,9 +21,6 @@ class PreTransformEventTest extends \PHPUnit_Framework_TestCase
     /** @var PreTransformEvent $fixture */
     protected $fixture;
 
-    /** @var \DOMDocument */
-    protected $source;
-
     /**
      * Creates a new (empty) fixture object.
      * Creates a new DOMDocument object.
@@ -29,19 +28,19 @@ class PreTransformEventTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->fixture = new PreTransformEvent(new \stdClass());
-        $this->source = new \DOMDocument('1.0', 'UTF-8');
     }
 
     /**
-     * @covers phpDocumentor\Transformer\Event\PreTransformEvent::getSource
-     * @covers phpDocumentor\Transformer\Event\PreTransformEvent::setSource
+     * @covers phpDocumentor\Transformer\Event\PreTransformEvent::getProject
+     * @covers phpDocumentor\Transformer\Event\PreTransformEvent::setProject
      */
-    public function testSetAndGetSource()
+    public function testSetAndGetProject()
     {
-        $this->assertSame(null, $this->fixture->getSource());
+        $project = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
+        $this->assertSame(null, $this->fixture->getProject());
 
-        $this->fixture->setSource($this->source);
+        $this->fixture->setProject($project);
 
-        $this->assertSame($this->source, $this->fixture->getSource());
+        $this->assertSame($project, $this->fixture->getProject());
     }
 }

--- a/tests/unit/phpDocumentor/Transformer/TransformerTest.php
+++ b/tests/unit/phpDocumentor/Transformer/TransformerTest.php
@@ -95,20 +95,6 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers phpDocumentor\Transformer\Transformer::setBehaviours
-     * @covers phpDocumentor\Transformer\Transformer::getBehaviours
-     */
-    public function testProvidingBehaviours()
-    {
-        $this->assertEquals(null, $this->fixture->getBehaviours());
-
-        $behaviours = m::mock('phpDocumentor\Transformer\Behaviour\Collection');
-        $this->fixture->setBehaviours($behaviours);
-
-        $this->assertEquals($behaviours, $this->fixture->getBehaviours());
-    }
-
-    /**
      * @covers phpDocumentor\Transformer\Transformer::getTemplates
      */
     public function testRetrieveTemplateCollection()
@@ -133,7 +119,6 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         $templateCollection = m::mock('phpDocumentor\Transformer\Template\Collection');
 
         $project = m::mock('phpDocumentor\Descriptor\ProjectDescriptor');
-        $behaviourCollection = $this->buildEmptyBehaviorCollection($project);
 
         $myTestWritterMock = m::mock('phpDocumentor\Transformer\Writer\WriterAbstract')
             ->shouldReceive('transform')->getMock();
@@ -143,7 +128,6 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
                 ->getMock();
 
         $fixture = new Transformer($templateCollection, $writerCollectionMock);
-        $fixture->setBehaviours($behaviourCollection);
 
         $transformation = m::mock('phpDocumentor\Transformer\Transformation')
             ->shouldReceive('execute')->with($project)
@@ -158,15 +142,6 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertNull($fixture->execute($project));
-    }
-
-    protected function buildEmptyBehaviorCollection(ProjectDescriptor $project)
-    {
-        $behaviourCollection = m::mock('phpDocumentor\Transformer\Behaviour\Collection');
-        $behaviourCollection->shouldReceive('process')->with($project);
-        $behaviourCollection->shouldReceive('count')->andReturn(0);
-
-        return $behaviourCollection;
     }
 
     /**


### PR DESCRIPTION
The goal of this refactoring was:
1. To move all output logic (logging) from the Transformer back to
   the TransformCommand using events.
2. To allow writers to initialize themselves or the ProjectDescriptor
   before all transformations are executed. This allows writers to set
   up globals and other state using the ProjectDescriptor that other
   writers could use. An example is the upcoming Search writer that can
   inject a partial to show a search box tailored to a specific search
   type.
3. To move behaviours out of the Transformer as to make it more lean
   and loosen dependencies.
4. To clean up the code of the Transformer
