### PR TITLE
nullable get in collection

### DIFF
--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -86,15 +86,22 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
      *
      * @phpstan-param T $valueIfEmpty
      *
-     * @phpstan-return ?T
+     * @phpstan-return T
      */
     public function get($index, $valueIfEmpty = null)
     {
-        if (!$this->offsetExists($index) && $valueIfEmpty !== null) {
-            $this->offsetSet($index, $valueIfEmpty);
+        if (!$this->offsetExists($index)) {
+            if($valueIfEmpty !== null) {
+                $this->offsetSet($index, $valueIfEmpty);
+            }
+            else{
+                throw new InvalidArgumentException('A default value should be provided in case the index is empty');
+            }
         }
 
-        return $this->offsetGet($index);
+        $element = $this->offsetGet($index);
+        Assert::notNull($element);
+        return $element;
     }
 
     /**
@@ -138,7 +145,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
      *
      * @return mixed
      *
-     * @phpstan-return ?T
+     * @phpstan-return T
      */
     public function __get(string $name)
     {


### PR DESCRIPTION
I presume fetching null when specifying a specific offset in collection is never wanted. You either expect some element or specify a default value.

If I'm right, this PR will remove the null return type from Collection::get() and ensure every call to get() will either return a value  or use the default value provided (or throw an Exception)

This will also ensure that 
```php
$coll = new Collection(['a'=>$collA, 'b'=>$collB]);
$coll->c->count()
```

returns a meaningful exception instead of a null pointer error

I create this in draft to see the results of the CI