### PR TITLE
Fix for Fatal error: Call to a member function getParent() on a non-obje...

### DIFF
--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/ConstantDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/ConstantDescriptor.php
@@ -36,6 +36,10 @@ class ConstantDescriptor implements UrlGeneratorInterface
      */
     public function __invoke($node)
     {
+        if (!($node instanceof Descriptor\ConstantDescriptor)) {
+            return false;
+        }
+
         $prefix = ($node->getParent() instanceof Descriptor\FileDescriptor || ! $node->getParent())
             ? $this->getUrlPathPrefixForGlobalConstants($node)
             : $this->getUrlPathPrefixForClassConstants($node);


### PR DESCRIPTION
...ct in ConstantDescriptor.php

This method needs to be able to return false if $node is not an instance of Descriptor\ConstantDescriptor.
