### PR TITLE
Fix for: Fatal error: Call to a member function getParent() on a non-obj...

### DIFF
--- a/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/PropertyDescriptor.php
+++ b/src/phpDocumentor/Transformer/Router/UrlGenerator/Standard/PropertyDescriptor.php
@@ -28,6 +28,10 @@ class PropertyDescriptor implements UrlGeneratorInterface
      */
     public function __invoke($node)
     {
+        if (!($node instanceof Descriptor\PropertyDescriptor)) {
+            return false;
+        }
+
         $converter = new QualifiedNameToUrlConverter();
         $className = $node->getParent()->getFullyQualifiedStructuralElementName();
 


### PR DESCRIPTION
...ect in PropertyDescriptor.php

This method needs to be able to return false if $node is not an instance of Descriptor\PropertyDescriptor.

See also: https://github.com/phpDocumentor/phpDocumentor2/pull/1429
