### PR TITLE
Remove directory separator

### DIFF
--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -24,7 +24,6 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Transformer\Router\Router;
-use const DIRECTORY_SEPARATOR;
 use function array_fill;
 use function count;
 use function current;
@@ -278,7 +277,7 @@ final class LinkRenderer
      */
     private function getPathPrefixBasedOnDepth() : string
     {
-        $directoryDepth = count(explode(DIRECTORY_SEPARATOR, $this->getDestination()));
+        $directoryDepth = count(explode('/', $this->getDestination()));
 
         return $directoryDepth > 1
             ? implode('/', array_fill(0, $directoryDepth - 1, '..')) . '/'

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
@@ -21,8 +21,6 @@ use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Transformer\Router\Router;
-use const DIRECTORY_SEPARATOR;
-use function str_replace;
 
 /**
  * @coversDefaultClass \phpDocumentor\Transformer\Writer\Twig\LinkRenderer
@@ -94,7 +92,7 @@ final class LinkRendererTest extends MockeryTestCase
             ->shouldReceive('generate')
             ->andReturn('/classes/My.Namespace.Class.html');
 
-        $this->renderer->setDestination(str_replace('/', DIRECTORY_SEPARATOR, '/root/of/project'));
+        $this->renderer->setDestination('/root/of/project');
         $collection = new Collection([$fqsen]);
         $result = $this->renderer->render($collection, 'url');
 


### PR DESCRIPTION
Since we are using flysystem everywhere there is no need to replace
the directory separator.