### PR TITLE
[WIP]: Add support for extensions

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -144,6 +144,15 @@ services:
     phpDocumentor\Compiler\Linker\Linker:
         arguments: ['%linker.substitutions%']
 
+    # The locations and extensions are now coded into this service; but this should be injected using a pipeline
+    # stage with the registerExtension and registerLocation methods.
+    phpDocumentor\Extensions:
+        arguments:
+            $extensions:
+                - 'phpDocumentor\Extensions\Example'
+            $locations:
+                'phpDocumentor\Extensions\': 'data/Extensions'
+
     phpDocumentor\Compiler\Compiler:
         calls:
             - [insert, ['@phpDocumentor\Compiler\Pass\ElementsIndexBuilder', !php/const \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::COMPILER_PRIORITY]]
@@ -157,6 +166,7 @@ services:
             - [insert, ['@phpDocumentor\Compiler\Pass\ResolveInlineMarkers', !php/const \phpDocumentor\Compiler\Pass\ResolveInlineMarkers::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Compiler\Pass\Debug', !php/const \phpDocumentor\Compiler\Pass\Debug::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Compiler\Linker\Linker', !php/const \phpDocumentor\Compiler\Linker\Linker::COMPILER_PRIORITY]]
+            - [insert, ['@phpDocumentor\Extensions', !php/const \phpDocumentor\Extensions::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Transformer\Transformer', !php/const \phpDocumentor\Transformer\Transformer::COMPILER_PRIORITY]]
 
     phpDocumentor\Reflection\Php\NodesFactory:

--- a/data/Extensions/Example.php
+++ b/data/Extensions/Example.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extensions;
+
+use phpDocumentor\Descriptor\ProjectDescriptor;
+
+final class Example
+{
+    public function __invoke(ProjectDescriptor $projectDescriptor)
+    {
+        echo 'Extension is executed';
+    }
+}

--- a/src/phpDocumentor/AutoloaderLocator.php
+++ b/src/phpDocumentor/AutoloaderLocator.php
@@ -20,9 +20,20 @@ use function json_decode;
 
 final class AutoloaderLocator
 {
+    private static $classLoader;
+
+    public static function loader() : ClassLoader
+    {
+        return self::autoload();
+    }
+
     public static function autoload() : ClassLoader
     {
-        return require static::findVendorPath() . '/autoload.php';
+        if (!static::$classLoader) {
+            static::$classLoader = require static::findVendorPath() . '/autoload.php';
+        }
+
+        return static::$classLoader;
     }
 
     /**

--- a/src/phpDocumentor/Extensions.php
+++ b/src/phpDocumentor/Extensions.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
+namespace phpDocumentor;
+
+use Composer\Autoload\ClassLoader;
+use InvalidArgumentException;
+use League\Uri\Uri;
+use League\Uri\UriInfo;
+use phpDocumentor\Compiler\CompilerPassInterface;
+use phpDocumentor\Descriptor\ProjectDescriptor;
+use Psr\Log\LoggerInterface;
+use function getcwd;
+use function is_callable;
+use function ob_get_clean;
+use function ob_start;
+use function sprintf;
+
+final class Extensions implements CompilerPassInterface
+{
+    /** @var integer represents the priority in the Compiler queue. Should be slightly more than the transformer */
+    public const COMPILER_PRIORITY = 5500;
+
+    /** @var ClassLoader */
+    private $loader;
+
+    /** @var callable[] */
+    private $extensions;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger, array $extensions = [], $locations = [])
+    {
+        $this->loader = AutoloaderLocator::loader();
+
+        $this->logger = $logger;
+        foreach ($locations as $namespace => $location) {
+            $this->registerLocation($namespace, $location);
+        }
+        foreach ($extensions as $extension) {
+            $this->registerExtension($extension);
+        }
+    }
+
+    /**
+     * Registers a namespace and location from where to load extensions.
+     *
+     * This is the big 'secret' behind extensions in phpDocumentor. Because we register the location dynamically we can
+     * refer to classes outside of the current project structure, and even outside of a PHAR when using the PHAR version
+     * of phpDocumentor.
+     *
+     * phpDocumentor uses the PSR-4 standard for autoloading extensions; this means that the name of the class must
+     * match the name of the file and only 1 class per file is allowed.
+     *
+     * @param string $namespace The namespace that matches the location.
+     * @param string $location The path from where to load extensions matching the namespace, when relative it will be
+     *     considered to be relative to the current working directory.
+     */
+    public function registerLocation(string $namespace, string $location) : void
+    {
+        if (UriInfo::isRelativePath(Uri::createFromString($location))) {
+            $location = getcwd() . DIRECTORY_SEPARATOR . $location;
+        }
+
+        // Some loaders double the number of slashes; causing autoloading to fail
+        if (strpos($namespace, '\\\\')) {
+            $namespace = stripslashes($namespace);
+        }
+
+        $this->loader->addPsr4(trim($namespace, '\\') . '\\', $location);
+    }
+
+    /**
+     * Registers the given class as an extension and immediately instantiates it.
+     *
+     * It is important that the location for this extension needs to have been registered before registering this
+     * extension; on moment of registration it will be instantiated and for that we need to be able to resolve it.
+     *
+     * @param string $className
+     * @see self::registerLocation() for more information on how to register locations for extensions.
+     */
+    public function registerExtension(string $className) : void
+    {
+        if ($this->loader->loadClass($className) !== true) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Could not find extension with class name "%s"; did you register its location?',
+                    $className
+                )
+            );
+        }
+
+        $extension = new $className();
+        if (!is_callable($extension)) {
+            throw new InvalidArgumentException(
+                sprintf('Extension %s is not callable, please implement the `__invoke()` method', $className)
+            );
+        }
+
+        $this->extensions[] = $extension;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDescription() : string
+    {
+        $extensions = [];
+        foreach ($this->extensions as $extension) {
+            $extensions[] = $this->extensionName($extension);
+        }
+
+        return 'Apply the effect of the extensions: ' . implode(', ', $extensions);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(ProjectDescriptor $project) : void
+    {
+        foreach ($this->extensions as $extension) {
+            ob_start();
+            $extension($project);
+            $output = trim(ob_get_clean());
+            if ($output) {
+                $this->logger->notice(sprintf("    %s: %s", $this->extensionName($extension), $output));
+            }
+        }
+    }
+
+    public function __toString() : string
+    {
+        return $this->getDescription();
+    }
+
+    private function extensionName(callable $extension) : string
+    {
+        return substr(get_class($extension), strripos(get_class($extension), '\\') + 1) ?: 'Unknown';
+    }
+}

--- a/src/phpDocumentor/Pipeline/Stage/Transform.php
+++ b/src/phpDocumentor/Pipeline/Stage/Transform.php
@@ -107,7 +107,7 @@ final class Transform
                 $transformer     = $event->getSubject();
                 $templates       = $transformer->getTemplates();
                 $transformations = $templates->getTransformations();
-                $this->logger->info(sprintf("\nApplying %d transformations", count($transformations)));
+                $this->logger->notice(sprintf("  Applying %d transformations", count($transformations)));
             }
         );
         Dispatcher::getInstance()->addListener(
@@ -117,14 +117,14 @@ final class Transform
                     return;
                 }
 
-                $this->logger->info('  Initialize writer "' . get_class($event->getWriter()) . '"');
+                $this->logger->info('    Initialize writer "' . get_class($event->getWriter()) . '"');
             }
         );
         Dispatcher::getInstance()->addListener(
             Transformer::EVENT_PRE_TRANSFORMATION,
             function (PreTransformationEvent $event) : void {
                 $this->logger->info(
-                    '  Execute transformation using writer "' . $event->getTransformation()->getWriter() . '"'
+                    '    Execute transformation using writer "' . $event->getTransformation()->getWriter() . '"'
                 );
             }
         );
@@ -153,8 +153,10 @@ final class Transform
 
     private function doTransform(ProjectDescriptorBuilder $builder) : void
     {
+        $this->logger->notice('Executing compiler passes');
         /** @var CompilerPassInterface $pass */
         foreach ($this->compiler as $pass) {
+            $this->logger->notice('  ' . $pass->getDescription());
             $pass->execute($builder->getProjectDescriptor());
         }
     }

--- a/src/phpDocumentor/Transformer/Transformer.php
+++ b/src/phpDocumentor/Transformer/Transformer.php
@@ -271,10 +271,10 @@ class Transformer implements CompilerPassInterface
         $this->logger->log(
             LogLevel::NOTICE,
             sprintf(
-                '  Writer %s %s on %s',
+                '    Writer %s%s%s',
                 $transformation->getWriter(),
                 ($transformation->getQuery() ? ' using query "' . $transformation->getQuery() . '"' : ''),
-                $transformation->getArtifact()
+                $transformation->getArtifact() ? ' to ' . $transformation->getArtifact() : ''
             )
         );
 


### PR DESCRIPTION
For phpDocumentor, we want to allow consumers and internal processes to
be able to manipulate what data will be rendered and with it the ability
to change what data is included.

Examples of this is the `@mixin` tag, with an extension you can read the
tags of all classes, determine whether it has a mixin tag and try to
locate an accompanying class that needs to be mixed in. Once found, you
can change the list of methods to include the mixed in methods; their
parent property remains a method to determine that they do not originate
in this class but instead from elsewhere.

This extension mechanism should also work when called from phpDocumentor
as a PHAR. Because you can register additional autoloading mechanisms
on runtime, it is able to query the real filesystem instead of inside
the PHAR. This means that projects could include their own extensions
and still refer to them from within the PHAR.

If this mechanism sticks, we could even attempt to move internal
processes (such as inheritence) to these extensions.