### PR TITLE
fix some errors on PHPStan lvl 6

### DIFF
--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -24,7 +24,11 @@ use function sprintf;
  */
 class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInterface
 {
-    /** @var ClassDescriptor|null $extends Reference to an instance of the superclass for this class, if any. */
+    /**
+     * Reference to an instance of the superclass for this class, if any.
+     *
+     * @var DescriptorAbstract|Fqsen|string|null $parent
+     */
     protected $parent;
 
     /** @var Collection $implements References to interfaces that are implemented by this class. */
@@ -63,7 +67,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     }
 
     /**
-     * {@inheritDoc}
+     * @param DescriptorAbstract|Fqsen|string|null $parents
      */
     public function setParent($parents) : void
     {
@@ -71,7 +75,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     }
 
     /**
-     * {@inheritDoc}
+     * @return DescriptorAbstract|Fqsen|string|null
      */
     public function getParent()
     {
@@ -97,7 +101,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     /**
      * {@inheritDoc}
      */
-    public function setFinal($final) : void
+    public function setFinal(bool $final) : void
     {
         $this->final = $final;
     }
@@ -113,7 +117,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     /**
      * {@inheritDoc}
      */
-    public function setAbstract($abstract) : void
+    public function setAbstract(bool $abstract) : void
     {
         $this->abstract = $abstract;
     }
@@ -145,7 +149,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     /**
      * {@inheritDoc}
      */
-    public function getInheritedConstants()
+    public function getInheritedConstants() : Collection
     {
         if ($this->getParent() === null || (!$this->getParent() instanceof self)) {
             return new Collection();

--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -26,6 +26,9 @@ use function count;
  *
  * The goal for this class is to allow Descriptors to be easily retrieved and set so that interaction in
  * templates becomes easier.
+ *
+ * @template-implements ArrayAccess<string|int, mixed>
+ * @template-implements IteratorAggregate<string|int, mixed>
  */
 class Collection implements Countable, IteratorAggregate, ArrayAccess
 {
@@ -96,6 +99,8 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
 
     /**
      * Retrieves an iterator to traverse this object.
+     *
+     * @return ArrayIterator<string|int, mixed>
      */
     public function getIterator() : ArrayIterator
     {

--- a/src/phpDocumentor/Descriptor/ConstantDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ConstantDescriptor.php
@@ -27,7 +27,7 @@ class ConstantDescriptor extends DescriptorAbstract implements Interfaces\Consta
     /** @var ClassDescriptor|InterfaceDescriptor|null $parent */
     protected $parent;
 
-    /** @var Type $type */
+    /** @var Type $types */
     protected $types;
 
     /** @var string $value */

--- a/src/phpDocumentor/Descriptor/DescriptorAbstract.php
+++ b/src/phpDocumentor/Descriptor/DescriptorAbstract.php
@@ -44,7 +44,7 @@ abstract class DescriptorAbstract implements Descriptor, Filterable
     /** @var string $description A more extensive description of this element. */
     protected $description = '';
 
-    /** @var FileDescriptor|null $file The file to which this element belongs; if applicable */
+    /** @var FileDescriptor|null $fileDescriptor The file to which this element belongs; if applicable */
     protected $fileDescriptor;
 
     /** @var int $line The line number on which this element occurs. */

--- a/src/phpDocumentor/Descriptor/InterfaceDescriptor.php
+++ b/src/phpDocumentor/Descriptor/InterfaceDescriptor.php
@@ -20,7 +20,7 @@ use phpDocumentor\Reflection\Fqsen;
  */
 class InterfaceDescriptor extends DescriptorAbstract implements Interfaces\InterfaceInterface
 {
-    /** @var Collection $extends */
+    /** @var Collection $parents */
     protected $parents;
 
     /** @var Collection $constants */

--- a/src/phpDocumentor/Descriptor/Interfaces/ChildInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/ChildInterface.php
@@ -31,7 +31,7 @@ interface ChildInterface
     /**
      * Sets the parent for this Descriptor.
      *
-     * @param ?DescriptorAbstract $parent
+     * @param DescriptorAbstract|Fqsen|string|null $parent
      */
-    public function setParent(?DescriptorAbstract $parent) : void;
+    public function setParent($parent) : void;
 }

--- a/src/phpDocumentor/Descriptor/NamespaceDescriptor.php
+++ b/src/phpDocumentor/Descriptor/NamespaceDescriptor.php
@@ -18,10 +18,10 @@ namespace phpDocumentor\Descriptor;
  */
 class NamespaceDescriptor extends DescriptorAbstract implements Interfaces\NamespaceInterface
 {
-    /** @var NamespaceDescriptor $parentNamespace */
+    /** @var NamespaceDescriptor|null $parent */
     protected $parent;
 
-    /** @var Collection $namespaces */
+    /** @var Collection $children */
     protected $children;
 
     /** @var Collection $functions */
@@ -56,8 +56,10 @@ class NamespaceDescriptor extends DescriptorAbstract implements Interfaces\Names
 
     /**
      * Sets the parent namespace for this namespace.
+     *
+     * @param ?NamespaceDescriptor $parent
      */
-    public function setParent(?DescriptorAbstract $parent) : void
+    public function setParent($parent) : void
     {
         $this->parent = $parent;
     }

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor/Settings.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor/Settings.php
@@ -138,6 +138,8 @@ final class Settings
 
     /**
      * Sets a property's value and if it differs from the previous then mark these settings as modified.
+     *
+     * @param int|bool|array $value
      */
     private function setValueAndCheckIfModified(string $propertyName, $value) : void
     {

--- a/src/phpDocumentor/Descriptor/Tag/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/Tag/MethodDescriptor.php
@@ -30,7 +30,7 @@ class MethodDescriptor extends TagDescriptor
     /** @var bool */
     private $static;
 
-    public function __construct($name)
+    public function __construct(string $name)
     {
         parent::__construct($name);
 

--- a/src/phpDocumentor/Pipeline/PipelineFactory.php
+++ b/src/phpDocumentor/Pipeline/PipelineFactory.php
@@ -18,6 +18,9 @@ use League\Pipeline\PipelineInterface;
 
 final class PipelineFactory
 {
+    /**
+     * @param iterable<callable> $stages
+     */
     public static function create(iterable $stages) : PipelineInterface
     {
         $builder = new PipelineBuilder();

--- a/src/phpDocumentor/Pipeline/Stage/Transform.php
+++ b/src/phpDocumentor/Pipeline/Stage/Transform.php
@@ -130,6 +130,9 @@ final class Transform
         );
     }
 
+    /**
+     * @param array<string, string> $templateNames
+     */
     private function loadTemplatesBasedOnNames(array $templateNames) : void
     {
         $stopWatch = new Stopwatch();

--- a/src/phpDocumentor/Transformer/Event/PreTransformationEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PreTransformationEvent.php
@@ -27,7 +27,7 @@ final class PreTransformationEvent extends Event
     /** @var object */
     private $subject;
 
-    public function __construct($subject, Transformation $transformation)
+    public function __construct(object $subject, Transformation $transformation)
     {
         $this->subject = $subject;
         $this->transformation = $transformation;

--- a/src/phpDocumentor/Transformer/Template.php
+++ b/src/phpDocumentor/Transformer/Template.php
@@ -26,6 +26,9 @@ use function preg_match;
 
 /**
  * Model representing a template.
+ *
+ * @template-implements ArrayAccess<int|string, Transformation>
+ * @template-implements IteratorAggregate<int|string, Transformation>
  */
 final class Template implements ArrayAccess, Countable, IteratorAggregate
 {
@@ -272,6 +275,9 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
         }
     }
 
+    /**
+     * @return ArrayIterator<int|string, Transformation>
+     */
     public function getIterator() : ArrayIterator
     {
         return new ArrayIterator($this->transformations);

--- a/src/phpDocumentor/Transformer/Writer/Collection.php
+++ b/src/phpDocumentor/Transformer/Writer/Collection.php
@@ -23,6 +23,8 @@ use function preg_match;
  * In this collection we can receive writers.
  *
  * In addition this class can also verify if all requirements for the various writers in it are met.
+ *
+ * @template-extends ArrayObject<string,WriterAbstract>
  */
 class Collection extends ArrayObject
 {

--- a/src/phpDocumentor/Transformer/Writer/Graph.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph.php
@@ -43,6 +43,9 @@ final class Graph extends WriterAbstract implements ProjectDescriptor\WithCustom
         $this->plantumlClassDiagram = $plantumlClassDiagram;
     }
 
+    /**
+     * @return array<string, bool>
+     */
     public function getDefaultSettings() : array
     {
         return [ 'graphs.enabled' => false ];

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -105,6 +105,9 @@ final class LinkRenderer
         return $this->destination;
     }
 
+    /**
+     * @param Descriptor|Fqsen|Uri $value
+     */
     public function link($value) : string
     {
         $uri = $this->router->generate($value);
@@ -288,6 +291,9 @@ final class LinkRenderer
         return $url ? sprintf('<a href="%s">%s</a>', $url, (string) $node) : (string) $node;
     }
 
+    /**
+     * @param iterable<Type> $value
+     */
     private function renderType(iterable $value) : array
     {
         $result = [];


### PR DESCRIPTION
This PR make some progress for #2216

It fixes some errors on level 6 (mainly generics description and some typos on property names in phpdoc)

There are 2 errors left on lvl 5 from recent commits but the first one implied to add checks in code and I didn't know how to fix the second one.

This PR reveals 2 new errors on level 5 that I didn't analyze for now.

I didn't run on docker and for some reason, I couldn't launch phpcbf. I'll fix errors from CI reported here.