### PR TITLE
Static Analysis improvements

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,8 +17,8 @@ parameters:
     - '#Access to an undefined property phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\DescriptorAbstract>>::\$[a-z]+#'
     # Issue on the content of this collection https://github.com/phpDocumentor/phpDocumentor/pull/2249#issuecomment-581111947
     - '#Parameter \#1 \$item of method phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\TagDescriptor>::add\(\) expects phpDocumentor\\Descriptor\\TagDescriptor, phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\DescriptorAbstract>\|phpDocumentor\\Descriptor\\DescriptorAbstract given\.#'
-    # Covariance issues with Collections. Maybe an feature to submit to Phpstan?
-    - '#Method phpDocumentor\\Descriptor\\Collection::merge\(\) has parameter \$collection#'
+    # https://github.com/phpDocumentor/phpDocumentor/issues/2279
+    - '#Instanceof between phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\InterfaceDescriptor\|phpDocumentor\\Reflection\\Fqsen>\|phpDocumentor\\Reflection\\Fqsen\|string\|null and phpDocumentor\\Descriptor\\InterfaceDescriptor will always evaluate to false\.#'
     -
             message: "#^Parameter \\#1 \\$value of method phpDocumentor\\\\GraphViz\\\\Graph\\:\\:setCenter\\(\\) expects bool, string given\\.$#"
             count: 1
@@ -49,19 +49,12 @@ parameters:
     - %currentWorkingDirectory%/tests/data/*.php
     - %currentWorkingDirectory%/tests/features/assets/**/*.php
     - %currentWorkingDirectory%/tests/ReferenceImplementation.php
-   # files with issues because of removed validators
-    - %currentWorkingDirectory%/src/phpDocumentor/Plugin/Core/Transformer/Writer/Xml.php
-    - %currentWorkingDirectory%/src/phpDocumentor/Plugin/Core/Transformer/Writer/Checkstyle.php
-   # use of magic methods
-    - %currentWorkingDirectory%/src/phpDocumentor/Parser/Command/Project/ParseCommand.php
-   # method doesn't exist??? phpDocumentor\Plugin\Scrybe\Converter\ToLatexInterface::setTableOfContents()
-    - %currentWorkingDirectory%/src/phpDocumentor/Plugin/Scrybe/Command/Manual/ToLatexCommand.php
    # exclude guide generation, since this is not a working system at the moment
     - %currentWorkingDirectory%/src/phpDocumentor/Guides/*.php
     - %currentWorkingDirectory%/src/phpDocumentor/Pipeline/Stage/RenderGuide.php
     - %currentWorkingDirectory%/src/phpDocumentor/Guides/**/*.php
    # needs adjustment of interface in phpDocumentor/reflection in order to be able to typehint the command
-    - %currentWorkingDirectory%/src/phpDocumentor/Parser/Middleware/*.php
+    - %currentWorkingDirectory%/src/phpDocumentor/Parser/Middleware/CacheMiddleware.php
    # phpunit TestCase while having to use a composer-global install ("Class PHPUnit\\Framework\\TestCase not found and could not be autoloaded")
     - %currentWorkingDirectory%/tests/unit/**/*.php
     - %currentWorkingDirectory%/tests/integration/**/*.php

--- a/src/phpDocumentor/Compiler/Linker/DescriptorRepository.php
+++ b/src/phpDocumentor/Compiler/Linker/DescriptorRepository.php
@@ -28,7 +28,7 @@ class DescriptorRepository
 {
     private const CONTEXT_MARKER = '@context';
 
-    /** @var DescriptorAbstract[] */
+    /** @var array<DescriptorAbstract> */
     private $elementList = [];
 
     /**
@@ -93,7 +93,7 @@ class DescriptorRepository
     /**
      * Sets the list of object aliases to resolve the FQSENs with.
      *
-     * @param DescriptorAbstract[] $elementList
+     * @param array<DescriptorAbstract> $elementList
      */
     public function setObjectAliasesList(array $elementList) : void
     {

--- a/src/phpDocumentor/Compiler/Linker/Linker.php
+++ b/src/phpDocumentor/Compiler/Linker/Linker.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Linker;
 
-use ArrayAccess;
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\ClassDescriptor;
+use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\Descriptor;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
@@ -113,14 +114,15 @@ class Linker implements CompilerPassInterface
      *     the field's contents. Pass these contents to a new call of substitute and use a setter to replace the field's
      *     contents if anything other than null is returned.
      *
+     * The Container is a descriptor that acts as container for all elements underneath or null if there is no current
+     * container.
+     *
      * This method will return null if no substitution was possible and all of the above should not update the parent
      * item when null is passed.
      *
-     * @param string|Fqsen|object|array<mixed> $item
-     * @param DescriptorAbstract|null          $container A descriptor that acts as container for all elements
-     *                                                    underneath or null if there is no current container.
+     * @param string|Fqsen|Type|Collection<mixed>|array<mixed>|Descriptor $item
      *
-     * @return string|DescriptorAbstract|array<mixed>|null
+     * @return string|DescriptorAbstract|Collection<string|DescriptorAbstract>|array<string|DescriptorAbstract>|null
      */
     public function substitute($item, ?DescriptorAbstract $container = null)
     {
@@ -137,7 +139,7 @@ class Linker implements CompilerPassInterface
         }
 
         if (is_iterable($item)) {
-            Assert::true(is_array($item) || $item instanceof ArrayAccess);
+            Assert::true(is_array($item) || $item instanceof Collection);
 
             return $this->substituteChildrenOfCollection($item, $container);
         }
@@ -148,18 +150,16 @@ class Linker implements CompilerPassInterface
 
         $this->substituteMembersOfObject($item, $container);
 
-        //phpcs:disable Generic.Files.LineLength.TooLong
         return null;
     }
 
     /**
-     * @param array<string|DescriptorAbstract|null>|(ArrayAccess<array-key, string|DescriptorAbstract>&iterable<array-key, string|DescriptorAbstract>) $collection
+     * @param array<string|DescriptorAbstract>|Collection<string|DescriptorAbstract> $collection
      *
-     * @return array<string|DescriptorAbstract|null>|(ArrayAccess<array-key, string|DescriptorAbstract>&iterable<array-key, string|DescriptorAbstract>)|null
+     * @return array<string|DescriptorAbstract>|Collection<string|DescriptorAbstract>|null
      */
     private function substituteChildrenOfCollection(iterable $collection, ?DescriptorAbstract $container) : ?iterable
     {
-        //phpcs:enable Generic.Files.LineLength.TooLong
         $isModified = false;
         foreach ($collection as $key => $element) {
             $element = $this->substitute($element, $container);

--- a/src/phpDocumentor/Compiler/Pass/PackageTreeBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/PackageTreeBuilder.php
@@ -57,7 +57,7 @@ final class PackageTreeBuilder implements CompilerPassInterface
 
     public function execute(ProjectDescriptor $project) : void
     {
-        $packages = new Collection();
+        $packages = Collection::fromClassString(PackageDescriptor::class);
         $packages['\\'] = $project->getPackage();
 
         /** @var FileDescriptor $file */

--- a/src/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTags.php
+++ b/src/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTags.php
@@ -101,6 +101,7 @@ final class ResolveInlineLinkAndSeeTags implements CompilerPassInterface
         $descriptor->setDescription(
             preg_replace_callback(
                 self::REGEX_INLINE_LINK_OR_SEE_TAG,
+                /** @param list<string> $match */
                 function (array $match) {
                     return $this->resolveTag($match);
                 },
@@ -112,9 +113,9 @@ final class ResolveInlineLinkAndSeeTags implements CompilerPassInterface
     /**
      * Resolves an individual tag, indicated by the results of the Regex used to extract tags.
      *
-     * @param string[] $match
+     * @param list<string> $match
      *
-     * @return string|string[]
+     * @return string|list<string>
      */
     private function resolveTag(array $match)
     {
@@ -160,7 +161,7 @@ final class ResolveInlineLinkAndSeeTags implements CompilerPassInterface
     /**
      * Creates a Tag Reflector from the given array of tag line, tag name and tag content.
      *
-     * @param string[] $match
+     * @param list<string> $match
      */
     private function createLinkOrSeeTagFromRegexMatch(array $match) : Tag
     {

--- a/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
+++ b/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
@@ -43,7 +43,6 @@ final class ResolveInlineMarkers implements CompilerPassInterface
 
         /** @var FileDescriptor $file */
         foreach ($project->getFiles() as $file) {
-            $markerData = [];
             $matches     = [];
             $source = $file->getSource() ?: '';
 

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerInterface.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerInterface.php
@@ -18,6 +18,7 @@ use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\Element;
 use phpDocumentor\Reflection\Php\Argument;
+use phpDocumentor\Reflection\Php\File;
 
 /**
  * Interface for Assembler classes that transform data to specific Descriptor types.
@@ -28,7 +29,7 @@ interface AssemblerInterface
     /**
      * Creates a Descriptor from the provided data.
      *
-     * @param Element|Tag|Argument $data
+     * @param Element|Tag|Argument|File $data
      *
      * @return Descriptor
      */

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
@@ -37,7 +37,7 @@ class FileAssembler extends AssemblerAbstract
     /**
      * Creates a Descriptor from the provided data.
      *
-     * @param mixed $data TODO: should be FileDescriptor type, but cause weird issues
+     * @param File $data
      */
     public function create($data) : FileDescriptor
     {

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -28,7 +28,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     /**
      * Reference to an instance of the superclass for this class, if any.
      *
-     * @var ClassDescriptor|InterfaceDescriptor|Fqsen|string|null $parent
+     * @var ClassDescriptor|Fqsen|string|null $parent
      */
     protected $parent;
 
@@ -72,7 +72,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     }
 
     /**
-     * @param ClassDescriptor|InterfaceDescriptor|Fqsen|string|null $parents
+     * @param ClassDescriptor|Fqsen|string|null $parents
      */
     public function setParent($parents) : void
     {
@@ -80,7 +80,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     }
 
     /**
-     * @return ClassDescriptor|InterfaceDescriptor|Fqsen|string|null
+     * @return ClassDescriptor|Fqsen|string|null
      */
     public function getParent()
     {
@@ -244,10 +244,11 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
      */
     public function getMagicProperties() : Collection
     {
+        $tags = $this->getTags();
         /** @var Collection<Tag\PropertyDescriptor> $propertyTags */
-        $propertyTags = $this->getTags()->get('property', new Collection());
-        $propertyTags = $propertyTags->merge($this->getTags()->get('property-read', new Collection()));
-        $propertyTags = $propertyTags->merge($this->getTags()->get('property-write', new Collection()));
+        $propertyTags = $tags->get('property', new Collection())->filter(Tag\PropertyDescriptor::class)
+            ->merge($tags->get('property-read', new Collection())->filter(Tag\PropertyDescriptor::class))
+            ->merge($tags->get('property-write', new Collection())->filter(Tag\PropertyDescriptor::class));
 
         $properties = Collection::fromClassString(PropertyDescriptor::class);
 

--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -203,7 +203,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
     /**
      * Returns a new collection with the items from this collection and the provided combined.
      *
-     * @param Collection $collection should be Collection<T> but create issues with inherited Descriptors
+     * @param Collection<T> $collection
      *
      * @return Collection<T>
      */
@@ -215,9 +215,11 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
     }
 
     /**
-     * @param class-string<T> $className
+     * @param class-string<F> $className
      *
-     * @return Collection<object&T>
+     * @return Collection<object&F&T>
+     *
+     * @template F
      */
     public function filter(string $className) : Collection
     {

--- a/src/phpDocumentor/Descriptor/DescriptorAbstract.php
+++ b/src/phpDocumentor/Descriptor/DescriptorAbstract.php
@@ -37,7 +37,7 @@ abstract class DescriptorAbstract implements Filterable
     /** @var NamespaceDescriptor|string $namespace The namespace for this element */
     protected $namespace = '';
 
-    /** @var PackageDescriptor $package The package with which this element is associated */
+    /** @var PackageDescriptor|string $package The package with which this element is associated */
     protected $package;
 
     /** @var string $summary A summary describing the function of this element in short. */
@@ -363,8 +363,7 @@ abstract class DescriptorAbstract implements Filterable
      */
     public function getErrors() : Collection
     {
-        /** @var Collection<Error> $errors */
-        $errors = (new Collection())->merge($this->errors);
+        $errors = $this->errors;
         foreach ($this->tags as $tags) {
             foreach ($tags as $tag) {
                 $errors = $errors->merge($tag->getErrors());

--- a/src/phpDocumentor/Descriptor/FileDescriptor.php
+++ b/src/phpDocumentor/Descriptor/FileDescriptor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use phpDocumentor\Descriptor\Validation\Error;
+use phpDocumentor\Reflection\Fqsen;
 use function method_exists;
 
 /**
@@ -30,7 +31,7 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
     /** @var string|null $source */
     protected $source = null;
 
-    /** @var Collection<NamespaceDescriptor> $namespaceAliases */
+    /** @var Collection<NamespaceDescriptor>|Collection<Fqsen> $namespaceAliases */
     protected $namespaceAliases;
 
     /** @var Collection<string> $includes */
@@ -111,7 +112,7 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
     /**
      * Returns the namespace aliases that have been defined in this file.
      *
-     * @return Collection<NamespaceDescriptor>
+     * @return Collection<NamespaceDescriptor>|Collection<Fqsen>
      */
     public function getNamespaceAliases() : Collection
     {
@@ -121,7 +122,7 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
     /**
      * Sets the collection of namespace aliases for this file.
      *
-     * @param Collection<NamespaceDescriptor> $namespaceAliases
+     * @param Collection<NamespaceDescriptor>|Collection<Fqsen> $namespaceAliases
      */
     public function setNamespaceAliases(Collection $namespaceAliases) : void
     {
@@ -286,9 +287,15 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
     {
         $errors = $this->getErrors();
 
-        $types = $this->getClasses()->merge($this->getInterfaces())->merge($this->getTraits());
+        $types = Collection::fromClassString(DescriptorAbstract::class)
+            ->merge($this->getClasses())
+            ->merge($this->getInterfaces())
+            ->merge($this->getTraits());
 
-        $elements = $this->getFunctions()->merge($this->getConstants())->merge($types);
+        $elements = Collection::fromClassString(DescriptorAbstract::class)
+            ->merge($this->getFunctions())
+            ->merge($this->getConstants())
+            ->merge($types);
 
         foreach ($elements as $element) {
             $errors = $errors->merge($element->getErrors());

--- a/src/phpDocumentor/Descriptor/Interfaces/InterfaceInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/InterfaceInterface.php
@@ -29,7 +29,7 @@ interface InterfaceInterface extends ElementInterface, TypeInterface
      *
      * @return Collection<InterfaceDescriptor|Fqsen>
      */
-    public function getParent() : ?Collection;
+    public function getParent() : Collection;
 
     /**
      * Sets the parent for this Descriptor.

--- a/src/phpDocumentor/Descriptor/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/MethodDescriptor.php
@@ -124,7 +124,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
      */
     public function setArguments(Collection $arguments) : void
     {
-        $this->arguments = new Collection();
+        $this->arguments = Collection::fromClassString(ArgumentDescriptor::class);
 
         foreach ($arguments as $argument) {
             assert($argument instanceof ArgumentDescriptor);
@@ -231,7 +231,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
             return null;
         }
 
-        /** @var ClassDescriptor|InterfaceDescriptor|Collection<InterfaceDescriptor> $parentClass */
+        /** @var ClassDescriptor|Collection<InterfaceDescriptor>|Fqsen|string|null $parentClass */
         $parentClass = $associatedClass->getParent();
         if ($parentClass instanceof ClassDescriptor || $parentClass instanceof Collection) {
             // the parent of a class is always a class, but the parent of an interface is a collection of interfaces.

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor.php
@@ -68,7 +68,7 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
         $this->setIndexes(new Collection());
 
         $this->setPartials(new Collection());
-        $this->versions = new Collection();
+        $this->versions = Collection::fromClassString(VersionDescriptor::class);
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/Tag/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/Tag/MethodDescriptor.php
@@ -35,7 +35,7 @@ class MethodDescriptor extends TagDescriptor
     {
         parent::__construct($name);
 
-        $this->arguments = new Collection();
+        $this->arguments = Collection::fromClassString(ArgumentDescriptor::class);
     }
 
     public function setMethodName(string $methodName) : void

--- a/src/phpDocumentor/Descriptor/TagDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TagDescriptor.php
@@ -35,7 +35,7 @@ class TagDescriptor implements Filterable
     public function __construct(string $name)
     {
         $this->setName($name);
-        $this->errors = new Collection();
+        $this->errors = Collection::fromClassString(Validation\Error::class);
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -100,10 +100,11 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
      */
     public function getMagicProperties() : Collection
     {
+        $tags = $this->getTags();
         /** @var Collection<Tag\PropertyDescriptor> $propertyTags */
-        $propertyTags = $this->getTags()->get('property', new Collection());
-        $propertyTags->merge($this->getTags()->get('property-read', new Collection()));
-        $propertyTags->merge($this->getTags()->get('property-write', new Collection()));
+        $propertyTags = $tags->get('property', new Collection())->filter(Tag\PropertyDescriptor::class)
+            ->merge($tags->get('property-read', new Collection())->filter(Tag\PropertyDescriptor::class))
+            ->merge($tags->get('property-write', new Collection())->filter(Tag\PropertyDescriptor::class));
 
         $properties = Collection::fromClassString(PropertyDescriptor::class);
 

--- a/src/phpDocumentor/Guides/Directive/ConfigurationBlockDirective.php
+++ b/src/phpDocumentor/Guides/Directive/ConfigurationBlockDirective.php
@@ -15,8 +15,11 @@ namespace phpDocumentor\Guides\Directive;
 
 use Doctrine\RST\Directives\SubDirective;
 use Doctrine\RST\Nodes\CodeNode;
+use Doctrine\RST\Nodes\DocumentNode;
 use Doctrine\RST\Nodes\Node;
 use Doctrine\RST\Parser;
+use Webmozart\Assert\Assert;
+
 use function strtoupper;
 
 class ConfigurationBlockDirective extends SubDirective
@@ -28,6 +31,8 @@ class ConfigurationBlockDirective extends SubDirective
 
     public function processSub(Parser $parser, ?Node $document, string $variable, string $data, array $options) : ?Node
     {
+        Assert::isInstanceOf($document, DocumentNode::class);
+
         $blocks = [];
         foreach ($document->getNodes() as $node) {
             if (!$node instanceof CodeNode) {

--- a/src/phpDocumentor/Guides/Generator/HtmlForPdfGenerator.php
+++ b/src/phpDocumentor/Guides/Generator/HtmlForPdfGenerator.php
@@ -134,7 +134,7 @@ class HtmlForPdfGenerator
 
     private function fixInternalImages(string $fileContent, string $relativeImagesPath) : string
     {
-        return $fileContent = preg_replace('{src="(?:\.\./)+([^"]+?)"}', "src=\"$relativeImagesPath$1\"", $fileContent);
+        return preg_replace('{src="(?:\.\./)+([^"]+?)"}', "src=\"$relativeImagesPath$1\"", $fileContent);
     }
 
     private function fixUniqueIdsAndAnchors(string $fileContent, string $uid) : string
@@ -182,6 +182,6 @@ class HtmlForPdfGenerator
 
     private function getParserFilename(string $filePath, string $inputDir) : string
     {
-        return $parserFilename = str_replace([$inputDir . '/', '.html'], ['', ''], $filePath);
+        return str_replace([$inputDir.'/', '.html'], ['', ''], $filePath);
     }
 }

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -119,14 +119,14 @@ final class LinkRenderer
     }
 
     /**
-     * @param Type[]|Type|Descriptor|Fqsen|Path|string|iterable $value
+     * @param array<Type>|Type|Descriptor|Fqsen|Path|string|iterable<mixed> $value
      *
      * @return string[]|string
      */
     public function render($value, string $presentation)
     {
         if (is_array($value) && current($value) instanceof Type) {
-            /** @var iterable<Type> $value Assuming every element of iterable is similar */
+            /** @var array<Type> $value Assuming every element of iterable is similar */
             return $this->renderType($value);
         }
 


### PR DESCRIPTION
This PR adds improvements based on Psalm and PHPStan
- It removes an issue ignored in phpstan.neon by changing the syntax of successive merges
- It remove the long and ugly type we had to handle in Linker when we could receive Compound in the method
- It slightly change the filter() template documentation to allow filtering with a subtype (F) of the Collection type(T)
and other small changes