### PR TITLE
check current working directory for composer.json

### DIFF
--- a/src/phpDocumentor/Bootstrap.php
+++ b/src/phpDocumentor/Bootstrap.php
@@ -141,6 +141,9 @@ class Bootstrap
         if (file_exists($composerConfigurationPath)) {
             $vendorDir = $rootFolderWhenInstalledWithComposer
                 . $this->getCustomVendorPathFromComposer($composerConfigurationPath);
+        } elseif (file_exists(getcwd() . DIRECTORY_SEPARATOR  . 'composer.json')) {
+            $vendorDir = getcwd() . DIRECTORY_SEPARATOR
+                . $this->getCustomVendorPathFromComposer(getcwd() . DIRECTORY_SEPARATOR  . 'composer.json');
         }
 
         return file_exists($vendorDir) ? $vendorDir : null;


### PR DESCRIPTION
this might be a fix for #1405. This will only work when you execute phpdocumentor from you project root. 

Bad thing, impossible to test with a unit test. 
