### PR TITLE
[Merge after 2.8] Add HHVM compatibility

### DIFF
--- a/src/phpDocumentor/Bootstrap.php
+++ b/src/phpDocumentor/Bootstrap.php
@@ -170,7 +170,7 @@ class Bootstrap
      */
     protected function addDomPdfConfig($vendorPath)
     {
-        if (! \Phar::running()) {
+        if (! method_exists('Phar', 'running') || ! \Phar::running()) {
             defined('DOMPDF_ENABLE_AUTOLOAD') or define('DOMPDF_ENABLE_AUTOLOAD', false);
             require_once($vendorPath . '/dompdf/dompdf/dompdf_config.inc.php');
         }

--- a/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xsl.php
+++ b/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xsl.php
@@ -170,7 +170,7 @@ class Xsl extends WriterAbstract implements Routable
         // Argument) will be raised. Thanks to @FnTmLV for finding the cause. See issue #284 for more information.
         // An exception to the above is when running from a Phar file; in this case the stream is handled as if on
         // linux; see issue #713 for more information on this exception.
-        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN' && ! \Phar::running()) {
+        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN' && (! method_exists('Phar', 'running') ||  ! \Phar::running())) {
             $filename = '/' . $filename;
         }
 


### PR DESCRIPTION
In this commit we have made the changes that are necessary to run phpDocumentor
using HHVM. HHVM currently does not support the Phar::running() method, which
does also mean that unexpected side-effects may happen when running the PHAR file
from HHVM.

The most important side effects when running the Phar file is that HHVM will load
the DOMPDF extension, which normally fails under Phar, and that under windows paths
may not be converted correctly in some cases.

The latter is not important at this moment because HHVM does not run in Windows
anyway.
