### PR TITLE
Ensure /tmp/ is the start of a path before replace

### DIFF
--- a/src/phpDocumentor/Parser/Command/Project/ParseCommand.php
+++ b/src/phpDocumentor/Parser/Command/Project/ParseCommand.php
@@ -143,9 +143,10 @@ class ParseCommand extends Command
         /** @var ConfigurationHelper $configurationHelper */
         $configurationHelper = $this->getHelper('phpdocumentor_configuration');
         $target = $configurationHelper->getOption($input, 'target', 'parser/target');
-        if( strpos( $target, '/tmp/' ) === 0 )
+        if (strpos($target, '/tmp/') === 0) {
             $target = str_replace('/tmp/', sys_get_temp_dir() . DIRECTORY_SEPARATOR, $target);
-
+        }
+        
         $fileSystem = new Filesystem();
         if (! $fileSystem->isAbsolutePath($target)) {
             $target = getcwd().DIRECTORY_SEPARATOR.$target;


### PR DESCRIPTION
We have an issue where '/tmp/' is in the target path, but is not the lowest directory (/usr/local/zend/tmp/). This folder is already the system temp folder... which is causing the path to become '/usr/local/zend/usr/local/zend/tmp/'
