### PR TITLE
Bump PhpStan to 0.12.9, fix new issues

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -107,7 +107,7 @@ jobs:
             all-build-${{ hashFiles('**/composer.lock') }}
             all-build-
       - name: PHPStan
-        uses: phpDocumentor/phpstan-ga@0.12.3
+        uses: phpDocumentor/phpstan-ga@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
@@ -112,7 +112,7 @@ class ElementsIndexBuilder implements CompilerPassInterface
      * Adds a series of descriptors to the given list of collections.
      *
      * @param DescriptorAbstract|DescriptorAbstract[] $elements
-     * @param array<Collection<DescriptorAbstract>>   $indexes
+     * @param list<Collection<DescriptorAbstract>>    $indexes
      */
     protected function addElementsToIndexes($elements, array $indexes) : void
     {

--- a/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
+++ b/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
@@ -102,7 +102,7 @@ final class CommandlineOptionsMiddleware
      *
      * @param array<string, array<string, array<string, mixed>>> $configuration
      *
-     * @return array<string, array<string, array<string, mixed>>>
+     * @return array<string, array<string, array<string, mixed>|false>>
      */
     private function disableCache(array $configuration) : array
     {

--- a/src/phpDocumentor/Configuration/Definition/Upgradable.php
+++ b/src/phpDocumentor/Configuration/Definition/Upgradable.php
@@ -20,9 +20,9 @@ interface Upgradable
      * The 'configVersion' field in the result will inform the ConfigurationFactory what the next Configuration
      * definition should be used to parse this result.
      *
-     * @param array<string, array<string, mixed>> $values
+     * @param array<string, string|array<string, mixed>> $values
      *
-     * @return array<string, string|array<mixed>>
+     * @return array<string, string|array<string, mixed>>
      */
     public function upgrade(array $values) : array;
 }

--- a/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
@@ -66,8 +66,6 @@ class ArgumentDescriptor extends DescriptorAbstract implements Interfaces\Argume
 
     /**
      * @return list<?Type>
-     *
-     * @phpstan-return array<int, ?Type>
      */
     public function getTypes() : array
     {

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -28,7 +28,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     /**
      * Reference to an instance of the superclass for this class, if any.
      *
-     * @var DescriptorAbstract|Fqsen|string|null $parent
+     * @var ClassDescriptor|InterfaceDescriptor|Fqsen|string|null $parent
      */
     protected $parent;
 
@@ -72,7 +72,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     }
 
     /**
-     * @param DescriptorAbstract|Fqsen|string|null $parents
+     * @param ClassDescriptor|InterfaceDescriptor|Fqsen|string|null $parents
      */
     public function setParent($parents) : void
     {
@@ -80,7 +80,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     }
 
     /**
-     * @return DescriptorAbstract|Fqsen|string|null
+     * @return ClassDescriptor|InterfaceDescriptor|Fqsen|string|null
      */
     public function getParent()
     {
@@ -153,6 +153,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
 
     public function getInheritedMethods() : Collection
     {
+        /** @var Collection<?MethodDescriptor> $inheritedMethods */
         $inheritedMethods = new Collection();
 
         foreach ($this->getUsedTraits() as $trait) {
@@ -221,6 +222,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
 
     public function getInheritedProperties() : Collection
     {
+        /** @var Collection<?PropertyDescriptor> $inheritedProperties */
         $inheritedProperties = new Collection();
 
         foreach ($this->getUsedTraits() as $trait) {

--- a/src/phpDocumentor/Descriptor/DescriptorAbstract.php
+++ b/src/phpDocumentor/Descriptor/DescriptorAbstract.php
@@ -359,10 +359,11 @@ abstract class DescriptorAbstract implements Filterable
     /**
      * Returns all errors that occur in this element.
      *
-     * @return Collection<Error>
+     * @return Collection<?Error>
      */
     public function getErrors() : Collection
     {
+        /** @var Collection<?Error> $errors */
         $errors = (new Collection())->merge($this->errors);
         foreach ($this->tags as $tags) {
             foreach ($tags as $tag) {

--- a/src/phpDocumentor/Descriptor/DocumentationSetDescriptor.php
+++ b/src/phpDocumentor/Descriptor/DocumentationSetDescriptor.php
@@ -21,7 +21,7 @@ abstract class DocumentationSetDescriptor
     protected $name = '';
 
     /**
-     * @phpstan-var array{dsn?: Dsn, paths?: array<int, string>}
+     * @phpstan-var array{dsn?: Dsn, paths?: list<string>}
      * @var array<Dsn|list<string>>
      */
     protected $source = [];
@@ -46,7 +46,7 @@ abstract class DocumentationSetDescriptor
      *   it was ran and makes it uncacheable. But should this be cached? In any case, I need it for the RenderGuide
      *   writer at the moment; so refactor this once that becomes clearer.
      *
-     * @phpstan-return array{dsn?: Dsn, paths?: array<int, string>}
+     * @phpstan-return array{dsn?: Dsn, paths?: list<string>}
      */
     public function getSource() : array
     {

--- a/src/phpDocumentor/Descriptor/Filter/FilterInterface.php
+++ b/src/phpDocumentor/Descriptor/Filter/FilterInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Filter;
 
+use phpDocumentor\Descriptor\DescriptorAbstract;
+
 interface FilterInterface
 {
-    public function __invoke(?Filterable $filterable) : ?Filterable;
+    public function __invoke(?DescriptorAbstract $filterable) : ?DescriptorAbstract;
 }

--- a/src/phpDocumentor/Descriptor/Filter/StripIgnore.php
+++ b/src/phpDocumentor/Descriptor/Filter/StripIgnore.php
@@ -15,7 +15,6 @@ namespace phpDocumentor\Descriptor\Filter;
 
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
-use Webmozart\Assert\Assert;
 
 /**
  * Strips any Descriptor if the ignore tag is present with that element.
@@ -36,9 +35,8 @@ class StripIgnore implements FilterInterface
     /**
      * Filter Descriptor with ignore tags.
      */
-    public function __invoke(?Filterable $value) : ?Filterable
+    public function __invoke(?DescriptorAbstract $value) : ?DescriptorAbstract
     {
-        Assert::nullOrIsInstanceOf($value, DescriptorAbstract::class);
         if ($value !== null && $value->getTags()->get('ignore')) {
             return null;
         }

--- a/src/phpDocumentor/Descriptor/Filter/StripInternal.php
+++ b/src/phpDocumentor/Descriptor/Filter/StripInternal.php
@@ -44,12 +44,8 @@ class StripInternal implements FilterInterface
 
     /**
      * If the ProjectDescriptor's settings allow internal tags then return the Descriptor, otherwise null to filter it.
-     *
-     * @param DescriptorAbstract $value
-     *
-     * @return DescriptorAbstract|null
      */
-    public function __invoke(?Filterable $value) : ?Filterable
+    public function __invoke(?DescriptorAbstract $value) : ?DescriptorAbstract
     {
         $isInternalAllowed = $this->builder->getProjectDescriptor()->isVisibilityAllowed(Settings::VISIBILITY_INTERNAL);
         if ($isInternalAllowed) {

--- a/src/phpDocumentor/Descriptor/Filter/StripOnVisibility.php
+++ b/src/phpDocumentor/Descriptor/Filter/StripOnVisibility.php
@@ -37,15 +37,11 @@ class StripOnVisibility implements FilterInterface
 
     /**
      * Filter Descriptor with based on visibility.
-     *
-     * @param DescriptorAbstract|Filterable $value
-     *
-     * @return DescriptorAbstract|Filterable|null
      */
-    public function __invoke(?Filterable $value) : ?Filterable
+    public function __invoke(?DescriptorAbstract $value) : ?DescriptorAbstract
     {
-        if (!$value instanceof DescriptorAbstract) {
-            return $value;
+        if ($value === null) {
+            return null;
         }
 
         // if a Descriptor is marked as 'api' and this is set as a visibility; _always_ show it; even if the visibility

--- a/src/phpDocumentor/Descriptor/GuideSetDescriptor.php
+++ b/src/phpDocumentor/Descriptor/GuideSetDescriptor.php
@@ -20,7 +20,7 @@ final class GuideSetDescriptor extends DocumentationSetDescriptor
     /**
      * @param array<Dsn|list<string>> $source
      *
-     * @phpstan-param array{dsn: Dsn, paths: array<int, string>} $source
+     * @phpstan-param array{dsn: Dsn, paths: list<string>} $source
      */
     public function __construct(string $name, array $source, string $output)
     {

--- a/src/phpDocumentor/Descriptor/InterfaceDescriptor.php
+++ b/src/phpDocumentor/Descriptor/InterfaceDescriptor.php
@@ -62,10 +62,11 @@ class InterfaceDescriptor extends DescriptorAbstract implements Interfaces\Inter
     }
 
     /**
-     * @return Collection<ConstantDescriptor>
+     * @return Collection<?ConstantDescriptor>
      */
     public function getInheritedConstants() : Collection
     {
+        /** @var Collection<?ConstantDescriptor> $inheritedConstants */
         $inheritedConstants = new Collection();
 
         /** @var self $parent */
@@ -93,6 +94,7 @@ class InterfaceDescriptor extends DescriptorAbstract implements Interfaces\Inter
 
     public function getInheritedMethods() : Collection
     {
+        /** @var Collection<?MethodDescriptor> $inheritedMethods */
         $inheritedMethods = new Collection();
 
         /** @var self $parent */

--- a/src/phpDocumentor/Descriptor/Interfaces/ClassInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/ClassInterface.php
@@ -54,7 +54,7 @@ interface ClassInterface extends ElementInterface, ChildInterface, TypeInterface
     /** @return Collection<?MethodDescriptor> */
     public function getMethods() : Collection;
 
-    /** @return Collection<MethodDescriptor> */
+    /** @return Collection<?MethodDescriptor> */
     public function getInheritedMethods() : Collection;
 
     /** @param Collection<?PropertyDescriptor> $properties */
@@ -63,6 +63,6 @@ interface ClassInterface extends ElementInterface, ChildInterface, TypeInterface
     /** @return Collection<?PropertyDescriptor> */
     public function getProperties() : Collection;
 
-    /** @return Collection<PropertyDescriptor> */
+    /** @return Collection<?PropertyDescriptor> */
     public function getInheritedProperties() : Collection;
 }

--- a/src/phpDocumentor/Descriptor/Interfaces/ConstantInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/ConstantInterface.php
@@ -29,8 +29,6 @@ interface ConstantInterface extends ElementInterface, TypeInterface
      * Returns the types that may be present in this constant.
      *
      * @return list<?Type>
-     *
-     * @phpstan-return array<int, ?Type>
      */
     public function getTypes() : array;
 

--- a/src/phpDocumentor/Descriptor/Interfaces/InterfaceInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/InterfaceInterface.php
@@ -69,7 +69,7 @@ interface InterfaceInterface extends ElementInterface, TypeInterface
     /**
      * Returns a list of all methods that were inherited from parent interfaces.
      *
-     * @return Collection<MethodDescriptor>
+     * @return Collection<?MethodDescriptor>
      */
     public function getInheritedMethods() : Collection;
 }

--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -213,7 +213,7 @@ class ProjectDescriptorBuilder
     public function setVisibility(array $apiConfig) : void
     {
         $visibilities = $apiConfig['visibility'];
-        $visibility = null;
+        $visibility = 0;
 
         foreach ($visibilities as $item) {
             switch ($item) {

--- a/src/phpDocumentor/Descriptor/PropertyDescriptor.php
+++ b/src/phpDocumentor/Descriptor/PropertyDescriptor.php
@@ -86,8 +86,6 @@ class PropertyDescriptor extends DescriptorAbstract implements
 
     /**
      * @return list<string>
-     *
-     * @phpstan-return array<int, string>
      */
     public function getTypes() : array
     {

--- a/src/phpDocumentor/Descriptor/Tag/BaseTypes/TypedAbstract.php
+++ b/src/phpDocumentor/Descriptor/Tag/BaseTypes/TypedAbstract.php
@@ -48,8 +48,6 @@ abstract class TypedAbstract extends TagDescriptor
      * Returns the list of types associated with this tag.
      *
      * @return list<Type>
-     *
-     * @phpstan-return array<int, Type>
      */
     public function getTypes() : array
     {

--- a/src/phpDocumentor/Guides/Generator/HtmlForPdfGenerator.php
+++ b/src/phpDocumentor/Guides/Generator/HtmlForPdfGenerator.php
@@ -148,7 +148,7 @@ class HtmlForPdfGenerator
         );
     }
 
-    private function cleanupContent($content)
+    private function cleanupContent(string $content)
     {
         // remove internal anchors
         $content = preg_replace('#<a class="headerlink"([^>]+)>¶</a>#', '', $content);

--- a/src/phpDocumentor/Parser/FileCollector.php
+++ b/src/phpDocumentor/Parser/FileCollector.php
@@ -25,9 +25,6 @@ interface FileCollector
      * @param list<string>         $extensions
      *
      * @return File[]
-     *
-     * @phpstan-param array<int, string>         $paths
-     * @phpstan-param array<int, string>         $extensions
      */
     public function getFiles(Dsn $dsn, array $paths, array $ignore, array $extensions) : array;
 }

--- a/src/phpDocumentor/Parser/FlySystemCollector.php
+++ b/src/phpDocumentor/Parser/FlySystemCollector.php
@@ -35,11 +35,6 @@ final class FlySystemCollector implements FileCollector
      * @param list<string>         $extensions
      *
      * @return list<FlySystemFile>
-     *
-     * @phpstan-param array<int, string>         $paths
-     * @phpstan-param array<int, string>         $extensions
-     *
-     * @phpstan-return array<int, FlySystemFile>
      */
     public function getFiles(Dsn $dsn, array $paths, array $ignore, array $extensions) : array
     {

--- a/src/phpDocumentor/Parser/SpecificationFactory.php
+++ b/src/phpDocumentor/Parser/SpecificationFactory.php
@@ -31,9 +31,6 @@ final class SpecificationFactory implements FactoryInterface
      * @param list<string> $globs
      * @param array<string, bool|array<string>|null> $ignore
      * @param list<string> $extensions
-     *
-     * @phpstan-param array<int, string> $globs
-     * @phpstan-param array<int, string> $extensions
      */
     public function create(array $globs, array $ignore, array $extensions) : SpecificationInterface
     {

--- a/src/phpDocumentor/Parser/SpecificationFactoryInterface.php
+++ b/src/phpDocumentor/Parser/SpecificationFactoryInterface.php
@@ -26,9 +26,6 @@ interface SpecificationFactoryInterface
      * @param list<string> $paths
      * @param array<string, bool|array<string>|null> $ignore
      * @param list<string> $extensions
-     *
-     * @phpstan-param array<int, string> $paths
-     * @phpstan-param array<int, string> $extensions
      */
     public function create(array $paths, array $ignore, array $extensions) : SpecificationInterface;
 }

--- a/src/phpDocumentor/Pipeline/Stage/Parser/Payload.php
+++ b/src/phpDocumentor/Pipeline/Stage/Parser/Payload.php
@@ -36,8 +36,6 @@ final class Payload extends ApplicationPayload
 
     /**
      * @return list<array<array<mixed>|bool|string>>
-     *
-     * @phpstan-return array<int, array<array<mixed>|bool|string>>
      */
     public function getApiConfigs() : array
     {

--- a/src/phpDocumentor/Transformer/Writer/Pathfinder.php
+++ b/src/phpDocumentor/Transformer/Writer/Pathfinder.php
@@ -29,10 +29,8 @@ final class Pathfinder
      * is returned.
      *
      * @return Traversable<mixed>|list<mixed>
-     *
-     * @phpstan-return Traversable<mixed>|array<int, mixed>
      */
-    public function find(object $object, string $query)
+    public function find(object $object, string $query) : iterable
     {
         if ($query) {
             $node = $this->walkObjectTree($object, $query);

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -195,8 +195,6 @@ final class LinkRenderer
      * @param iterable<mixed> $value
      *
      * @return list<string>
-     *
-     * @phpstan-return array<int, string>
      */
     private function renderASeriesOfLinks(iterable $value, string $presentation) : array
     {
@@ -304,8 +302,6 @@ final class LinkRenderer
      * @param iterable<Type> $value
      *
      * @return list<string>
-     *
-     * @phpstan-return array<int, string>
      */
     private function renderType(iterable $value) : array
     {


### PR DESCRIPTION
Also removed phpstan specific notations when it didn't make sense anymore and fixed some errors reported by psalm

I think my next step will be to take a look at collections to identify sources of null. This issue leads to have null everywhere and it spreads in phpdoc everywhere a Collection is used