### PR TITLE
Reintroduce re-encoding of files

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -215,13 +215,16 @@ services:
     # Increments the progress bar; by placing it in front of the cache you see the progress bar
     # increment, even while we only consume the cache
     phpDocumentor\Parser\Middleware\EmittingMiddleware:
-      tags: [ { name: 'phpdoc.parser.middleware', priority: 4500 } ]
+        tags: [ { name: 'phpdoc.parser.middleware', priority: 4500 } ]
 
     phpDocumentor\Parser\Middleware\CacheMiddleware:
         tags: [ { name: 'phpdoc.parser.middleware', priority: 4000 } ]
 
     phpDocumentor\Parser\Middleware\ErrorHandlingMiddleware:
         tags: [ { name: 'phpdoc.parser.middleware', priority: 3000 } ]
+
+    phpDocumentor\Parser\Middleware\ReEncodingMiddleware:
+      tags: [ { name: 'phpdoc.parser.middleware', priority: 2000 } ]
 
     ###################################################################################
     ## Autoloading definitions for external services ##################################

--- a/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
+++ b/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
@@ -76,6 +76,7 @@ final class CommandlineOptionsMiddleware
             $version = $this->overwriteMarkers($version);
             $version = $this->overwriteIncludeSource($version);
             $version = $this->overwriteVisibility($version);
+            $version = $this->overwriteEncoding($version);
             $version = $this->overwriteDefaultPackageName($version);
         }
 
@@ -422,5 +423,27 @@ final class CommandlineOptionsMiddleware
         }
 
         return $configuration;
+    }
+
+    /**
+     * @param array<string, array<int, array<string, mixed>>> $version
+     *
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    private function overwriteEncoding(array $version) : array
+    {
+        /** @var string|null $encoding */
+        $encoding = $this->options['encoding'] ?? null;
+        if (!$encoding) {
+            return $version;
+        }
+
+        if (!isset($version['api'])) {
+            $version['api'] = $this->createDefaultApiSettings();
+        }
+
+        $version['api'][0]['encoding'] = $encoding;
+
+        return $version;
     }
 }

--- a/src/phpDocumentor/Parser/Middleware/ErrorHandlingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/ErrorHandlingMiddleware.php
@@ -46,6 +46,8 @@ final class ErrorHandlingMiddleware implements Middleware
                 '  Unable to parse file "' . $filename . '", an error was detected: ' . $e->getMessage(),
                 LogLevel::ALERT
             );
+            $this->log('  -- Found in ' . $e->getFile() . ' at line ' . $e->getLine(), LogLevel::NOTICE);
+            $this->log('  ' . $e->getTraceAsString(), LogLevel::DEBUG);
         }
 
         // when an error occurs, return an empty file with an empty hash; this means phpDocumentor will try to

--- a/src/phpDocumentor/Parser/Middleware/ReEncodingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/ReEncodingMiddleware.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
+namespace phpDocumentor\Parser\Middleware;
+
+use phpDocumentor\Parser\ReEncodedFile;
+use phpDocumentor\Reflection\Middleware\Command;
+use phpDocumentor\Reflection\Middleware\Middleware;
+use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
+use Symfony\Component\String\ByteString;
+
+final class ReEncodingMiddleware implements Middleware
+{
+    /** @var string */
+    private $encoding = 'UTF-8';
+
+    public function withEncoding(string $encoding) : void
+    {
+        $this->encoding = $encoding;
+    }
+
+    public function execute(Command $command, callable $next) : object
+    {
+        if (!$command instanceof CreateCommand) {
+            return $next($command);
+        }
+
+        $file = new ReEncodedFile(
+            $command->getFile()->path(),
+            (new ByteString($command->getFile()->getContents()))->toUnicodeString($this->encoding)
+        );
+
+        return $next(new CreateCommand($file, $command->getStrategies()));
+    }
+}

--- a/src/phpDocumentor/Parser/ReEncodedFile.php
+++ b/src/phpDocumentor/Parser/ReEncodedFile.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
+namespace phpDocumentor\Parser;
+
+use phpDocumentor\Reflection\File;
+use Symfony\Component\String\UnicodeString;
+use function md5;
+
+final class ReEncodedFile implements File
+{
+    /** @var string */
+    private $path;
+
+    /** @var UnicodeString */
+    private $contents;
+
+    public function __construct(string $path, UnicodeString $contents)
+    {
+        $this->path = $path;
+        $this->contents = $contents;
+    }
+
+    /**
+     * Returns the content of the file as a string.
+     */
+    public function getContents() : string
+    {
+        return $this->contents->toString();
+    }
+
+    /**
+     * Returns md5 hash of the file.
+     */
+    public function md5() : string
+    {
+        return md5($this->getContents());
+    }
+
+    /**
+     * Returns an relative path to the file.
+     */
+    public function path() : string
+    {
+        return $this->path;
+    }
+}

--- a/src/phpDocumentor/Pipeline/Stage/Parser/ParseFiles.php
+++ b/src/phpDocumentor/Pipeline/Stage/Parser/ParseFiles.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage\Parser;
 
+use phpDocumentor\Parser\Middleware\ReEncodingMiddleware;
 use phpDocumentor\Parser\Parser;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -33,16 +34,21 @@ final class ParseFiles
     /** @var AdapterInterface */
     private $descriptorsCache;
 
+    /** @var ReEncodingMiddleware */
+    private $reEncodingMiddleware;
+
     public function __construct(
         Parser $parser,
         LoggerInterface $logger,
         AdapterInterface $filesCache,
-        AdapterInterface $descriptorsCache
+        AdapterInterface $descriptorsCache,
+        ReEncodingMiddleware $reEncodingMiddleware
     ) {
         $this->parser = $parser;
         $this->logger = $logger;
         $this->filesCache = $filesCache;
         $this->descriptorsCache = $descriptorsCache;
+        $this->reEncodingMiddleware = $reEncodingMiddleware;
     }
 
     public function __invoke(Payload $payload) : Payload
@@ -67,7 +73,8 @@ final class ParseFiles
             );
         }
 
-        $this->parser->setEncoding($apiConfig['encoding']);
+        $this->reEncodingMiddleware->withEncoding($apiConfig['encoding']);
+
         $this->parser->setMarkers($apiConfig['markers']);
         $this->parser->setIgnoredTags($apiConfig['ignore-tags']);
         $this->parser->setValidate($apiConfig['validate']);

--- a/tests/unit/phpDocumentor/Configuration/CommandlineOptionsMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Configuration/CommandlineOptionsMiddlewareTest.php
@@ -275,6 +275,23 @@ final class CommandlineOptionsMiddlewareTest extends MockeryTestCase
     /**
      * @covers ::__invoke
      */
+    public function testItShouldOverwriteTheEncodingSetInTheDefaultConfiguration() : void
+    {
+        $configuration = $this->givenAConfigurationWithoutApiDefinition();
+        $encoding = 'iso-8859-1';
+        $middleware = $this->createCommandlineOptionsMiddleware(['encoding' => $encoding]);
+
+        $newConfiguration = $middleware($configuration);
+
+        $this->assertEquals(
+            $encoding,
+            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['encoding']
+        );
+    }
+
+    /**
+     * @covers ::__invoke
+     */
     public function testItShouldOverwriteTheDefaultPackageNameSetInTheDefaultConfiguration() : void
     {
         $configuration = $this->givenAConfigurationWithoutApiDefinition();

--- a/tests/unit/phpDocumentor/Parser/Middleware/ErrorHandlingMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Parser/Middleware/ErrorHandlingMiddlewareTest.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
 use phpDocumentor\Reflection\Php\File;
 use phpDocumentor\Reflection\Php\ProjectFactoryStrategies;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
@@ -70,6 +71,12 @@ final class ErrorHandlingMiddlewareTest extends TestCase
             '  Unable to parse file "' . __FILE__ . '", an error was detected: this is a test',
             []
         )->shouldBeCalled();
+        $logger->log(
+            LogLevel::NOTICE,
+            Argument::containingString('  -- Found in '),
+            []
+        )->shouldBeCalled();
+        $logger->log(LogLevel::DEBUG, Argument::any(), [])->shouldBeCalled();
 
         $middleware = new ErrorHandlingMiddleware($logger->reveal());
 

--- a/tests/unit/phpDocumentor/Parser/Middleware/ReEncodingMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Parser/Middleware/ReEncodingMiddlewareTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
+namespace phpDocumentor\Parser\Middleware;
+
+use phpDocumentor\Parser\ReEncodedFile;
+use phpDocumentor\Reflection\File;
+use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
+use phpDocumentor\Reflection\Php\File as PhpFile;
+use phpDocumentor\Reflection\Php\ProjectFactoryStrategies;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\String\Exception\InvalidArgumentException;
+use Symfony\Component\String\UnicodeString;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Parser\Middleware\ReEncodingMiddleware
+ * @covers ::<private>
+ */
+final class ReEncodingMiddlewareTest extends TestCase
+{
+    /**
+     * @covers ::withEncoding
+     * @covers ::execute
+     */
+    public function testItReencodesFileContentsUsingTheGivenEncoding() : void
+    {
+        $contents = new UnicodeString('äNDERUNGEN');
+        $file = $this->createFileWithIso8859EncodedContents($contents);
+
+        $middleware = new ReEncodingMiddleware();
+        $middleware->withEncoding('iso-8859-1');
+        $result = $middleware->execute(
+            new CreateCommand($file, new ProjectFactoryStrategies([])),
+            function (CreateCommand $command) use ($contents) : PhpFile {
+                $reEncodedFile = $command->getFile();
+                $this->assertInstanceOf(ReEncodedFile::class, $reEncodedFile);
+
+                // only when the file has been re-encoded to UTF-8 is the output the same as $contents
+                // if there was no re-encoding, then this test would fail.
+                $this->assertSame($contents->toString(), $reEncodedFile->getContents());
+
+                return new PhpFile($reEncodedFile->md5(), $reEncodedFile->path());
+            }
+        );
+
+        $this->assertInstanceOf(PhpFile::class, $result);
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testItFailsToReEncodeFileIfTheGivenEncodingIsWrong() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "utf-8" string.');
+
+        $contents = new UnicodeString('äNDERUNGEN');
+        $file = $this->createFileWithIso8859EncodedContents($contents);
+
+        $middleware = new ReEncodingMiddleware();
+        $middleware->withEncoding('utf-8');
+        $middleware->execute(
+            new CreateCommand($file, new ProjectFactoryStrategies([])),
+            static function () : void {
+                // not important; never called due to exception
+            }
+        );
+    }
+
+    private function createFileWithIso8859EncodedContents(UnicodeString $contents) : File
+    {
+        $file = $this->prophesize(File::class);
+        $file->path()->willReturn('/tmp/fakeFile.php');
+        $file->getContents()->willReturn($contents->toByteString('iso-8859-1')->toString());
+
+        return $file->reveal();
+    }
+}

--- a/tests/unit/phpDocumentor/Parser/ReEncodedFileTest.php
+++ b/tests/unit/phpDocumentor/Parser/ReEncodedFileTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
+namespace phpDocumentor\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\String\UnicodeString;
+use function md5;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Parser\ReEncodedFile
+ * @covers ::__construct
+ * @covers ::<private>
+ */
+final class ReEncodedFileTest extends TestCase
+{
+    /**
+     * @covers ::path
+     */
+    public function testReEncodedFileExposesPath() : void
+    {
+        $path = '/tmp/fileToBeParsed';
+        $file = new ReEncodedFile($path, new UnicodeString('Contents'));
+
+        $this->assertSame($path, $file->path());
+    }
+
+    /**
+     * @covers ::getContents
+     */
+    public function testReEncodedFileExposesContents() : void
+    {
+        $contents = 'Contents';
+        $file = new ReEncodedFile('/tmp/fileToBeParsed', new UnicodeString($contents));
+
+        $this->assertSame($contents, $file->getContents());
+    }
+
+    /**
+     * @covers ::md5
+     */
+    public function testReEncodedFileExposesHashOfContents() : void
+    {
+        $contents = 'Contents';
+        $file = new ReEncodedFile('/tmp/fileToBeParsed', new UnicodeString($contents));
+
+        $this->assertSame(md5($contents), $file->md5());
+    }
+}


### PR DESCRIPTION
In issue #2254 it was reported that phpDocumentor was no longer able to
deal with ISO-8859-1 characters in a file.

After research, it was shown that during the migration from local files
to FlySystem the mechanism to re-encode files was not re-introduced.
This clearly causes issues and in this change, I re-introduce this
behaviour as a Parser middleware.

This middleware will extract the file contents from FlySystem,
determines whether re-encoding is needed and does so. After this, a new
type of File is passed to the rest of the chain for processing.

### TODO
- [x] Add more and specific tests for this feature
- [x] Ensure all styling and analysis issues are resolved
- [x] Check auto-detection mechanism -- ByteString supports autodetection but because we assume UTF-8 when no encoding is provided we cannot let it autodetect.