### PR TITLE
Introduce FlySystem into twig file loading

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Run PHPUnit
       run: php tools/phpunit.phar
     - name: Quick check code coverage level
-      run: php tests/coverage-checker.php 68
+      run: php tests/coverage-checker.php 69
     - name: Upload to Scrutinizer
       run: tools/ocular code-coverage:upload --format=php-clover build/logs/clover.xml
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,7 +67,7 @@ jobs:
         extension-csv: mbstring, intl, iconv, libxml, dom, json, simplexml, zlib
         ini-values-csv: memory_limit=2G, display_errors=On, error_reporting=-1
         coverage: xdebug
-        pecl: false
+        pecl: true
     - name: Run PHPUnit
       run: php tools/phpunit.phar
     - name: Quick check code coverage level
@@ -188,7 +188,7 @@ jobs:
           php-version: '7.2'
           extension-csv: mbstring, intl, iconv, libxml, dom, json, simplexml, zlib
           ini-values-csv: memory_limit=2G, display_errors=On, error_reporting=-1
-          pecl: false
+          pecl: true
       - name: Download PHAR file
         if: matrix.profile == 'phar'
         uses: actions/download-artifact@v1
@@ -219,7 +219,7 @@ jobs:
           php-version: '7.2'
           extension-csv: mbstring, intl, iconv, libxml, dom, json, simplexml, zlib
           ini-values-csv: memory_limit=2G, display_errors=On, error_reporting=-1
-          pecl: false
+          pecl: true
       - name: Download PHAR file
         uses: actions/download-artifact@v1
         with:
@@ -276,7 +276,7 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extension-csv: mbstring, intl, iconv, libxml, dom, json, simplexml, zlib
         ini-values-csv: memory_limit=2G, display_errors=On, error_reporting=-1
-        pecl: false
+        pecl: true
     - name: Run PHPUnit
       run: php tools/phpunit.phar
 
@@ -319,7 +319,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extension-csv: mbstring, intl, iconv, libxml, dom, json, simplexml, zlib
           ini-values-csv: memory_limit=2G, display_errors=On, error_reporting=-1
-          pecl: false
+          pecl: true
       - name: Download PHAR file
         if: matrix.profile == 'phar'
         uses: actions/download-artifact@v1

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ phpstan:
 .PHONY: test
 test:
 	docker-compose run --rm phpunit ${ARGS}
-	docker-compose run --entrypoint=/usr/local/bin/php --rm phpunit tests/coverage-checker.php 68
+	docker-compose run --entrypoint=/usr/local/bin/php --rm phpunit tests/coverage-checker.php 69
 
 .PHONY: behat
 behat:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,6 @@ parameters:
     - '#.*NodeDefinition::fixXmlConfig.*#'
     - '#.*NodeDefinition::addDefaultsIfNotSet.*#'
 
-    - '#Constructor of class phpDocumentor\\Transformer\\Writer\\Twig\\Extension has an unused parameter \$transformation#'
     - '#Call to an undefined method League\\Flysystem\\Filesystem::find()#'
     # Bad design of descriptors.
     - '#Access to an undefined property phpDocumentor\\Descriptor\\Collection::\$[a-z]+#'

--- a/src/phpDocumentor/Transformer/Template.php
+++ b/src/phpDocumentor/Transformer/Template.php
@@ -18,7 +18,7 @@ use ArrayIterator;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\MountManager;
 use phpDocumentor\Transformer\Template\Parameter;
 use function array_merge;
 use function count;
@@ -50,7 +50,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
     /** @var Parameter[] Global parameters that are passed to each transformation. */
     private $parameters = [];
 
-    /** @var FilesystemInterface */
+    /** @var MountManager */
     private $files;
 
     /**
@@ -58,7 +58,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
      *
      * @param string $name Name for this template.
      */
-    public function __construct(string $name, FilesystemInterface $files)
+    public function __construct(string $name, MountManager $files)
     {
         $this->name = $name;
         $this->files = $files;
@@ -129,7 +129,20 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
         $this->version = $version;
     }
 
-    public function files() : FilesystemInterface
+    /**
+     * FlySystem filesystem / MountManager containing the template files, base templates files
+     * and destination filesystem.
+     *
+     * This MountManager has three mounts:
+     *
+     * - template://, the files of this template
+     * - templates://, the base folder containing phpDocumentor's global templates (i.e. `/data/templates`)
+     * - destination://, the destination where the template needs to write to
+     *
+     * By combining this in one mount manager it is easier for writers to copy files between destinations (since
+     * MountManager's can copy between filesystems) and for writers to read and write from various locations.
+     */
+    public function files() : MountManager
     {
         return $this->files;
     }

--- a/src/phpDocumentor/Transformer/Writer/PathGenerator.php
+++ b/src/phpDocumentor/Transformer/Writer/PathGenerator.php
@@ -20,7 +20,6 @@ use phpDocumentor\Transformer\Transformation;
 use RuntimeException;
 use Symfony\Component\String\UnicodeString;
 use UnexpectedValueException;
-use const DIRECTORY_SEPARATOR;
 use function array_map;
 use function current;
 use function explode;
@@ -29,7 +28,6 @@ use function implode;
 use function is_string;
 use function preg_replace_callback;
 use function sprintf;
-use function str_replace;
 use function strpos;
 use function trim;
 
@@ -66,24 +64,21 @@ class PathGenerator
      *   An artifact stating `classes/{{name}}.html` will try to find the
      *   node 'name' as a child of the given $node and use that value instead.
      *
-     * @return string|null returns the destination location or false if generation should be aborted.
+     * @return string returns the destination location or false if generation should be aborted.
      *
      * @throws InvalidArgumentException If no artifact is provided and no routing rule matches.
      * @throws UnexpectedValueException If the provided node does not contain anything.
      */
-    public function generate(Descriptor $descriptor, Transformation $transformation) : ?string
+    public function generate(Descriptor $descriptor, Transformation $transformation) : string
     {
         $path = $this->determinePath($descriptor, $transformation);
-        if ($path === null) {
-            return null;
-        }
 
         return $this->replaceVariablesInPath($path, $descriptor);
     }
 
-    private function determinePath(Descriptor $descriptor, Transformation $transformation) : ?string
+    private function determinePath(Descriptor $descriptor, Transformation $transformation) : string
     {
-        $path = DIRECTORY_SEPARATOR . $transformation->getArtifact();
+        $path = '/' . $transformation->getArtifact();
         if (!$transformation->getArtifact()) {
             $url = $this->router->generate($descriptor);
             if (!$url) {
@@ -92,10 +87,6 @@ class PathGenerator
                     . 'encountered: ' . get_class($descriptor)
                 );
             }
-
-            $path = $url[0] === DIRECTORY_SEPARATOR
-                ? str_replace('/', DIRECTORY_SEPARATOR, $url)
-                : null;
         }
 
         return $path;

--- a/src/phpDocumentor/Transformer/Writer/Twig.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig.php
@@ -122,7 +122,7 @@ final class Twig extends WriterAbstract
             }
 
             $path = $this->pathGenerator->generate($node, $transformation);
-            if ($path === null) {
+            if ($path === '') {
                 continue;
             }
 

--- a/src/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactory.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactory.php
@@ -13,21 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer\Twig;
 
-use InvalidArgumentException;
 use phpDocumentor\Descriptor\ProjectDescriptor;
-use phpDocumentor\Transformer\Template;
-use phpDocumentor\Transformer\Template\Parameter;
 use phpDocumentor\Transformer\Transformation;
 use Twig\Environment;
 use Twig\Extension\DebugExtension;
-use Twig\Loader\FilesystemLoader;
-use const DIRECTORY_SEPARATOR;
-use function array_unshift;
-use function class_exists;
-use function class_implements;
-use function in_array;
+use Twig\Loader\ChainLoader;
 use function ltrim;
-use function preg_split;
 
 class EnvironmentFactory
 {
@@ -44,29 +35,18 @@ class EnvironmentFactory
         Transformation $transformation,
         string $destination
     ) : Environment {
-        $callingTemplatePath = $this->getTemplatePath($transformation);
+        $mountManager = $transformation->template()->files();
+        $env = new Environment(
+            new ChainLoader(
+                [
+                    new FlySystemLoader($mountManager->getFilesystem('template')),
+                    new FlySystemLoader($mountManager->getFilesystem('templates')),
+                ]
+            )
+        );
 
-        $baseTemplatesPath = $transformation->getTransformer()->getTemplates()->getTemplatesPath();
-
-        $templateFolders = [
-            $baseTemplatesPath . '/..' . DIRECTORY_SEPARATOR . $callingTemplatePath,
-            // http://twig.sensiolabs.org/doc/recipes.html#overriding-a-template-that-also-extends-itself
-            $baseTemplatesPath,
-        ];
-
-        // get all invoked template paths, they overrule the calling template path
-        /** @var Template $template */
-        foreach ($transformation->getTransformer()->getTemplates() as $template) {
-            $path = $baseTemplatesPath . DIRECTORY_SEPARATOR . $template->getName();
-            array_unshift($templateFolders, $path);
-        }
-
-        // Clone twig because otherwise we cannot re-set the extensions on this twig environment on every run of this
-        // writer
-        $env = new Environment(new FilesystemLoader($templateFolders));
-
-        $this->addPhpDocumentorExtension($project, $transformation, $destination, $env);
-        $this->addExtensionsFromTemplateConfiguration($transformation, $project, $env);
+        $this->addPhpDocumentorExtension($project, $destination, $env);
+        $this->enableDebugWhenParameterIsSet($transformation, $env);
 
         return $env;
     }
@@ -76,64 +56,24 @@ class EnvironmentFactory
      */
     private function addPhpDocumentorExtension(
         ProjectDescriptor $project,
-        Transformation $transformation,
         string $path,
         Environment $twigEnvironment
     ) : void {
-        $base_extension = new Extension($project, $transformation, $this->renderer);
-        $base_extension->setDestination(ltrim($path, '/\\'));
-        $twigEnvironment->addExtension($base_extension);
+        $extension = new Extension($project, $this->renderer);
+        $extension->setDestination(ltrim($path, '/\\'));
+        $twigEnvironment->addExtension($extension);
     }
 
-    /**
-     * Tries to add any custom extensions that have been defined in the template or the transformation's configuration.
-     *
-     * This method will read the `twig-extension` parameter of the transformation (which inherits the template's
-     * parameter set) and try to add those extensions to the environment.
-     *
-     * @throws InvalidArgumentException If a twig-extension should be loaded but it could not be found.
-     */
-    private function addExtensionsFromTemplateConfiguration(
-        Transformation $transformation,
-        ProjectDescriptor $project,
-        Environment $twigEnvironment
-    ) : void {
-        $isDebug = $transformation->getParameter('twig-debug')
-            ? $transformation->getParameter('twig-debug')->value()
-            : false;
-//        if ($isDebug === 'true') {
+    private function enableDebugWhenParameterIsSet(Transformation $transformation, Environment $twigEnvironment) : void
+    {
+        $debugParameter = $transformation->getParameter('twig-debug');
+        $isDebug = $debugParameter ? $debugParameter->value() : false;
+        if ($isDebug !== 'true') {
+            return;
+        }
+
         $twigEnvironment->enableDebug();
         $twigEnvironment->enableAutoReload();
         $twigEnvironment->addExtension(new DebugExtension());
-//        }
-
-        /** @var Parameter $extension */
-        foreach ($transformation->getParametersWithKey('twig-extension') as $extension) {
-            $extensionValue = $extension->value();
-            if (!class_exists($extensionValue)) {
-                throw new InvalidArgumentException('Unknown twig extension: ' . $extensionValue);
-            }
-
-            // to support 'normal' Twig extensions we check the interface to determine what instantiation to do.
-            $implementsInterface = in_array(
-                'phpDocumentor\Transformer\Writer\Twig\ExtensionInterface',
-                class_implements($extensionValue),
-                true
-            );
-
-            $twigEnvironment->addExtension(
-                $implementsInterface ? new $extensionValue($project, $transformation) : new $extensionValue()
-            );
-        }
-    }
-
-    /**
-     * Returns the path belonging to the template.
-     */
-    private function getTemplatePath(Transformation $transformation) : string
-    {
-        $parts = preg_split('[\\\\|/]', $transformation->getSource());
-
-        return $parts[0] . DIRECTORY_SEPARATOR . $parts[1];
     }
 }

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -15,8 +15,8 @@ namespace phpDocumentor\Transformer\Writer\Twig;
 
 use Parsedown;
 use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\Descriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
-use phpDocumentor\Transformer\Transformation;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
@@ -55,16 +55,13 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
     /**
      * Registers the structure and transformation with this extension.
      *
-     * @param ProjectDescriptor $project        Represents the complete Abstract Syntax Tree.
-     * @param Transformation    $transformation Represents the transformation meta data used in the current generation
-     *        cycle.
+     * @param ProjectDescriptor $project Represents the complete Abstract Syntax Tree.
      */
     public function __construct(
         ProjectDescriptor $project,
-        Transformation $transformation,
         ?LinkRenderer $routeRenderer = null
     ) {
-        $this->data          = $project;
+        $this->data = $project;
         $this->routeRenderer = $routeRenderer;
     }
 
@@ -75,7 +72,7 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
      * file. This destination is relative to the Project's root and can
      * be used for the calculation of nesting depths, etc.
      *
-     * @see Writer\Twig for the invocation of this method.
+     * @see EnvironmentFactory for the invocation of this method.
      */
     public function setDestination(string $destination) : void
     {
@@ -120,13 +117,13 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
      */
     public function getFilters() : array
     {
-        $parser        = Parsedown::instance();
+        $parser = Parsedown::instance();
         $routeRenderer = $this->routeRenderer;
 
         return [
             'markdown' => new TwigFilter(
                 'markdown',
-                static function ($value) use ($parser) {
+                static function (string $value) use ($parser) : string {
                     return $parser->text($value);
                 }
             ),
@@ -147,14 +144,14 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
             ),
             'sort' => new TwigFilter(
                 'sort_*',
-                static function ($direction, $collection) {
+                static function (string $direction, $collection) {
                     if (!$collection instanceof Collection) {
                         return $collection;
                     }
 
                     $iterator = $collection->getIterator();
                     $iterator->uasort(
-                        static function ($a, $b) use ($direction) {
+                        static function (Descriptor $a, Descriptor $b) use ($direction) {
                             $aElem = strtolower($a->getName());
                             $bElem = strtolower($b->getName());
                             if ($aElem === $bElem) {

--- a/src/phpDocumentor/Transformer/Writer/Twig/ExtensionInterface.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/ExtensionInterface.php
@@ -13,23 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer\Twig;
 
-use phpDocumentor\Descriptor\ProjectDescriptor;
-use phpDocumentor\Transformer\Transformation;
-
 /**
  * An interface shared by all Twig interfaces intended for phpDocumentor.
  */
 interface ExtensionInterface
 {
-    /**
-     * Registers the structure and transformation objects with this extension.
-     *
-     * The Structure and Transformation object can be used to get context from
-     * and to provide additional information.
-     *
-     * @param ProjectDescriptor $project        Represents the complete Abstract Syntax Tree.
-     * @param Transformation    $transformation Represents the transformation meta data used in the current generation
-     *     cycle.
-     */
-    public function __construct(ProjectDescriptor $project, Transformation $transformation);
 }

--- a/src/phpDocumentor/Transformer/Writer/Twig/FlySystemLoader.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/FlySystemLoader.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
+namespace phpDocumentor\Transformer\Writer\Twig;
+
+use League\Flysystem\FileNotFoundException;
+use League\Flysystem\FilesystemInterface;
+use Twig\Error\LoaderError;
+use Twig\Loader\LoaderInterface;
+use Twig\Source;
+use function rtrim;
+use function sprintf;
+
+final class FlySystemLoader implements LoaderInterface
+{
+    /** @var FilesystemInterface */
+    private $filesystem;
+
+    /** @var string */
+    private $templatePath;
+
+    public function __construct(FilesystemInterface $filesystem, string $templatePath = '')
+    {
+        $this->filesystem = $filesystem;
+        $this->templatePath = $templatePath;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSourceContext($name)
+    {
+        $this->guardTemplateExistsAndIsFile($name);
+
+        $path = $this->resolveTemplateName($name);
+
+        return new Source(
+            $this->filesystem->read($path),
+            $name,
+            $path
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function exists($name)
+    {
+        return $this->filesystem->has($this->resolveTemplateName($name));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCacheKey($name)
+    {
+        $this->guardTemplateExistsAndIsFile($name);
+
+        return $name;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isFresh($name, $time)
+    {
+        $this->guardTemplateExistsAndIsFile($name);
+
+        $timestamp = $this->filesystem->getTimestamp($this->resolveTemplateName($name));
+
+        return (int) $time >= (int) $timestamp;
+    }
+
+    /**
+     * @throws LoaderError
+     */
+    private function guardTemplateExistsAndIsFile(string $name) : void
+    {
+        try {
+            $path = $this->resolveTemplateName($name);
+            $metadata = $this->filesystem->getMetadata($path);
+            if ($metadata['type'] !== 'file') {
+                throw new LoaderError(
+                    sprintf('Cannot use anything other than a file as a template, received: %s', $path)
+                );
+            }
+        } catch (FileNotFoundException $exception) {
+            throw new LoaderError(sprintf('Template "%s" could not be found on the given filesystem', $name));
+        }
+    }
+
+    private function resolveTemplateName(string $name) : string
+    {
+        $prefix = $this->templatePath;
+        if ($this->templatePath !== null && $this->templatePath !== '') {
+            $prefix = rtrim($prefix, '/') . '/';
+        }
+
+        return $prefix . $name;
+    }
+}

--- a/tests/unit/phpDocumentor/Faker/Provider.php
+++ b/tests/unit/phpDocumentor/Faker/Provider.php
@@ -27,7 +27,11 @@ final class Provider extends Base
 
     public function template(string $name = 'test') : Template
     {
-        return new Template($name, $this->fileSystem());
+        return new Template($name, new MountManager([
+            'template' => $this->fileSystem(),
+            'templates' => $this->fileSystem(),
+            'destination' => $this->fileSystem(),
+        ]));
     }
 
     public function transformation(?Template $template = null) : Transformation

--- a/tests/unit/phpDocumentor/Transformer/TemplateTest.php
+++ b/tests/unit/phpDocumentor/Transformer/TemplateTest.php
@@ -15,7 +15,7 @@ namespace phpDocumentor\Transformer;
 
 use ArrayIterator;
 use InvalidArgumentException;
-use League\Flysystem\Filesystem;
+use League\Flysystem\MountManager;
 use phpDocumentor\Faker\Faker;
 use phpDocumentor\Transformer\Template\Parameter;
 use PHPUnit\Framework\TestCase;
@@ -23,8 +23,6 @@ use function count;
 use function iterator_to_array;
 
 /**
- * Test class for \phpDocumentor\Transformer\Transformer.
- *
  * @coversDefaultClass \phpDocumentor\Transformer\Template
  * @covers ::__construct
  * @covers ::<private>
@@ -47,7 +45,7 @@ final class TemplateTest extends TestCase
     {
         $parameter = new Parameter('key', 'value');
 
-        $template = new Template('name', $this->givenExampleFilesystem());
+        $template = new Template('name', $this->givenExampleMountManager());
         $template->setAuthor('Mike');
         $template->setCopyright('copyright');
         $template->setDescription('description');
@@ -73,7 +71,7 @@ final class TemplateTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $template = new Template('name', $this->givenExampleFilesystem());
+        $template = new Template('name', $this->givenExampleMountManager());
         $template['key'] = 'value';
     }
 
@@ -84,7 +82,7 @@ final class TemplateTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $template = new Template('name', $this->givenExampleFilesystem());
+        $template = new Template('name', $this->givenExampleMountManager());
         $template->setVersion('abc');
     }
 
@@ -93,7 +91,7 @@ final class TemplateTest extends TestCase
      */
     public function testThatWeCanCheckIfATransformationIsRegistered() : void
     {
-        $template = new Template('name', $this->givenExampleFilesystem());
+        $template = new Template('name', $this->givenExampleMountManager());
         $transformation = new Transformation($template, '', '', '', '');
         $template['key'] = $transformation;
 
@@ -106,7 +104,7 @@ final class TemplateTest extends TestCase
      */
     public function testThatWeCanUnsetATransformation() : void
     {
-        $template = new Template('name', $this->givenExampleFilesystem());
+        $template = new Template('name', $this->givenExampleMountManager());
         $transformation = new Transformation($template, '', '', '', '');
         $template['key'] = $transformation;
 
@@ -122,7 +120,7 @@ final class TemplateTest extends TestCase
      */
     public function testThatWeCanCountTheNumberOfTransformations() : void
     {
-        $template = new Template('name', $this->givenExampleFilesystem());
+        $template = new Template('name', $this->givenExampleMountManager());
         $transformation = new Transformation($template, '', '', '', '');
         $template['key'] = $transformation;
 
@@ -134,7 +132,7 @@ final class TemplateTest extends TestCase
      */
     public function testThatWeCanIterateOnTheTransformations() : void
     {
-        $template = new Template('name', $this->givenExampleFilesystem());
+        $template = new Template('name', $this->givenExampleMountManager());
         $transformation = new Transformation($template, '', '', '', '');
         $template['key'] = $transformation;
 
@@ -149,7 +147,7 @@ final class TemplateTest extends TestCase
     {
         $parameter = new Parameter('key', 'value');
 
-        $template = new Template('name', $this->givenExampleFilesystem());
+        $template = new Template('name', $this->givenExampleMountManager());
         $transformation = new Transformation($template, '', '', '', '');
         $template['key'] = $transformation;
         $template->setParameter('key', $parameter);
@@ -159,8 +157,8 @@ final class TemplateTest extends TestCase
         $this->assertSame(['key' => $parameter], $transformation->getParameters());
     }
 
-    private function givenExampleFilesystem() : Filesystem
+    private function givenExampleMountManager() : MountManager
     {
-        return $this->faker()->fileSystem();
+        return new MountManager();
     }
 }

--- a/tests/unit/phpDocumentor/Transformer/TransformationTest.php
+++ b/tests/unit/phpDocumentor/Transformer/TransformationTest.php
@@ -41,12 +41,15 @@ final class TransformationTest extends m\Adapter\Phpunit\MockeryTestCase
     /** @var string */
     private $artifact = 'artifactString';
 
+    /** @var Template */
+    private $template;
+
     /**
      * Initializes the fixture and dependencies for this testcase.
      */
     protected function setUp() : void
     {
-        $this->template = new Template('My Template', $this->faker()->fileSystem());
+        $this->template = $this->faker()->template('My Template');
         $this->fixture = new Transformation(
             $this->template,
             $this->query,

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactoryTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
+namespace phpDocumentor\Transformer\Writer\Twig;
+
+use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Faker\Faker;
+use phpDocumentor\Transformer\Router\Router;
+use phpDocumentor\Transformer\Template\Parameter;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Extension\DebugExtension;
+use Twig\Loader\ChainLoader;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Transformer\Writer\Twig\EnvironmentFactory
+ * @covers ::__construct
+ * @covers ::<private>
+ */
+final class EnvironmentFactoryTest extends TestCase
+{
+    use Faker;
+
+    /**
+     * @uses \phpDocumentor\Descriptor\ProjectDescriptor
+     * @uses \phpDocumentor\Transformer\Writer\Twig\LinkRenderer
+     *
+     * @covers ::create
+     */
+    public function testItCreatesATwigEnvironmentWithThephpDocumentorExtension() : void
+    {
+        $router = $this->prophesize(Router::class);
+        $factory = new EnvironmentFactory(new LinkRenderer($router->reveal()));
+        $transformation = $this->faker()->transformation();
+
+        $environment = $factory->create(new ProjectDescriptor('name'), $transformation, '/home');
+
+        $this->assertInstanceOf(Environment::class, $environment);
+        $this->assertCount(4, $environment->getExtensions());
+        $this->assertTrue($environment->hasExtension(Extension::class));
+    }
+
+    /**
+     * @uses \phpDocumentor\Descriptor\ProjectDescriptor
+     * @uses \phpDocumentor\Transformer\Writer\Twig\LinkRenderer
+     *
+     * @covers ::create
+     */
+    public function testItCreatesATwigEnvironmentWithTheCorrectTemplateLoaders() : void
+    {
+        $router = $this->prophesize(Router::class);
+        $factory = new EnvironmentFactory(new LinkRenderer($router->reveal()));
+        $transformation = $this->faker()->transformation();
+        $mountManager = $transformation->template()->files();
+
+        $environment = $factory->create(new ProjectDescriptor('name'), $transformation, '/home');
+
+        /** @var ChainLoader $loader */
+        $loader = $environment->getLoader();
+
+        $this->assertInstanceOf(ChainLoader::class, $loader);
+        $this->assertEquals(
+            [
+                new FlySystemLoader($mountManager->getFilesystem('templates')),
+                new FlySystemLoader($mountManager->getFilesystem('template')),
+            ],
+            $loader->getLoaders()
+        );
+    }
+
+    /**
+     * @uses \phpDocumentor\Descriptor\ProjectDescriptor
+     * @uses \phpDocumentor\Transformer\Writer\Twig\LinkRenderer
+     * @uses \phpDocumentor\Transformer\Template\Parameter
+     *
+     * @covers ::create
+     */
+    public function testTheCreatedEnvironmentHasTheDebugExtensionWhenTheCorrectParameterIsSet() : void
+    {
+        $router = $this->prophesize(Router::class);
+        $factory = new EnvironmentFactory(new LinkRenderer($router->reveal()));
+        $transformation = $this->faker()->transformation();
+        $transformation->setParameters([new Parameter('twig-debug', 'true')]);
+
+        $environment = $factory->create(new ProjectDescriptor('name'), $transformation, '/home');
+
+        $this->assertTrue($environment->isDebug());
+        $this->assertTrue($environment->isAutoReload());
+        $this->assertInstanceOf(Environment::class, $environment);
+        $this->assertCount(5, $environment->getExtensions());
+        $this->assertTrue($environment->hasExtension(Extension::class));
+        $this->assertTrue($environment->hasExtension(DebugExtension::class));
+    }
+}


### PR DESCRIPTION
We want to load our twig templates using FlySystem's filesystems because
that enables us to more easily deal with templates inside and outside of
phpDocumentor's PHAR file and will simplify file handling.

TODO:

- [x] Unit tests
- [ ] Behat tests
- [x] Cleanup