### PR TITLE
Fix handling of invalid tags in methods and function

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
@@ -117,7 +117,7 @@ class FunctionAssembler extends AssemblerAbstract
         Argument $argument
     ) : ArgumentDescriptor {
         /** @var Collection<ParamDescriptor> $params */
-        $params = $functionDescriptor->getTags()->get('param', new Collection());
+        $params = $functionDescriptor->getTags()->get('param', new Collection())->filter(ParamDescriptor::class);
 
         if (!$this->argumentAssembler->getBuilder()) {
             $this->argumentAssembler->setBuilder($this->builder);

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
@@ -17,6 +17,7 @@ use phpDocumentor\Descriptor\ArgumentDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\MethodDescriptor;
 use phpDocumentor\Descriptor\Tag\ParamDescriptor;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\Php\Argument;
 use phpDocumentor\Reflection\Php\Method;
@@ -96,7 +97,7 @@ class MethodAssembler extends AssemblerAbstract
     protected function addArgument(Argument $argument, MethodDescriptor $descriptor) : void
     {
         /** @var Collection<ParamDescriptor> $params */
-        $params = $descriptor->getTags()->get('param', new Collection());
+        $params = $descriptor->getTags()->get('param', new Collection())->filter(ParamDescriptor::class);
 
         if (!$this->argumentAssembler->getBuilder()) {
             $this->argumentAssembler->setBuilder($this->builder);
@@ -119,9 +120,9 @@ class MethodAssembler extends AssemblerAbstract
 
         $paramTags = $data->getDocBlock()->getTagsByName('param');
 
-        /** @var Param|bool $lastParamTag */
+        /** @var Param|InvalidTag|bool $lastParamTag */
         $lastParamTag = end($paramTags);
-        if ($lastParamTag === false) {
+        if (!$lastParamTag instanceof Param) {
             return;
         }
 

--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -18,6 +18,7 @@ use ArrayIterator;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
+use function array_filter;
 use function array_merge;
 use function count;
 
@@ -199,5 +200,22 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
     public function merge(self $collection) : Collection
     {
         return new self(array_merge($this->items, $collection->getAll()));
+    }
+
+    /**
+     * @param class-string<T> $className
+     *
+     * @return Collection<object&T>
+     */
+    public function filter(string $className) : Collection
+    {
+        return new self(
+            array_filter(
+                $this->getAll(),
+                static function ($item) use ($className) {
+                    return $item instanceof $className;
+                }
+            )
+        );
     }
 }

--- a/src/phpDocumentor/Descriptor/FunctionDescriptor.php
+++ b/src/phpDocumentor/Descriptor/FunctionDescriptor.php
@@ -53,8 +53,8 @@ class FunctionDescriptor extends DescriptorAbstract implements Interfaces\Functi
         $definedReturn = new ReturnDescriptor('return');
         $definedReturn->setType($this->returnType);
 
-        /** @var Collection<ReturnDescriptor>|null $returnTags */
-        $returnTags = $this->getTags()->get('return');
+        /** @var Collection<ReturnDescriptor> $returnTags */
+        $returnTags = $this->getTags()->get('return', new Collection())->filter(ReturnDescriptor::class);
 
         if ($returnTags instanceof Collection && $returnTags->count() > 0) {
             return current($returnTags->getAll());

--- a/src/phpDocumentor/Descriptor/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/MethodDescriptor.php
@@ -172,7 +172,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
     public function getReturn() : Collection
     {
         /** @var Collection<ReturnDescriptor> $var */
-        $var = $this->getTags()->get('return', new Collection());
+        $var = $this->getTags()->get('return', new Collection())->filter(ReturnDescriptor::class);
         if ($var->count() !== 0) {
             return $var;
         }

--- a/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use stdClass;
 
 /**
  * Tests the functionality for the Collection class.
@@ -214,5 +215,21 @@ final class CollectionTest extends MockeryTestCase
         $result = $this->fixture->merge($collection2);
 
         $this->assertSame($expected, $result->getAll());
+    }
+
+    /**
+     * @covers ::filter
+     */
+    public function testFilterReturnsOnlyInstancesOfCertainType() : void
+    {
+        $expected = [0 => new stdClass()];
+
+        $this->fixture[0] = new stdClass();
+        $this->fixture[1] = null;
+        $this->fixture[2] = 'string';
+
+        $result = $this->fixture->filter(stdClass::class)->getAll();
+
+        $this->assertEquals($expected, $result);
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/MethodDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/MethodDescriptorTest.php
@@ -293,7 +293,7 @@ final class MethodDescriptorTest extends MockeryTestCase
         $this->assertInstanceOf(Collection::class, $this->fixture->getReturn());
         $this->assertSame(0, $this->fixture->getReturn()->count());
 
-        $returnTagDescriptor = new AuthorDescriptor('return');
+        $returnTagDescriptor = new ReturnDescriptor('return');
         $returnCollection = new Collection([$returnTagDescriptor]);
         $this->fixture->getTags()->clear();
         $parentProperty = $this->whenFixtureHasMethodInParentClassWithSameName($this->fixture->getName());
@@ -301,7 +301,7 @@ final class MethodDescriptorTest extends MockeryTestCase
 
         $result = $this->fixture->getReturn();
 
-        $this->assertSame($returnCollection, $result);
+        $this->assertEquals($returnCollection, $result);
     }
 
     /**


### PR DESCRIPTION
This pr should address the issue reported in #2250 and #2251 on smoke test. 

phpDocumentor detected an invalid tag in the docblocks and created the fallback tag type `InvalidTag` since we are working on more type strict return types and param types this broke the execution of phpDocumentor.
In this pr I added some filtering on a number of locations to make sure everything keeps working. And an error is reported in the rendered template. 