### PR TITLE
Add initial e2e test for Default template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-# IDE Shizzle; it is recommended to use a global .gitignore for this but since this is an OSS project we want to make
-# it easy to contribute
-.idea
-/nbproject/private/
-.buildpath
-.project
-.settings
-
 # No need to version the binary files of other tools
 bin/jsonlint*
 bin/validate-json*
@@ -14,21 +6,26 @@ bin/var-dump-server
 
 # Build folder and vendor folder are generated code; no need to version this
 build/*
+tests/features/assets/projects/MariosPizzeria/build/*
 vendor/*
+node_modules/*
 tools/
 temp/
 var/*
 *.phar
-screenshots
+cypress/screenshots
+cypress/videos
 .phpunit.result.cache
 
 # IDEs and editors
-/.idea
+.idea
+/nbproject/private/
+.buildpath
 .project
+.settings/
 .classpath
 .c9/
 *.launch
-.settings/
 *.sublime-workspace
 *.swp
 *.bkp

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,15 @@ pre-commit-test: phpcs phpstan test
 .PHONY: shell
 shell:
 	CURRENT_UID=$(shell id -u):$(shell id -g) docker-compose run --rm -v ${CURDIR}:/opt/phpdoc -w /opt/phpdoc --entrypoint=/bin/bash phpdoc
+
+.PHONY: npm-install
+npm-install:
+	docker run -it --rm -v ${CURDIR}:/opt/phpdoc -w /opt/phpdoc node npm install
+
+.PHONY: marios
+example-marios:
+	CURRENT_UID=$(shell id -u):$(shell id -g) docker-compose run --rm -v ${CURDIR}:/opt/phpdoc -w /opt/phpdoc/tests/features/assets/projects/MariosPizzeria phpdoc --template=default
+
+.PHONY: test-template
+test-template: npm-install example-marios
+	docker run -it --rm -v ${CURDIR}:/e2e -w /e2e cypress/included:3.2.0

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -45,6 +45,7 @@ parameters:
           - 'tags'
           - 'type'
       'phpDocumentor\Descriptor\Tag\ParamDescriptor': ['type']
+      'phpDocumentor\Descriptor\Tag\VarDescriptor': ['type']
       'phpDocumentor\Descriptor\Tag\ReturnDescriptor': ['type']
       'phpDocumentor\Descriptor\Tag\SeeDescriptor': ['reference']
       'phpDocumentor\Descriptor\Tag\UsesDescriptor': ['reference']

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,4 @@
+{
+  "pluginsFile": false,
+  "supportFile": false
+}

--- a/cypress/integration/frontpage.spec.js
+++ b/cypress/integration/frontpage.spec.js
@@ -1,0 +1,18 @@
+describe('Frontpage', function() {
+    before(function(){
+        cy.visit('tests/features/assets/projects/MariosPizzeria/build/api/index.html');
+    });
+
+    it('Has "Documentation" as title', function() {
+        cy.get('.phpdocumentor-title').contains("Documentation");
+    });
+
+    it('Has a search bar', function() {
+        cy.get('.phpdocumentor-sidebar__category-header').contains("Search");
+        cy.get('.phpdocumentor-field.phpdocumentor-search__field');
+    });
+
+    it('The "Marios" namespace in the sidebar', function() {
+        cy.get('.phpdocumentor-sidebar').contains("Marios");
+    });
+});

--- a/data/templates/default/base.html.twig
+++ b/data/templates/default/base.html.twig
@@ -10,6 +10,10 @@
     <link rel="stylesheet" href="{{ path('css/normalize.css') }}">
     <link rel="stylesheet" href="{{ path('css/template.css') }}">
     <link rel="icon" href="{{ path('images/favicon.ico') }}"/>
+    <script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.4.6/fuse.min.js"></script>
+    <script src="{{ path('js/search.js') }}"></script>
+    <script defer src="{{ path('js/searchIndex.js') }}"></script>
 </head>
 <body>
 <header class="phpdocumentor-top-header"></header>
@@ -19,7 +23,20 @@
     </section>
 </header>
 <main class="phpdocumentor">
-{% block content %}{% endblock %}
+    <div class="phpdocumentor-section">
+        {% include 'sidebar.html.twig' %}
+
+        <div class="nine phpdocumentor-columns phpdocumentor-content">
+        {% block content %}{% endblock %}
+            <div data-search-results class="phpdocumentor-search-results phpdocumentor-search-results--hidden">
+
+                <h2>Search results</h2>
+                <ul class="phpdocumentor-search-results__entries">
+
+                </ul>
+            </div>
+        </div>
+    </div>
 </main>
 
 </body>

--- a/data/templates/default/class.html.twig
+++ b/data/templates/default/class.html.twig
@@ -1,92 +1,128 @@
 {% extends 'base.html.twig' %}
 
 {% block content %}
-    <div class="phpdocumentor-section">
-        {% include 'sidebar.html.twig' %}
+    {% include 'breadcrumbs.html.twig' %}
 
-        <div class="nine phpdocumentor-columns">
-            {% include 'breadcrumbs.html.twig' %}
-
-            <h2 class="phpdocumentor-content__title">
-                {{ node.name }}
-                {% if node.parent %}
-                    <span class="phpdocumentor-class__extends">
-                    extends <a href="{{ link(node.parent) }}">{{ node.parent.name }}</a>
+    <h2 class="phpdocumentor-content__title">
+        {{ node.name }}
+        {% if node.parent %}
+            <span class="phpdocumentor-class__extends">
+                    extends {{ node.parent|route('class:short') }}
                 </span>
-                {% endif %}
-                {% if node.interfaces|length > 0 %}
-                    <span class="phpdocumentor-class__implements">
+        {% endif %}
+        {% if node.interfaces|length > 0 %}
+            <span class="phpdocumentor-class__implements">
                         implements
                         {% for interface in node.interfaces %}
-                            <a href="{{ link(interface) }}">{{ interface.name }}</a>{% if not loop.last %}, {% endif %}
+                            {{ interface|route('class:short') }}{% if not loop.last %}, {% endif %}
                         {% endfor %}
                     </span>
-                {% endif %}
-                {% if node.usedTraits|length > 0 %}
-                    <span class="phpdocumentor-class__extends">
+        {% endif %}
+        {% if node.usedTraits|length > 0 %}
+            <span class="phpdocumentor-class__extends">
                         Uses
                         {% for trait in node.usedTraits %}
-                            <a href="{{ link(trait) }}">{{ trait.name }}</a>{% if not loop.last %}, {% endif %}
+                            {{ trait|route('class:short') }}{% if not loop.last %}, {% endif %}
                         {% endfor %}
                     </span>
-                {% endif %}
-            </h2>
+        {% endif %}
+    </h2>
 
-            <p class="phpdocumentor-class__summary">{{ node.summary }}</p>
-            <section class="phpdocumentor-class__description">{{ node.description|markdown }}</section>
+    <p class="phpdocumentor-class__summary">{{ node.summary }}</p>
+    <section class="phpdocumentor-class__description">{{ node.description|markdown }}</section>
 
-            <h3>Table of Contents</h3>
-            <table class="phpdocumentor-table_of_contents">
-                {% for constant in node.constants %}
-                    <tr>
-                        <th class="phpdocumentor-heading">{{ constant.name }}</th>
-                        <td class="phpdocumentor-cell">{{ constant.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ constant.value }}</td>
-                    </tr>
-                {% endfor %}
-                {% for property in node.properties %}
-                    <tr>
-                        <th class="phpdocumentor-heading">${{ property.name }}</th>
-                        <td class="phpdocumentor-cell">{{ property.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ property.types|route('class:short')|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-                {% for property in node.magicProperties %}
-                    <tr>
-                        <th class="phpdocumentor-heading">${{ property.name }}</th>
-                        <td class="phpdocumentor-cell">{{ property.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ property.types|route('class:short')|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-                {% for property in node.inheritedProperties %}
-                    <tr>
-                        <th class="phpdocumentor-heading">${{ property.name }}</th>
-                        <td class="phpdocumentor-cell">{{ property.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ property.types|route('class:short')|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-                {% for method in node.methods %}
-                    <tr>
-                        <th class="phpdocumentor-heading">{{ method.name }}()</th>
-                        <td class="phpdocumentor-cell">{{ method.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ method.response.types|route|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-                {% for method in node.magicMethods %}
-                    <tr>
-                        <th class="phpdocumentor-heading">{{ method.name }}()</th>
-                        <td class="phpdocumentor-cell">{{ method.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ method.response.types|route|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-                {% for method in node.inheritedMethods %}
-                    <tr>
-                        <th class="phpdocumentor-heading">{{ method.parent.name }}::{{ method.name }}()</th>
-                        <td class="phpdocumentor-cell">{{ method.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ method.response.types|route|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-            </table>
-        </div>
-    </div>
+    <h3>Table of Contents</h3>
+    <table class="phpdocumentor-table_of_contents">
+        {% for constant in node.constants %}
+            <tr>
+                <th class="phpdocumentor-heading"><a href="{{ link(constant) }}">{{ constant.name }}</a></th>
+                <td class="phpdocumentor-cell">{{ constant.summary }}</td>
+                <td class="phpdocumentor-cell">{{ constant.value }}</td>
+            </tr>
+        {% endfor %}
+        {% for property in node.properties %}
+            <tr>
+                <th class="phpdocumentor-heading"><a href="{{ link(property) }}">${{ property.name }}</a></th>
+                <td class="phpdocumentor-cell">{{ property.summary }}</td>
+                <td class="phpdocumentor-cell">{{ property.type|route('class:short')|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+        {% for property in node.magicProperties %}
+            <tr>
+                <th class="phpdocumentor-heading"><a href="{{ link(property) }}">${{ property.name }}</a></th>
+                <td class="phpdocumentor-cell">{{ property.summary }}</td>
+                <td class="phpdocumentor-cell">{{ property.type|route('class:short')|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+        {% for property in node.inheritedProperties %}
+            <tr>
+                <th class="phpdocumentor-heading"><a href="{{ link(property) }}">${{ property.name }}</a></th>
+                <td class="phpdocumentor-cell">{{ property.summary }}</td>
+                <td class="phpdocumentor-cell">{{ property.type|route('class:short')|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+        {% for method in node.methods %}
+            <tr>
+                <th class="phpdocumentor-heading"><a href="{{ link(method) }}">{{ method.name }}()</a></th>
+                <td class="phpdocumentor-cell">{{ method.summary }}</td>
+                <td class="phpdocumentor-cell">{{ method.response.type|route('class:short')|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+        {% for method in node.magicMethods %}
+            <tr>
+                <th class="phpdocumentor-heading"><a href="{{ link(method) }}">{{ method.name }}()</a></th>
+                <td class="phpdocumentor-cell">{{ method.summary }}</td>
+                <td class="phpdocumentor-cell">{{ method.response.type|route('class:short')|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+        {% for method in node.inheritedMethods %}
+            <tr>
+                <th class="phpdocumentor-heading"><a href="{{ link(method) }}">{{ method.name }}()</a></th>
+                <td class="phpdocumentor-cell">{{ method.summary }}</td>
+                <td class="phpdocumentor-cell">{{ method.response.type|route('class:short')|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+
+    {% if node.constants|length > 0 %}
+        <section>
+            <h3 class="phpdocumentor-constants__header">Constants</h3>
+            {% for constant in node.constants %}
+                {% include 'constant.html.twig' %}
+            {% endfor %}
+            {% for constant in node.inheritedConstants %}
+                {% include 'constant.html.twig' %}
+            {% endfor %}
+        </section>
+    {% endif %}
+
+    {% if node.properties|length > 0 or node.magicProperties|length > 0 or node.inheritedProperties|length > 0 %}
+        <section>
+            <h3 class="phpdocumentor-properties__header">Properties</h3>
+            {% for property in node.properties %}
+                {% include 'property.html.twig' %}
+            {% endfor %}
+            {% for property in node.magicProperties %}
+                {% include 'property.html.twig' %}
+            {% endfor %}
+            {% for property in node.inheritedProperties %}
+                {% include 'property.html.twig' %}
+            {% endfor %}
+        </section>
+    {% endif %}
+
+    {% if node.methods|length > 0 or node.magicMethods|length > 0 or node.inheritedMethods|length > 0 %}
+        <section>
+            <h3 class="phpdocumentor-methods__header">Methods</h3>
+            {% for method in node.methods %}
+                {% include 'method.html.twig' %}
+            {% endfor %}
+            {% for method in node.magicMethods %}
+                {% include 'method.html.twig' %}
+            {% endfor %}
+            {% for method in node.inheritedMethods %}
+                {% include 'method.html.twig' %}
+            {% endfor %}
+        </section>
+    {% endif %}
 {% endblock %}

--- a/data/templates/default/constant.html.twig
+++ b/data/templates/default/constant.html.twig
@@ -1,0 +1,10 @@
+<a id="constant_{{ constant.name }}"></a>
+<section class="phpdocumentor-constant">
+    <h4 class="phpdocumentor-constant__signature">
+        ${{ constant.name }}
+        {% if constant.type %}: {{ constant.type|route('class:short')|join('|')|raw }}{% endif %}
+        = {{ constant.value }}
+    </h4>
+    <p class="phpdocumentor-summary">{{ constant.summary }}</p>
+    <section class="phpdocumentor-description">{{ constant.description }}</section>
+</section>

--- a/data/templates/default/css/template.css
+++ b/data/templates/default/css/template.css
@@ -1,86 +1,93 @@
 :root {
-    --container-width: 960px;
-
-    --font-primary: 'Source Sans Pro', Helvetica, Arial, sans-serif;
-    --font-secondary: 'Source Sans Pro', Helvetica, Arial, sans-serif;
-    --line-height--primary: 1.6;
-    --letter-spacing--primary: .05rem;
-
-    --text-base-size: 1em;
-    --text-scale-ratio: 1.2;
-    --text-color: #222;
-
-    --text-xxs: calc(var(--text-base-size) / var(--text-scale-ratio) / var(--text-scale-ratio) / var(--text-scale-ratio));
-    --text-xs: calc(var(--text-base-size) / var(--text-scale-ratio) / var(--text-scale-ratio));
-    --text-sm: calc(var(--text-base-size) / var(--text-scale-ratio));
-    --text-md: var(--text-base-size);
-    --text-lg: calc(var(--text-base-size) * var(--text-scale-ratio));
-    --text-xl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio));
-    --text-xxl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio));
-    --text-xxxl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio));
-    --text-xxxxl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio));
-    --text-xxxxxl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio));
+    --code-background-color: var(--primary-color-lighter);
 
     --spacing-base-size: 1rem;
-    --spacing-scale-ratio: 1.5;
+    --text-base-size: 1em;
+    --header-bg-color: var(--primary-color);
+    --button-border-color: var(--primary-color-darken);
 
-    --spacing-xxxs: calc(var(--spacing-base-size) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio));
-    --spacing-xxs: calc(var(--spacing-base-size) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio));
-    --spacing-xs: calc(var(--spacing-base-size) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio));
-    --spacing-sm: calc(var(--spacing-base-size) / var(--spacing-scale-ratio));
-    --spacing-md: var(--spacing-base-size);
-    --spacing-lg: calc(var(--spacing-base-size) * var(--spacing-scale-ratio));
-    --spacing-xl: calc(var(--spacing-base-size) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio));
-    --spacing-xxl: calc(var(--spacing-base-size) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio));
-    --spacing-xxxl: calc(var(--spacing-base-size) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio));
-
-    --border-radius-base-size: 4px;
-
+    --code-border-color: var(--primary-color-darken);
+    --button-color: transparent;
     --primary-color: hsl(96, 57%, 60%);
+    --popover-background-color: hsla(96, 57%, 95%, 0.9);
+    --text-color: #222;
     --primary-color-darken: hsl(96, 57%, 40%);
     --primary-color-darker: hsl(96, 57%, 20%);
-
-    --top-header-bg-color: #333;
-    --top-header-text-color: white;
-    --top-header-height: calc(var(--text-sm) + 2 * var(--spacing-sm));
-    --header-bg-color: var(--primary-color);
-    --link-color-primary: var(--primary-color-darken);
-    --link-hover-color-primary: var(--primary-color-darker);
+    --primary-color-lighten: hsl(96, 57%, 80%);
+    --primary-color-lighter: hsl(96, 57%, 99%);
     --button-color-primary: var(--primary-color);
-    --button-text-color-primary: white;
-    --button-color: transparent;
-    --button-border-color: var(--primary-color-darken);
-    --button-text-color: #555;
-    --form-field-color: #fff;
+    --link-color-primary: var(--primary-color-darken);
     --form-field-border-color: #D1D1D1;
+    --form-field-color: #fff;
+    --top-header-bg-color: #333;
+
+    --top-header-height: calc(var(--text-sm) + 2 * var(--spacing-sm));
+    --top-header-text-color: white;
+
+    --line-height--primary: 1.6;
+    --link-hover-color-primary: var(--primary-color-darker);
+    --spacing-lg: calc(var(--spacing-base-size) * var(--spacing-scale-ratio));
+    --text-lg: calc(var(--text-base-size) * var(--text-scale-ratio));
+    --spacing-md: var(--spacing-base-size);
+    --text-md: var(--text-base-size);
+    --font-primary: 'Source Sans Pro', Helvetica, Arial, sans-serif;
+    --border-radius-base-size: 3px;
+    --spacing-scale-ratio: 1.5;
+
+    --text-scale-ratio: 1.2;
+
+    --font-secondary: 'Source Sans Pro', Helvetica, Arial, sans-serif;
+    --table-separator-color: var(--primary-color-lighten);
+    --spacing-sm: calc(var(--spacing-base-size) / var(--spacing-scale-ratio));
+    --text-sm: calc(var(--text-base-size) / var(--text-scale-ratio));
+    --letter-spacing--primary: .05rem;
+
+    --button-text-color: #555;
 
     --title-text-color: white;
+    --button-text-color-primary: white;
+
     --title-text-shadow-color: var(--primary-color-darker);
+    --container-width: 960px;
+    --spacing-xl: calc(var(--spacing-base-size) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio));
+    --text-xl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio));
+    --spacing-xs: calc(var(--spacing-base-size) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio));
+    --text-xs: calc(var(--text-base-size) / var(--text-scale-ratio) / var(--text-scale-ratio));
+    --spacing-xxl: calc(var(--spacing-base-size) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio));
+    --text-xxl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio));
+    --spacing-xxs: calc(var(--spacing-base-size) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio));
+    --text-xxs: calc(var(--text-base-size) / var(--text-scale-ratio) / var(--text-scale-ratio) / var(--text-scale-ratio));
+    --spacing-xxxl: calc(var(--spacing-base-size) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio) * var(--spacing-scale-ratio));
+    --text-xxxl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio));
+    --spacing-xxxs: calc(var(--spacing-base-size) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio) / var(--spacing-scale-ratio));
+
+    --text-xxxxl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio));
+    --text-xxxxxl: calc(var(--text-base-size) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio) * var(--text-scale-ratio));
 }
 
 /* Grid
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .phpdocumentor-section {
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: var(--container-width);
+    padding: 0 var(--spacing-lg);
     position: relative;
     width: 100%;
-    max-width: var(--container-width);
-    margin: 0 auto;
-    padding: 0 var(--spacing-lg);
-    box-sizing: border-box;
 }
 
 .phpdocumentor-column,
 .phpdocumentor-columns {
-    width: 100%;
-    float: left;
     box-sizing: border-box;
+    float: left;
+    width: 100%;
 }
 
 /* For devices larger than 400px */
 @media (min-width: 400px) {
     .phpdocumentor-section {
-        width: 85%;
         padding: 0;
+        width: 85%;
     }
 }
 
@@ -146,8 +153,8 @@
     }
 
     .twelve.phpdocumentor-columns {
-        width: 100%;
         margin-left: 0;
+        width: 100%;
     }
 
     .one-third.phpdocumentor-column {
@@ -237,11 +244,16 @@
 /* Base Styles
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 body {
-    font-size: var(--text-md);
-    line-height: var(--line-height--primary);
-    font-family: var(--font-primary);
-    letter-spacing: var(--letter-spacing--primary);
     color: var(--text-color);
+    font-family: var(--font-primary);
+    font-size: var(--text-md);
+    letter-spacing: var(--letter-spacing--primary);
+    line-height: var(--line-height--primary);
+}
+
+/* Used for screen readers and such */
+.visually-hidden {
+    display: none;
 }
 
 /* Typography
@@ -252,50 +264,56 @@ body {
 .phpdocumentor h4,
 .phpdocumentor h5,
 .phpdocumentor h6 {
-    margin-top: 0;
     margin-bottom: var(--spacing-lg);
+    margin-top: var(--spacing-lg);
 }
 
 .phpdocumentor h1 {
     font-size: var(--text-xxxxl);
-    line-height: 1.2;
     letter-spacing: .05rem;
+    line-height: 1.2;
+    margin-top: 0;
 }
 
 .phpdocumentor h2 {
     font-size: var(--text-xxxl);
-    line-height: 1.25;
     letter-spacing: .05rem;
+    line-height: 1.25;
+    margin-top: 0;
 }
 
 .phpdocumentor h3 {
     font-size: var(--text-xxl);
-    line-height: 1.3;
     letter-spacing: .05rem;
+    line-height: 1.3;
 }
 
 .phpdocumentor h4 {
     font-size: var(--text-xl);
-    line-height: 1.35;
     letter-spacing: .025rem;
+    line-height: 1.35;
+    margin-bottom: var(--spacing-md);
 }
 
 .phpdocumentor h5 {
     font-size: var(--text-lg);
-    line-height: 1.5;
     letter-spacing: .0125rem;
+    line-height: 1.5;
+    margin-bottom: var(--spacing-md);
+    margin-top: var(--spacing-md);
 }
 
 .phpdocumentor h6 {
     font-size: var(--text-md);
-    line-height: var(--line-height--primary);
     letter-spacing: 0;
+    line-height: var(--line-height--primary);
+    margin-bottom: var(--spacing-md);
+    margin-top: var(--spacing-md);
 }
 
 .phpdocumentor p {
     margin-top: 0;
 }
-
 
 /* Links
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
@@ -307,60 +325,58 @@ body {
     color: var(--link-hover-color-primary);
 }
 
-
 /* Buttons
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .phpdocumentor-button {
-    display: inline-block;
-    height: 38px;
-    padding: 0 var(--spacing-xxl);
+    background-color: var(--button-color);
+    border: 1px solid var(--button-border-color);
+    border-radius: var(--border-radius-base-size);
+    box-sizing: border-box;
     color: var(--button-text-color);
-    text-align: center;
+    cursor: pointer;
+    display: inline-block;
     font-size: var(--text-sm);
     font-weight: 600;
-    line-height: 38px;
+    height: 38px;
     letter-spacing: .1rem;
-    text-transform: uppercase;
+    line-height: 38px;
+    padding: 0 var(--spacing-xxl);
+    text-align: center;
     text-decoration: none;
+    text-transform: uppercase;
     white-space: nowrap;
-    background-color: var(--button-color);
-    border-radius: var(--border-radius-base-size);
-    border: 1px solid var(--button-border-color);
-    cursor: pointer;
-    box-sizing: border-box;
 }
 
 .phpdocumentor-button:hover,
 .phpdocumentor-button:focus {
-    color: #333;
     border-color: #888;
+    color: #333;
     outline: 0;
 }
 
 .phpdocumentor-button.button-primary {
-    color: var(--button-text-color-primary);
     background-color: var(--button-color-primary);
     border-color: var(--button-color-primary);
+    color: var(--button-text-color-primary);
 }
 
 .phpdocumentor-button.phpdocumentor-button--primary:hover,
 .phpdocumentor-button.phpdocumentor-button--primary:focus {
-    color: var(--button-text-color-primary);
     background-color: var(--link-color-primary);
     border-color: var(--link-color-primary);
+    color: var(--button-text-color-primary);
 }
-
 
 /* Forms
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .phpdocumentor-field {
-    height: 38px;
-    padding: var(--spacing-xxxs) var(--spacing-xxs); /* The 6px vertically centers text on FF, ignored by Webkit */
     background-color: var(--form-field-color);
     border: 1px solid var(--form-field-border-color);
     border-radius: var(--border-radius-base-size);
     box-shadow: none;
     box-sizing: border-box;
+    height: 38px;
+    padding: var(--spacing-xxxs) var(--spacing-xxs); /* The 6px vertically centers text on FF, ignored by Webkit */
 }
 
 /* Removes awkward default styles on some inputs for iOS */
@@ -372,15 +388,15 @@ input[type="tel"],
 input[type="url"],
 input[type="password"],
 textarea {
-    -webkit-appearance: none;
     -moz-appearance: none;
+    -webkit-appearance: none;
     appearance: none;
 }
 
 .phpdocumentor-textarea {
     min-height: 65px;
-    padding-top: var(--spacing-xxxs);
     padding-bottom: var(--spacing-xxxs);
+    padding-top: var(--spacing-xxxs);
 }
 
 .phpdocumentor-field:focus {
@@ -394,8 +410,8 @@ textarea {
 }
 
 .phpdocumentor-fieldset {
-    padding: 0;
     border-width: 0;
+    padding: 0;
 }
 
 input[type="checkbox"].phpdocumentor-field,
@@ -405,10 +421,9 @@ input[type="radio"].phpdocumentor-field {
 
 .phpdocumentor-label > .phpdocumentor-label--body {
     display: inline-block;
-    margin-left: var(--spacing-xs);
     font-weight: normal;
+    margin-left: var(--spacing-xs);
 }
-
 
 /* Lists
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
@@ -421,16 +436,16 @@ ol.phpdocumentor-list {
 }
 
 ol.phpdocumentor-list, ul.phpdocumentor-list {
-    padding-left: 0;
     margin-top: 0;
+    padding-left: 0;
 }
 
 ul.phpdocumentor-list ul.phpdocumentor-list,
 ul.phpdocumentor-list ol.phpdocumentor-list,
 ol.phpdocumentor-list ol.phpdocumentor-list,
 ol.phpdocumentor-list ul.phpdocumentor-list {
-    margin: var(--spacing-xs) 0 var(--spacing-xs) calc(var(--spacing-xs) * 2);
     font-size: var(--text-sm);
+    margin: var(--spacing-xs) 0 var(--spacing-xs) calc(var(--spacing-xs) * 2);
 }
 
 li.phpdocumentor-list {
@@ -450,37 +465,33 @@ ul.phpdocumentor-breadcrumbs > li {
 }
 
 ul.phpdocumentor-breadcrumbs > li + li:before {
-    padding: 0 var(--spacing-xxs);
     color: #ccc;
     content: "\\\A0";
+    padding: 0 var(--spacing-xxs);
 }
 
 /* Code
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .phpdocumentor-code {
-    padding: .2rem .5rem;
-    margin: 0 .2rem;
-    font-size: var(--text-sm);
-    white-space: nowrap;
-    background: #F1F1F1;
-    border: 1px solid #E1E1E1;
+    background: var(--code-background-color);
+    border: 1px solid var(--code-border-color);
     border-radius: var(--border-radius-base-size);
+    font-size: var(--text-sm);
+    padding: var(--spacing-xs) var(--spacing-sm);
 }
 
 pre > .phpdocumentor-code {
     display: block;
-    padding: var(--spacing-md) var(--spacing-xl);
     white-space: pre;
 }
-
 
 /* Tables
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 th.phpdocumentor-heading,
 td.phpdocumentor-cell {
+    border-bottom: 1px solid var(--table-separator-color);
     padding: var(--spacing-sm) var(--spacing-md);
     text-align: left;
-    border-bottom: 1px solid #E1E1E1;
 }
 
 th.phpdocumentor-heading:first-child,
@@ -493,7 +504,6 @@ td.phpdocumentor-cell:last-child {
     padding-right: 0;
 }
 
-
 /* Spacing
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .phpdocumentor-button {
@@ -501,7 +511,7 @@ td.phpdocumentor-cell:last-child {
 }
 
 .phpdocumentor-field {
-    margin-bottom: var(--spacing-xl);
+    margin-bottom: var(--spacing-md);
 }
 
 .phpdocumentor pre,
@@ -516,17 +526,16 @@ td.phpdocumentor-cell:last-child {
     margin-bottom: var(--spacing-md);
 }
 
-
 /* Utilities
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .phpdocumentor-full-width {
-    width: 100%;
     box-sizing: border-box;
+    width: 100%;
 }
 
 .phpdocumentor-max-full-width {
-    max-width: 100%;
     box-sizing: border-box;
+    max-width: 100%;
 }
 
 .phpdocumentor-pull-right {
@@ -537,14 +546,13 @@ td.phpdocumentor-cell:last-child {
     float: left;
 }
 
-
 /* Misc
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 .phpdocumentor-line {
-    margin-top: var(--spacing-xxl);
-    margin-bottom: var(--spacing-xxl);
-    border-width: 0;
     border-top: 1px solid #E1E1E1;
+    border-width: 0;
+    margin-bottom: var(--spacing-xxl);
+    margin-top: var(--spacing-xxl);
 }
 
 /* Clearing
@@ -554,23 +562,22 @@ td.phpdocumentor-cell:last-child {
 .phpdocumentor-section:after,
 .phpdocumentor-row:after,
 .phpdocumentor-cf {
+    clear: both;
     content: "";
     display: table;
-    clear: both;
 }
-
 
 /* Elements
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
 .phpdocumentor-top-header {
+    align-items: center;
     background: var(--top-header-bg-color);
-    min-height: var(--top-header-height);
-    font-size: var(--text-sm);
     color: var(--top-header-text-color);
     display: flex;
-    align-items: center;
     flex-direction: row;
+    font-size: var(--text-sm);
+    min-height: var(--top-header-height);
     padding: 0 var(--spacing-sm);
 }
 
@@ -582,20 +589,20 @@ td.phpdocumentor-cell:last-child {
 }
 
 .phpdocumentor-header:after {
-    content: '';
-    position: absolute;
-    bottom: -8px;
-    left: 0;
-    right: 0;
     border-bottom: 3px solid var(--header-bg-color);
+    bottom: -8px;
+    content: '';
+    left: 0;
+    position: absolute;
+    right: 0;
 }
 
 .phpdocumentor-title {
     color: var(--title-text-color);
-    text-shadow: 0 0 2px var(--title-text-shadow-color);
     font-size: var(--text-xxxxl);
-    line-height: 1.2;
     letter-spacing: .05rem;
+    line-height: 1.2;
+    text-shadow: 0 0 2px var(--title-text-shadow-color);
 }
 
 .phpdocumentor-summary,
@@ -610,8 +617,18 @@ td.phpdocumentor-cell:last-child {
 .phpdocumentor-class__implements {
     display: block;
     font-size: var(--text-xxs);
-    opacity: .7;
     font-weight: normal;
+    opacity: .7;
+}
+
+.phpdocumentor-description {
+    margin-bottom: var(--spacing-md);
+}
+
+.phpdocumentor-method__signature {
+    display: inline-block;
+    font-size: var(--text-sm);
+    margin-bottom: var(--spacing-md);
 }
 
 .phpdocumentor-table_of_contents {
@@ -626,6 +643,105 @@ td.phpdocumentor-cell:last-child {
 .phpdocumentor .phpdocumentor-sidebar__root-namespace {
     font-size: var(--text-md);
     margin-bottom: var(--spacing-xxs);
+}
+
+.phpdocumentor-constant:not(:last-child),
+.phpdocumentor-method:not(:last-child),
+.phpdocumentor-property:not(:last-child) {
+    border-bottom: 1px solid var(--primary-color-lighten);
+    padding-bottom: var(--spacing-lg);
+}
+
+.phpdocumentor-constants__header,
+.phpdocumentor-properties__header,
+.phpdocumentor-methods__header {
+    border-bottom: 2px solid var(--primary-color-darken);
+    padding-bottom: var(--spacing-md);
+}
+
+.phpdocumentor-content {
+    position: relative;
+}
+
+.phpdocumentor-search-results {
+    backdrop-filter: blur(5px);
+    background: var(--popover-background-color);
+    min-height: 100%;
+    left: calc(var(--spacing-lg) * -1);
+    position: absolute;
+    right: calc(var(--spacing-lg) * -1);
+    top: 0;
+    padding: 0 var(--spacing-lg);
+    opacity: 1;
+    pointer-events: all;
+
+    transition: opacity .3s, background .3s;
+}
+
+.phpdocumentor-search-results--hidden {
+    background: transparent;
+    backdrop-filter: blur(0);
+    opacity: 0;
+    pointer-events: none;
+}
+
+.phpdocumentor-search-results__entries {
+    list-style: none;
+    padding: 0;
+}
+
+.phpdocumentor-search-results__entry {
+    border-bottom: 1px solid var(--table-separator-color);
+    padding: var(--spacing-sm) var(--spacing-md);
+    text-align: left;
+}
+
+.phpdocumentor-search-results__entry a {
+    display: block;
+}
+
+.phpdocumentor-search-results__entry small {
+    margin-top: var(--spacing-xs);
+    margin-bottom: var(--spacing-md);
+    color: var(--primary-color-darker);
+    display: block;
+}
+.phpdocumentor-search-results__entry h3 {
+    margin: 0;
+}
+
+.phpdocumentor-search {
+    position: relative;
+    display: none; /** disable by default for non-js flow */
+    opacity: .3; /** white-out default for loading indication */
+    transition: opacity .3s, background .3s;
+}
+.phpdocumentor-search:before {
+    content: '';
+    background: transparent;
+    left: calc(-1 * var(--spacing-md));
+    height: 100%;
+    position: absolute;
+    right: -15px;
+    z-index: -1;
+    opacity: 0;
+    transition: opacity .3s, background .3s;
+}
+
+.phpdocumentor-search--enabled {
+    display: block;
+}
+
+.phpdocumentor-search--active {
+    opacity: 1;
+}
+.phpdocumentor-search--has-results:before {
+    background: var(--popover-background-color);
+    opacity: 1;
+}
+
+.phpdocumentor-search input:disabled {
+    background-color: lightgray;
 }
 
 /* Media Queries

--- a/data/templates/default/index.html.twig
+++ b/data/templates/default/index.html.twig
@@ -1,54 +1,48 @@
 {% extends 'base.html.twig' %}
 
 {% block content %}
-    <div class="phpdocumentor-section">
-        {% include 'sidebar.html.twig' %}
+    {% include 'breadcrumbs.html.twig' %}
 
-        <div class="nine phpdocumentor-columns">
-            {% include 'breadcrumbs.html.twig' %}
+    <h2>{{ node.name == '\\' ? 'API Documentation' : node.name }}</h2>
+    {% if node.children|length > 0 %}
+        <h3>Namespaces</h3>
+        <ul>
+            {% for namespace in node.children %}
+                <li><a href="{{ link(namespace) }}">{{ namespace.name }}</a></li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 
-            <h2>{{ node.name == '\\' ? 'API Documentation' : node.name }}</h2>
-            {% if node.children|length > 0 %}
-            <h3>Namespaces</h3>
-            <ul>
-                {% for namespace in node.children %}
-                <li><a href="{{ link(namespace) }}">{{namespace.name}}</a></li>
-                {% endfor %}
-            </ul>
-            {% endif %}
+    {% if node.interfaces|length > 0 or node.classes|length > 0 %}
+        <h3>Interfaces and Classes</h3>
+        <dl>
+            {% for interface in node.interfaces %}
+                <dt><a href="{{ link(interface) }}">{{ interface.name }}</a></dt>
+                <dd>{{ interface.summary }}</dd>
+            {% endfor %}
 
-            {% if node.interfaces|length > 0 or node.classes|length > 0 %}
-            <h3>Interfaces and Classes</h3>
-            <dl>
-                {% for interface in node.interfaces %}
-                <dt><a href="{{ link(interface) }}">{{interface.name}}</a></dt>
-                <dd>{{interface.summary}}</dd>
-                {% endfor %}
+            {% for class in node.classes %}
+                <dt><a href="{{ link(class) }}">{{ class.name }}</a></dt>
+                <dd>{{ class.summary }}</dd>
+            {% endfor %}
+        </dl>
+    {% endif %}
 
-                {% for class in node.classes %}
-                <dt><a href="{{ link(class) }}">{{class.name}}</a></dt>
-                <dd>{{class.summary}}</dd>
-                {% endfor %}
-            </dl>
-            {% endif %}
+    {% if node.constants|length > 0 %}
+        <h3>Constants</h3>
+        <ul>
+            {% for constant in node.constants %}
+                <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 
-            {% if node.constants|length > 0 %}
-            <h3>Constants</h3>
-            <ul>
-                {% for constant in node.constants %}
-                <li><a href="{{ link(constant) }}">{{constant.name}}</a></li>
-                {% endfor %}
-            </ul>
-            {% endif %}
-
-            {% if node.functions|length > 0 %}
-            <h3>Functions</h3>
-            <ul>
-                {% for function in node.functions %}
-                <li><a href="{{ link(function) }}">{{function.name}}</a></li>
-                {% endfor %}
-            </ul>
-            {% endif %}
-        </div>
-    </div>
+    {% if node.functions|length > 0 %}
+        <h3>Functions</h3>
+        <ul>
+            {% for function in node.functions %}
+                <li><a href="{{ link(function) }}">{{ function.name }}</a></li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 {% endblock %}

--- a/data/templates/default/interface.html.twig
+++ b/data/templates/default/interface.html.twig
@@ -1,26 +1,20 @@
 {% extends 'base.html.twig' %}
 
 {% block content %}
-    <div class="phpdocumentor-section">
-        {% include 'sidebar.html.twig' %}
+    {% include 'breadcrumbs.html.twig' %}
 
-        <div class="nine phpdocumentor-columns">
-            {% include 'breadcrumbs.html.twig' %}
+    <h2 class="phpdocumentor-content__title">
+        {{ node.name }}
+        {% if node.parent|length > 0 %}
+            <span class="phpdocumentor-interface__extends">
+                extends
+                {% for interface in node.parents %}
+                    <a href="{{ link(interface) }}">{{ interface.name }}</a>{% if not loop.last %}, {% endif %}
+                {% endfor %}
+            </span>
+        {% endif %}
+    </h2>
 
-            <h2 class="phpdocumentor-content__title">
-                {{ node.name }}
-                {% if node.parent|length > 0 %}
-                    <span class="phpdocumentor-interface__extends">
-                        extends
-                        {% for interface in node.parents %}
-                            <a href="{{ link(interface) }}">{{ interface.name }}</a>{% if not loop.last %}, {% endif %}
-                        {% endfor %}
-                    </span>
-                {% endif %}
-            </h2>
-
-            <p class="phpdocumentor-interface__summary">{{ node.summary }}</p>
-            <section class="phpdocumentor-interface__description">{{ node.description|markdown }}</section>
-        </div>
-    </div>
+    <p class="phpdocumentor-interface__summary">{{ node.summary }}</p>
+    <section class="phpdocumentor-interface__description">{{ node.description|markdown }}</section>
 {% endblock %}

--- a/data/templates/default/method.html.twig
+++ b/data/templates/default/method.html.twig
@@ -1,0 +1,45 @@
+<a id="method_{{ method.name }}"></a>
+<section class="phpdocumentor-method">
+    <h4 class="phpdocumentor-method__name">{{ method.name }}()</h4>
+    {% if method.summary %}
+    <p class="phpdocumentor-summary">{{ method.summary }}</p>
+    {% endif %}
+    <code class="phpdocumentor-method__signature phpdocumentor-code prettyprint">
+        {{ method.visibility }}
+        {{ method.name }}(
+        {% for argument in method.arguments %}
+            {% if argument.default %}[{% endif %}{% if not loop.first %}, {% endif %}
+            ${{ argument.name }} : {{ argument.type|route('class:short')|join('|')|raw }}
+            {% if argument.default %} = {{ argument.default }} ]{% endif %}
+        {% endfor %}
+        )
+        : {{ method.response.type|route('class:short')|join('|')|raw }}
+    </code>
+
+    {% if method.description %}
+    <section class="phpdocumentor-description">{{ method.description|markdown }}</section>
+    {% endif %}
+
+    {% if method.arguments|length > 0 %}
+        <h5>Parameters</h5>
+        <dl>
+            {% for argument in method.arguments %}
+                <dt>
+                    <strong>${{ argument.name }}</strong>
+                    : {{ argument.type|route('class:short')|join('|')|raw }}
+                    {% if argument.default %} = {{ argument.default }}{% endif %}
+                </dt>
+                <dd>{{ argument.description }}</dd>
+            {% endfor %}
+        </dl>
+    {% endif %}
+
+    {% if (method.response.type and method.response.type != 'void') or method.response.description %}
+        <h5>Return values</h5>
+        {{ method.response.type|route('class:short')|join('|')|raw }}
+        {% if method.response.description %}
+            &mdash; {{ method.response.description }}
+        {% endif %}
+    {% endif %}
+
+</section>

--- a/data/templates/default/property.html.twig
+++ b/data/templates/default/property.html.twig
@@ -1,0 +1,10 @@
+<a id="property_{{ property.name }}"></a>
+<section class="phpdocumentor-property">
+    <h4 class="phpdocumentor-property__signature">
+        ${{ property.name }}
+        {% if property.type %}: {{ property.type|route('class:short')|join('|')|raw }}{% endif %}
+        {% if property.default %} = {{ property.default }}{% endif %}
+    </h4>
+    <p class="phpdocumentor-summary">{{ property.summary }}</p>
+    <section class="phpdocumentor-description">{{ property.description }}</section>
+</section>

--- a/data/templates/default/search.js.twig
+++ b/data/templates/default/search.js.twig
@@ -1,0 +1,150 @@
+// Search module for phpDocumentor
+//
+// This module is a wrapper around fuse.js that will use a given index and attach itself to a
+// search form and to a search results pane identified by the following data attributes:
+//
+// 1. data-search-form
+// 2. data-search-results
+//
+// The data-search-form is expected to have a single input element of type 'search' that will trigger searching for
+// a series of results, were the data-search-results pane is expected to have a direct UL child that will be populated
+// with rendered results.
+//
+// The search has various stages, upon loading this stage the data-search-form receives the CSS class
+// 'phpdocumentor-search--enabled'; this indicates that JS is allowed and indices are being loaded. It is recommended
+// to hide the form by default and show it when it receives this class to achieve progressive enhancement for this
+// feature.
+//
+// After loading this module, it is expected to load a search index asynchronously, for example:
+//
+//         <script defer src="js/searchIndex.js"></script>
+//
+// In this script the generated index should attach itself to the search module using the `appendIndex` function. By
+// doing it like this the page will continue loading, unhindered by the loading of the search.
+//
+// After the page has fully loaded, and all these deferred indexes loaded, the initialization of the search module will
+// be called and the form will receive the class 'phpdocumentor-search--active', indicating search is ready. At this
+// point, the input field will also have it's 'disabled' attribute removed.
+var Search = (function () {
+    var fuse;
+    var index = [];
+    var options = {
+        shouldSort: true,
+        threshold: 0.6,
+        location: 0,
+        distance: 100,
+        maxPatternLength: 32,
+        minMatchCharLength: 1,
+        keys: [
+            "fqsen",
+            "name",
+            "summary",
+            "url"
+        ]
+    };
+
+    // Credit David Walsh (https://davidwalsh.name/javascript-debounce-function)
+    // Returns a function, that, as long as it continues to be invoked, will not
+    // be triggered. The function will be called after it stops being called for
+    // N milliseconds. If `immediate` is passed, trigger the function on the
+    // leading edge, instead of the trailing.
+    function debounce(func, wait, immediate) {
+        var timeout;
+
+        return function executedFunction() {
+            var context = this;
+            var args = arguments;
+
+            var later = function () {
+                timeout = null;
+                if (!immediate) func.apply(context, args);
+            };
+
+            var callNow = immediate && !timeout;
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+            if (callNow) func.apply(context, args);
+        };
+    }
+
+    function close() {
+        var form = document.querySelector('[data-search-form]');
+        var searchResults = document.querySelector('[data-search-results]');
+
+        form.classList.toggle('phpdocumentor-search--has-results', false);
+        searchResults.classList.add('phpdocumentor-search-results--hidden');
+    }
+
+    function search(event) {
+        // prevent enter's from autosubmitting
+        event.stopPropagation();
+
+        var form = document.querySelector('[data-search-form]');
+        var searchResults = document.querySelector('[data-search-results]');
+        var searchResultEntries = document.querySelector('[data-search-results] > ul');
+
+        searchResultEntries.innerHTML = '';
+
+        if (!event.target.value) {
+            close();
+            return;
+        }
+
+        form.classList.toggle('phpdocumentor-search--has-results', true);
+        searchResults.classList.remove('phpdocumentor-search-results--hidden');
+        var results = fuse.search(event.target.value);
+
+        results.forEach(function (result) {
+            var entry = document.createElement("li");
+            entry.classList.add("phpdocumentor-search-results__entry");
+            entry.innerHTML += '<h3><a href="' + result.url + '">' + result.name + "</h3>\n";
+            entry.innerHTML += '<small>' + result.fqsen + "</small>\n";
+            entry.innerHTML += '<div class="phpdocumentor-summary">' + result.summary + '</div>';
+            searchResultEntries.appendChild(entry)
+        });
+    }
+
+    function appendIndex(added) {
+        index = index.concat(added);
+
+        // re-initialize search engine when appending an index after initialisation
+        if (typeof fuse !== 'undefined') {
+            fuse = new Fuse(index, options);
+        }
+    }
+
+    function init() {
+        fuse = new Fuse(index, options);
+
+        var form = document.querySelector('[data-search-form]');
+        var searchField = document.querySelector('[data-search-form] input[type="search"');
+
+        form.classList.add('phpdocumentor-search--active');
+
+        searchField.setAttribute('placeholder', 'Search for ..');
+        searchField.removeAttribute('disabled');
+        searchField.addEventListener('keyup', debounce(search, 300));
+
+        window.addEventListener('keyup', function (event) {
+            if (event.code === 'Escape') {
+                close();
+            }
+        });
+    }
+
+    return {
+        appendIndex,
+        init
+    }
+})();
+
+window.addEventListener('DOMContentLoaded', function () {
+    var form = document.querySelector('[data-search-form]');
+
+    // When JS is supported; show search box. Must be before including the search for it to take effect immediately
+    form.classList.add('phpdocumentor-search--enabled');
+});
+
+window.addEventListener('load', function () {
+    Search.init();
+});

--- a/data/templates/default/searchIndex.js.twig
+++ b/data/templates/default/searchIndex.js.twig
@@ -1,0 +1,12 @@
+Search.appendIndex(
+    [
+        {% for element in project.indexes.elements %}
+        {
+            "fqsen": "{{ element.fullyQualifiedStructuralElementName|e('js') }}",
+            "name": "{{ element.name|e('js') }}",
+            "summary": "{{ element.summary|e('js') }}",
+            "url": "{{ link(element) }}"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+    ]
+);

--- a/data/templates/default/sidebar.html.twig
+++ b/data/templates/default/sidebar.html.twig
@@ -1,10 +1,17 @@
 <aside class="three phpdocumentor-columns phpdocumentor-sidebar">
+    <section data-search-form class="phpdocumentor-search">
+        <h1 class="phpdocumentor-sidebar__category-header">Search</h1>
+        <label class="phpdocumentor-label">
+            <span class="visually-hidden">Search for</span>
+            <input type="search" class="phpdocumentor-field phpdocumentor-search__field" placeholder="Loading .." disabled />
+        </label>
+    </section>
     <h1 class="phpdocumentor-sidebar__category-header">API</h1>
     {% for namespace in project.namespace.children %}
-        <h2 class="phpdocumentor-sidebar__root-namespace">{{ namespace|route('class:short')|raw }}</h2>
+        <h2 class="phpdocumentor-sidebar__root-namespace">{{ namespace|route('class:short') }}</h2>
         <ul class="phpdocumentor-list">
             {% for child in namespace.children %}
-                <li><a href="{{ link(child) }}">{{ child.name }}</a></li>
+                <li>{{ child|route('class:short') }}</li>
             {% endfor %}
         </ul>
     {% endfor %}

--- a/data/templates/default/template.xml
+++ b/data/templates/default/template.xml
@@ -10,6 +10,8 @@
     <transformation writer="twig" query="indexes.classes" source="templates/default/class.html.twig" />
     <transformation writer="twig" query="indexes.interfaces" source="templates/default/interface.html.twig" />
     <transformation writer="twig" query="indexes.traits" source="templates/default/trait.html.twig" />
+    <transformation writer="twig" source="templates/default/search.js.twig" artifact="js/search.js" />
+    <transformation writer="twig" source="templates/default/searchIndex.js.twig" artifact="js/searchIndex.js" />
   </transformations>
   <parameters>
     <parameter key="twig-debug">true</parameter>

--- a/data/templates/default/trait.html.twig
+++ b/data/templates/default/trait.html.twig
@@ -1,50 +1,44 @@
 {% extends 'base.html.twig' %}
 
 {% block content %}
-    <div class="phpdocumentor-section">
-        {% include 'sidebar.html.twig' %}
+    {% include 'breadcrumbs.html.twig' %}
 
-        <div class="nine phpdocumentor-columns">
-            {% include 'breadcrumbs.html.twig' %}
+    <h2 class="phpdocumentor-content__title">
+        {{ node.name }}
+    </h2>
 
-            <h2 class="phpdocumentor-content__title">
-                {{ node.name }}
-            </h2>
+    <p class="phpdocumentor-trait__summary">{{ node.summary }}</p>
+    <section class="phpdocumentor-trait__description">{{ node.description|markdown }}</section>
 
-            <p class="phpdocumentor-trait__summary">{{ node.summary }}</p>
-            <section class="phpdocumentor-trait__description">{{ node.description|markdown }}</section>
-
-            <h3>Table of Contents</h3>
-            <table class="phpdocumentor-table_of_contents">
-                {% for property in node.properties %}
-                    <tr>
-                        <th class="phpdocumentor-heading">${{ property.name }}</th>
-                        <td class="phpdocumentor-cell">{{ property.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ property.types|route('class:short')|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-                {% for property in node.magicProperties %}
-                    <tr>
-                        <th class="phpdocumentor-heading">${{ property.name }}</th>
-                        <td class="phpdocumentor-cell">{{ property.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ property.types|route('class:short')|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-                {% for method in node.methods %}
-                    <tr>
-                        <th class="phpdocumentor-heading">{{ method.name }}()</th>
-                        <td class="phpdocumentor-cell">{{ method.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ method.response.types|route|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-                {% for method in node.magicMethods %}
-                    <tr>
-                        <th class="phpdocumentor-heading">{{ method.name }}()</th>
-                        <td class="phpdocumentor-cell">{{ method.summary }}</td>
-                        <td class="phpdocumentor-cell">{{ method.response.types|route|join('|')|raw }}</td>
-                    </tr>
-                {% endfor %}
-            </table>
-        </div>
-    </div>
+    <h3>Table of Contents</h3>
+    <table class="phpdocumentor-table_of_contents">
+        {% for property in node.properties %}
+            <tr>
+                <th class="phpdocumentor-heading">${{ property.name }}</th>
+                <td class="phpdocumentor-cell">{{ property.summary }}</td>
+                <td class="phpdocumentor-cell">{{ property.types|route('class:short')|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+        {% for property in node.magicProperties %}
+            <tr>
+                <th class="phpdocumentor-heading">${{ property.name }}</th>
+                <td class="phpdocumentor-cell">{{ property.summary }}</td>
+                <td class="phpdocumentor-cell">{{ property.types|route('class:short')|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+        {% for method in node.methods %}
+            <tr>
+                <th class="phpdocumentor-heading">{{ method.name }}()</th>
+                <td class="phpdocumentor-cell">{{ method.summary }}</td>
+                <td class="phpdocumentor-cell">{{ method.response.types|route|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+        {% for method in node.magicMethods %}
+            <tr>
+                <th class="phpdocumentor-heading">{{ method.name }}()</th>
+                <td class="phpdocumentor-cell">{{ method.summary }}</td>
+                <td class="phpdocumentor-cell">{{ method.response.types|route|join('|')|raw }}</td>
+            </tr>
+        {% endfor %}
+    </table>
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1592 @@
+{
+  "name": "phpdocumentor",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@cypress/listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "@cypress/xvfb": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+      "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "lodash.once": "^4.1.1"
+      }
+    },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "arch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "cachedir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-1.3.0.tgz",
+      "integrity": "sha512-O1ji32oyON9laVPJL1IZ5bmwd2cB46VfpxkDequezH+15FDzzVddEyrGEeX4WusDSqKxdyFdDQDEG1yo1GoWkg==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.1"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
+    },
+    "check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "cypress": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.8.1.tgz",
+      "integrity": "sha512-eLk5OpL/ZMDfQx9t7ZaDUAGVcvSOPTi7CG1tiUnu9BGk7caBiDhuFi3Tz/D5vWqH/Dl6Uh4X+Au4W+zh0xzbXw==",
+      "dev": true,
+      "requires": {
+        "@cypress/listr-verbose-renderer": "0.4.1",
+        "@cypress/xvfb": "1.2.4",
+        "@types/sizzle": "2.3.2",
+        "arch": "2.1.1",
+        "bluebird": "3.5.0",
+        "cachedir": "1.3.0",
+        "chalk": "2.4.2",
+        "check-more-types": "2.24.0",
+        "commander": "2.15.1",
+        "common-tags": "1.8.0",
+        "debug": "3.2.6",
+        "execa": "0.10.0",
+        "executable": "4.1.1",
+        "extract-zip": "1.6.7",
+        "fs-extra": "5.0.0",
+        "getos": "3.1.1",
+        "is-ci": "1.2.1",
+        "is-installed-globally": "0.1.0",
+        "lazy-ass": "1.6.0",
+        "listr": "0.12.0",
+        "lodash": "4.17.15",
+        "log-symbols": "2.2.0",
+        "minimist": "1.2.0",
+        "moment": "2.24.0",
+        "ramda": "0.24.1",
+        "request": "2.88.0",
+        "request-progress": "3.0.0",
+        "supports-color": "5.5.0",
+        "tmp": "0.1.0",
+        "untildify": "3.0.3",
+        "url": "0.11.0",
+        "yauzl": "2.10.0"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "execa": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "executable": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+      "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+      "dev": true,
+      "requires": {
+        "pify": "^2.2.0"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "yauzl": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+          "dev": true,
+          "requires": {
+            "fd-slicer": "~1.0.1"
+          }
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "getos": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.1.tgz",
+      "integrity": "sha512-oUP1rnEhAr97rkitiszGP9EgDVYnmchgFzfqRzSkgtfv7ai6tEi7Ko8GgjNXts7VLWEqrTWyhsOKLe5C5b/Zkg==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.1"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.5.0"
+      }
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true
+    },
+    "listr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
+      "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "figures": "^1.7.0",
+        "indent-string": "^2.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.2.0",
+        "listr-verbose-renderer": "^0.4.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "ora": "^0.2.3",
+        "p-map": "^1.1.1",
+        "rxjs": "^5.0.0-beta.11",
+        "stream-to-observable": "^0.1.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
+      "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.42.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
+      }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-spinners": "^0.1.2",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
+      "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "request-progress": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+      "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+      "dev": true,
+      "requires": {
+        "throttleit": "^1.0.0"
+      }
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      }
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
+      "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true
+    },
+    "throttleit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^2.6.3"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "untildify": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+      "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      },
+      "dependencies": {
+        "fd-slicer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+          "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+          "dev": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "phpdocumentor",
+  "version": "1.0.0",
+  "description": "[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT) [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fphpdocumentor%2Fphpdocumentor%2Fbadge%3Fref%3Dmaster&style=flat&label=build&logo=none)](https://actions-badge.atrox.dev/phpdocumentor/phpdocumentor/goto?ref=master) [![Code Coverage](https://scrutinizer-ci.com/g/phpDocumentor/phpDocumentor/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/phpDocumentor/phpDocumentor/?branch=master) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/phpDocumentor/phpDocumentor/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/phpDocumentor/phpDocumentor/?branch=master) ![Packagist Version](https://img.shields.io/packagist/v/phpdocumentor/phpdocumentor?label=packagist%20stable) ![Packagist Pre Release Version](https://img.shields.io/packagist/vpre/phpdocumentor/phpdocumentor?label=packagist%20unstable) [![Downloads](https://img.shields.io/packagist/dm/phpDocumentor/phpDocumentor.svg)](https://packagist.org/packages/phpDocumentor/phpDocumentor)",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
+  "scripts": {
+    "cypress:open": "cypress open"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/phpDocumentor/phpDocumentor.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/phpDocumentor/phpDocumentor/issues"
+  },
+  "homepage": "https://github.com/phpDocumentor/phpDocumentor#readme",
+  "devDependencies": {
+    "cypress": "^3.8.1"
+  }
+}

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor.php
@@ -189,4 +189,13 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
 
         return (bool) ($visibilityAllowed & $visibility);
     }
+
+    public function findElement(Fqsen $fqsen) : ?Descriptor
+    {
+        if (!isset($this->getIndexes()['elements'])) {
+            return null;
+        }
+
+        return $this->getIndexes()['elements']->get((string) $fqsen);
+    }
 }

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -24,6 +24,7 @@ use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 use function array_unshift;
+use function str_replace;
 use function strtolower;
 
 /**
@@ -65,7 +66,7 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
         ?LinkRenderer $routeRenderer = null
     ) {
         $this->data = $project;
-        $this->routeRenderer = $routeRenderer;
+        $this->routeRenderer = $routeRenderer->withProject($project);
     }
 
     /**
@@ -143,7 +144,11 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
             'markdown' => new TwigFilter(
                 'markdown',
                 static function (string $value) use ($parser) : string {
-                    return $parser->text($value);
+                    return str_replace(
+                        ['<pre>', '<code>'],
+                        ['<pre class="prettyprint">', '<code class="prettyprint">'],
+                        $parser->text($value)
+                    );
                 },
                 ['is_safe' => ['all']]
             ),
@@ -160,7 +165,8 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
                     string $presentation = LinkRenderer::PRESENTATION_NORMAL
                 ) use ($routeRenderer) {
                     return $routeRenderer->render($value, $presentation);
-                }
+                },
+                ['is_safe' => ['all']]
             ),
             'sort' => new TwigFilter(
                 'sort_*',

--- a/tests/features/assets/projects/MariosPizzeria/phpdoc.xml
+++ b/tests/features/assets/projects/MariosPizzeria/phpdoc.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor>
+    <parser>
+        <default-package-name>Marios</default-package-name>
+        <target>build/api-cache</target>
+    </parser>
+    <transformer>
+        <target>build/api</target>
+    </transformer>
+    <files>
+        <directory>.</directory>
+        <ignore>tests/*</ignore>
+    </files>
+    <transformations>
+        <template name="default" />
+    </transformations>
+</phpdocumentor>

--- a/tests/features/assets/projects/MariosPizzeria/src/Pizzeria.php
+++ b/tests/features/assets/projects/MariosPizzeria/src/Pizzeria.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marios;
+
+final class Pizzeria
+{
+}

--- a/tests/features/assets/projects/MariosPizzeria/tests/PizzeriaTest.php
+++ b/tests/features/assets/projects/MariosPizzeria/tests/PizzeriaTest.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Marios;
+
+final class PizzeriaTest
+{
+}

--- a/tests/features/template/default/class.feature
+++ b/tests/features/template/default/class.feature
@@ -1,0 +1,12 @@
+Feature: Class documentation page
+
+#  @template
+#  Scenario: Author tag should be visible
+#    Given A project named "simple" based on "simple"
+#    And I ran "phpdoc --template=clean"
+#    And I am on "/build/docs/classes/Simple.Blog.Post.html"
+#    Then I should see "author" in the ".table-condensed tr th" element
+#    And I should see "jaapio" in the ".table-condensed tr td" element
+#    And I should see "jaapio@phpdoc.org" in the ".table-condensed tr td p a" element
+
+

--- a/tests/features/template/default/general.feature
+++ b/tests/features/template/default/general.feature
@@ -1,0 +1,7 @@
+Feature: documentation index
+
+  Scenario:
+    Given A project named "Marios" based on "MariosPizzeria"
+    And I ran "phpdoc"
+    And I am on "/build/api/index.html"
+    Then I should see "my doc"


### PR DESCRIPTION
Because Behat is not able to comfortably test frontends, I have done an
experiment using Cypress as a test runner. This change is the result of
this experiment.

In this change I have introduced a new make command `make test-template`
that will install Cypress using NPM, run phpDocumentor against the
Mario's Pizzeria example, and test the output using Cypress.

I have chosen not to include this in the build pipeline yet as this is
an example meant for feedback; if we continue this way I want to clean
up the make commands a bit more and add it to Github Actions.