### PR TITLE
Wrong handling of getInheritedElement for Constant and Property

### DIFF
--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -28,7 +28,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     /**
      * Reference to an instance of the superclass for this class, if any.
      *
-     * @var ClassDescriptor|InterfaceDescriptor|Fqsen|string|null $parent
+     * @var ClassDescriptor|Fqsen|string|null $parent
      */
     protected $parent;
 
@@ -72,7 +72,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     }
 
     /**
-     * @param ClassDescriptor|InterfaceDescriptor|Fqsen|string|null $parents
+     * @param ClassDescriptor|Fqsen|string|null $parents
      */
     public function setParent($parents) : void
     {
@@ -80,7 +80,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     }
 
     /**
-     * @return ClassDescriptor|InterfaceDescriptor|Fqsen|string|null
+     * @return ClassDescriptor|Fqsen|string|null
      */
     public function getParent()
     {

--- a/src/phpDocumentor/Descriptor/ConstantDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ConstantDescriptor.php
@@ -135,12 +135,8 @@ class ConstantDescriptor extends DescriptorAbstract implements Interfaces\Consta
         /** @var ClassDescriptor|InterfaceDescriptor|null $associatedClass */
         $associatedClass = $this->getParent();
 
-        if (($associatedClass instanceof ClassDescriptor || $associatedClass instanceof InterfaceDescriptor)
-            && ($associatedClass->getParent() instanceof ClassDescriptor
-                || $associatedClass->getParent() instanceof InterfaceDescriptor
-            )
-        ) {
-            /** @var ClassDescriptor|InterfaceDescriptor $parentClass */
+        if ($associatedClass instanceof ClassDescriptor && $associatedClass->getParent() instanceof ClassDescriptor) {
+            /** @var ClassDescriptor $parentClass */
             $parentClass = $associatedClass->getParent();
 
             return $parentClass->getConstants()->get($this->getName());

--- a/src/phpDocumentor/Descriptor/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/MethodDescriptor.php
@@ -231,7 +231,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
             return null;
         }
 
-        /** @var ClassDescriptor|InterfaceDescriptor|Collection<InterfaceDescriptor> $parentClass */
+        /** @var ClassDescriptor|Collection<InterfaceDescriptor>|null $parentClass */
         $parentClass = $associatedClass->getParent();
         if ($parentClass instanceof ClassDescriptor || $parentClass instanceof Collection) {
             // the parent of a class is always a class, but the parent of an interface is a collection of interfaces.

--- a/src/phpDocumentor/Descriptor/PropertyDescriptor.php
+++ b/src/phpDocumentor/Descriptor/PropertyDescriptor.php
@@ -154,12 +154,8 @@ class PropertyDescriptor extends DescriptorAbstract implements
         /** @var ClassDescriptor|InterfaceDescriptor|null $associatedClass */
         $associatedClass = $this->getParent();
 
-        if (($associatedClass instanceof ClassDescriptor || $associatedClass instanceof InterfaceDescriptor)
-            && ($associatedClass->getParent() instanceof ClassDescriptor
-                || $associatedClass->getParent() instanceof InterfaceDescriptor
-            )
-        ) {
-            /** @var ClassDescriptor|InterfaceDescriptor $parentClass */
+        if ($associatedClass instanceof ClassDescriptor && $associatedClass->getParent() instanceof ClassDescriptor) {
+            /** @var ClassDescriptor $parentClass */
             $parentClass = $associatedClass->getParent();
 
             return $parentClass->getProperties()->get($this->getName());


### PR DESCRIPTION
Hi,

While adding types in one of my PR, I stumbled on those:
https://github.com/phpDocumentor/phpDocumentor/blob/master/src/phpDocumentor/Descriptor/ConstantDescriptor.php#L133
https://github.com/phpDocumentor/phpDocumentor/blob/master/src/phpDocumentor/Descriptor/PropertyDescriptor.php#L152

For me, it's not handled correctly.
If I understand everything, here's what happens: 

- getParent on ConstantDescriptor or PropertyDescriptor will return ClassDescriptor, InterfaceDescriptor or null.
- we check if we have a Class or Interface so we exclude null
- getParent on ClassDescriptor could return ClassDescriptor, never InterfaceDescriptor
- getParent on InterfaceDescriptor could return a collection of InterfaceDescriptor, never a single InterfaceDescriptor.

Conclusion: There's no way we can end up with a single instance of InterfaceDescriptor inside the "if".

This PR drops the impossible case.

I think I get the original intent, and it is better handled in MethodDescriptor::getInheritedElement : https://github.com/phpDocumentor/phpDocumentor/blob/master/src/phpDocumentor/Descriptor/MethodDescriptor.php#L220
If I'm right, this behaviour could be extracted in DescriptorAbstract to avoid code repetition