### PR TITLE
Replace Cocur/Slugify with Symfony/String

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-zlib": "*",
-        "cocur/slugify": "^3.2",
         "erusev/parsedown": "~1.0",
         "jean85/pretty-package-versions": "^1.2",
         "league/flysystem": "^1.0",
@@ -59,6 +58,7 @@
         "symfony/monolog-bundle": "^3.0",
         "symfony/routing": "^5.0",
         "symfony/stopwatch": "^5.0",
+        "symfony/string": "5.0.*",
         "symfony/yaml": "^5.0",
         "twig/twig": "~2.0",
         "webmozart/assert": "^1.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,73 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2eda8c8a8e2a8d3b48abf721f5b6ee0",
+    "content-hash": "333a4d5a1806fe1ed39402da23570de4",
     "packages": [
-        {
-            "name": "cocur/slugify",
-            "version": "v3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cocur/slugify.git",
-                "reference": "d41701efe58ba2df9cae029c3d21e1518cc6780e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cocur/slugify/zipball/d41701efe58ba2df9cae029c3d21e1518cc6780e",
-                "reference": "d41701efe58ba2df9cae029c3d21e1518cc6780e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "laravel/framework": "~5.1",
-                "latte/latte": "~2.2",
-                "league/container": "^2.2.0",
-                "mikey179/vfsstream": "~1.6",
-                "mockery/mockery": "~0.9",
-                "nette/di": "~2.2",
-                "phpunit/phpunit": "~4.8.36|~5.2",
-                "pimple/pimple": "~1.1",
-                "plumphp/plum": "~0.1",
-                "silex/silex": "~1.3",
-                "symfony/config": "~2.4|~3.0|~4.0",
-                "symfony/dependency-injection": "~2.4|~3.0|~4.0",
-                "symfony/http-kernel": "~2.4|~3.0|~4.0",
-                "twig/twig": "~1.26|~2.0",
-                "zendframework/zend-modulemanager": "~2.2",
-                "zendframework/zend-servicemanager": "~2.2",
-                "zendframework/zend-view": "~2.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cocur\\Slugify\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ivo Bathke",
-                    "email": "ivo.bathke@gmail.com"
-                },
-                {
-                    "name": "Florian Eckerstorfer",
-                    "email": "florian@eckerstorfer.co",
-                    "homepage": "https://florian.ec"
-                }
-            ],
-            "description": "Converts a string into a slug.",
-            "keywords": [
-                "slug",
-                "slugify"
-            ],
-            "time": "2019-01-31T20:38:55+00:00"
-        },
         {
             "name": "composer/ca-bundle",
             "version": "1.2.4",
@@ -2425,6 +2360,66 @@
             "time": "2019-11-27T13:56:44+00:00"
         },
         {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "45c566a1ca16273f7ea6b930e013462e00e14502"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/45c566a1ca16273f7ea6b930e013462e00e14502",
+                "reference": "45c566a1ca16273f7ea6b930e013462e00e14502",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T13:56:44+00:00"
+        },
+        {
             "name": "symfony/polyfill-intl-idn",
             "version": "v1.13.1",
             "source": {
@@ -2480,6 +2475,69 @@
                 "compatibility",
                 "idn",
                 "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T13:56:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "cfe6ad557c15f3797f667e9518ce759aa04ae4f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/cfe6ad557c15f3797f667e9518ce759aa04ae4f3",
+                "reference": "cfe6ad557c15f3797f667e9518ce759aa04ae4f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
                 "polyfill",
                 "portable",
                 "shim"
@@ -2727,6 +2785,70 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
+            "time": "2019-11-18T17:27:11+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "abab74551c7b6754046690d02b742154ed42e3a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/abab74551c7b6754046690d02b742154ed42e3a5",
+                "reference": "abab74551c7b6754046690d02b742154ed42e3a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^1.1|^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony String component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
             "time": "2019-11-18T17:27:11+00:00"
         },
         {

--- a/src/phpDocumentor/Transformer/Router/ClassBasedFqsenUrlGenerator.php
+++ b/src/phpDocumentor/Transformer/Router/ClassBasedFqsenUrlGenerator.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Router;
 
-use Cocur\Slugify\Slugify;
 use phpDocumentor\Reflection\Fqsen;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\String\Slugger\SluggerInterface;
 use function count;
 use function explode;
 use function strpos;
@@ -28,13 +28,13 @@ class ClassBasedFqsenUrlGenerator
     /** @var UrlGeneratorInterface */
     private $urlGenerator;
 
-    /** @var Slugify */
-    private $slugify;
+    /** @var SluggerInterface */
+    private $slugger;
 
-    public function __construct(UrlGeneratorInterface $urlGenerator)
+    public function __construct(UrlGeneratorInterface $urlGenerator, SluggerInterface $slugger)
     {
         $this->urlGenerator = $urlGenerator;
-        $this->slugify = new Slugify();
+        $this->slugger = $slugger;
     }
 
     /**
@@ -43,7 +43,7 @@ class ClassBasedFqsenUrlGenerator
     public function __invoke(Fqsen $fqsen) : string
     {
         $fqsenParts = explode('::', (string) $fqsen);
-        $className = $this->slugify($fqsenParts[0]);
+        $className = $this->slugger->slug($fqsenParts[0])->toString();
 
         if (count($fqsenParts) === 1) {
             return $this->urlGenerator->generate(
@@ -81,10 +81,5 @@ class ClassBasedFqsenUrlGenerator
                 '_fragment' => 'constant_' . $fqsenParts[1],
             ]
         );
-    }
-
-    private function slugify(string $string, bool $lowercase = false, string $default = '') : string
-    {
-        return $this->slugify->slugify($string, ['lowercase' => $lowercase]) ?: $default;
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,7 +1,4 @@
 {
-    "cocur/slugify": {
-        "version": "v3.2"
-    },
     "composer/ca-bundle": {
         "version": "1.1.1"
     },
@@ -167,8 +164,14 @@
     "symfony/polyfill-ctype": {
         "version": "v1.11.0"
     },
+    "symfony/polyfill-intl-grapheme": {
+        "version": "v1.13.1"
+    },
     "symfony/polyfill-intl-idn": {
         "version": "v1.12.0"
+    },
+    "symfony/polyfill-intl-normalizer": {
+        "version": "v1.13.1"
     },
     "symfony/polyfill-mbstring": {
         "version": "v1.6.0"
@@ -190,6 +193,9 @@
     },
     "symfony/stopwatch": {
         "version": "v4.0.3"
+    },
+    "symfony/string": {
+        "version": "v5.0.1"
     },
     "symfony/var-dumper": {
         "version": "v5.0.0"

--- a/tests/unit/phpDocumentor/Transformer/Router/ClassBasedFqsenUrlGeneratorTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/ClassBasedFqsenUrlGeneratorTest.php
@@ -17,6 +17,7 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Reflection\Fqsen;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 
 /**
  * Test for the MethodDescriptor URL Generator with the Standard Router
@@ -37,7 +38,7 @@ class ClassBasedFqsenUrlGeneratorTest extends MockeryTestCase
         $urlGenerator = m::mock(UrlGeneratorInterface::class);
         $urlGenerator->shouldReceive('generate')->andReturn($toPath);
         $fqsen = new Fqsen($fromFqsen);
-        $fixture = new ClassBasedFqsenUrlGenerator($urlGenerator);
+        $fixture = new ClassBasedFqsenUrlGenerator($urlGenerator, new AsciiSlugger());
 
         // Act
         $result = $fixture($fqsen);

--- a/tests/unit/phpDocumentor/Transformer/Router/RouterTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/RouterTest.php
@@ -28,6 +28,7 @@ use phpDocumentor\Uri;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 
 /**
  * @coversDefaultClass \phpDocumentor\Transformer\Router\Router
@@ -51,7 +52,11 @@ final class RouterTest extends TestCase
         $urlGenerator->generate($routeName, ['name' => $expected, '_fragment' => $fragment])
             ->willReturn($url);
 
-        $router = new Router(new ClassBasedFqsenUrlGenerator($urlGenerator->reveal()), $urlGenerator->reveal());
+        $router = new Router(
+            new ClassBasedFqsenUrlGenerator($urlGenerator->reveal(), new AsciiSlugger()),
+            $urlGenerator->reveal(),
+            new AsciiSlugger()
+        );
         $result = $router->generate($node);
 
         $this->assertSame($url, $result);
@@ -65,7 +70,11 @@ final class RouterTest extends TestCase
         $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
         $urlGenerator->generate()->shouldNotBeCalled();
 
-        $router = new Router(new ClassBasedFqsenUrlGenerator($urlGenerator->reveal()), $urlGenerator->reveal());
+        $router = new Router(
+            new ClassBasedFqsenUrlGenerator($urlGenerator->reveal(), new AsciiSlugger()),
+            $urlGenerator->reveal(),
+            new AsciiSlugger()
+        );
 
         $this->assertSame('https://my/uri', $router->generate($this->givenAUri()));
     }
@@ -78,7 +87,11 @@ final class RouterTest extends TestCase
         $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
         $urlGenerator->generate()->shouldNotBeCalled();
 
-        $router = new Router(new ClassBasedFqsenUrlGenerator($urlGenerator->reveal()), $urlGenerator->reveal());
+        $router = new Router(
+            new ClassBasedFqsenUrlGenerator($urlGenerator->reveal(), new AsciiSlugger()),
+            $urlGenerator->reveal(),
+            new AsciiSlugger()
+        );
         $result = $router->generate(new stdClass()); // An stdClass is not routable
 
         $this->assertSame('', $result);


### PR DESCRIPTION
With phpDocumentor we are frequently running into transliteration and
slugification issues. For the slugify side of things we used
Cocur/Slugify but recently the Symfony/String component became available
that has support for various string manipulations, including
sluggification, that have transliteration of strings in mind.

With this change I hope to make a start to make the transliteration support
more robust for phpDocumentor and enable us to do more with this
feature.