### PR TITLE
Used "auto_reload" setting to reload the Twig cache on demand

### DIFF
--- a/src/phpDocumentor/Plugin/Twig/Writer/Twig.php
+++ b/src/phpDocumentor/Plugin/Twig/Writer/Twig.php
@@ -148,7 +148,7 @@ class Twig extends WriterAbstract implements Routable
 
         $env = new \Twig_Environment(
             new \Twig_Loader_Filesystem($templateFolders),
-            array('cache' => sys_get_temp_dir() . '/phpdoc-twig-cache')
+            array('cache' => sys_get_temp_dir() . '/phpdoc-twig-cache', 'auto_reload' => true)
         );
 
         $this->addPhpDocumentorExtension($project, $transformation, $destination, $env);


### PR DESCRIPTION
Right now, if Twig templates are modified, the cache is not refreshed automatically, with the result of a big WTF. With "auto_reload" set, Twig compares the timestamps of the templates and the cache and refreshes on demand.
