### PR TITLE
Collection: Named Constructor

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
@@ -221,8 +221,7 @@ class FileAssembler extends AssemblerAbstract
 
     protected function overridePackageTag(File $data, FileDescriptor $fileDescriptor) : void
     {
-        /** @var Collection<TagDescriptor> $packages */
-        $packages = new Collection();
+        $packages = Collection::fromClassString(TagDescriptor::class);
         $package  = $this->extractPackageFromDocBlock($data->getDocBlock());
         if (!$package) {
             $package = $this->getBuilder()->getDefaultPackage();

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
@@ -61,8 +61,7 @@ class FunctionAssembler extends AssemblerAbstract
      */
     protected function mapReflectorPropertiesOntoDescriptor(Function_ $reflector, FunctionDescriptor $descriptor) : void
     {
-        /** @var Collection<TagDescriptor> $packages */
-        $packages = new Collection();
+        $packages = Collection::fromClassString(TagDescriptor::class);
         $package  = $this->extractPackageFromDocBlock($reflector->getDocBlock());
         //TODO: this looks like a potential bug. Have to investigate this!
         if ($package) {

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -153,8 +153,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
 
     public function getInheritedMethods() : Collection
     {
-        /** @var Collection<MethodDescriptor> $inheritedMethods */
-        $inheritedMethods = new Collection();
+        $inheritedMethods = Collection::fromClassString(MethodDescriptor::class);
 
         foreach ($this->getUsedTraits() as $trait) {
             if (!$trait instanceof TraitDescriptor) {
@@ -181,8 +180,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
         /** @var Collection<MethodDescriptor> $methodTags */
         $methodTags = clone $this->getTags()->get('method', new Collection());
 
-        /** @var Collection<MethodDescriptor> $methods */
-        $methods = new Collection();
+        $methods = Collection::fromClassString(MethodDescriptor::class);
 
         /** @var Tag\MethodDescriptor $methodTag */
         foreach ($methodTags as $methodTag) {
@@ -222,8 +220,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
 
     public function getInheritedProperties() : Collection
     {
-        /** @var Collection<PropertyDescriptor> $inheritedProperties */
-        $inheritedProperties = new Collection();
+        $inheritedProperties = Collection::fromClassString(PropertyDescriptor::class);
 
         foreach ($this->getUsedTraits() as $trait) {
             if (!$trait instanceof TraitDescriptor) {
@@ -252,8 +249,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
         $propertyTags = $propertyTags->merge($this->getTags()->get('property-read', new Collection()));
         $propertyTags = $propertyTags->merge($this->getTags()->get('property-write', new Collection()));
 
-        /** @var Collection<PropertyDescriptor> $properties */
-        $properties = new Collection();
+        $properties = Collection::fromClassString(PropertyDescriptor::class);
 
         try {
             /** @var Tag\PropertyDescriptor $propertyTag */

--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -230,4 +230,18 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
             )
         );
     }
+
+    /**
+     * @template C
+     *
+     * @param class-string<C> $classString
+     * @param array<C> $elements
+     *
+     * @return Collection<C>
+     */
+    public static function fromClassString(string $classString, array $elements = []) : Collection
+    {
+        Assert::classExists($classString);
+        return new Collection($elements);
+    }
 }

--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -232,16 +232,17 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
     }
 
     /**
-     * @template C
-     *
      * @param class-string<C> $classString
      * @param array<C> $elements
      *
      * @return Collection<C>
+     *
+     * @template C
      */
     public static function fromClassString(string $classString, array $elements = []) : Collection
     {
         Assert::classExists($classString);
+
         return new Collection($elements);
     }
 }

--- a/src/phpDocumentor/Descriptor/InterfaceDescriptor.php
+++ b/src/phpDocumentor/Descriptor/InterfaceDescriptor.php
@@ -66,8 +66,7 @@ class InterfaceDescriptor extends DescriptorAbstract implements Interfaces\Inter
      */
     public function getInheritedConstants() : Collection
     {
-        /** @var Collection<ConstantDescriptor> $inheritedConstants */
-        $inheritedConstants = new Collection();
+        $inheritedConstants = Collection::fromClassString(ConstantDescriptor::class);
 
         /** @var self $parent */
         foreach ($this->getParent() as $parent) {
@@ -94,8 +93,7 @@ class InterfaceDescriptor extends DescriptorAbstract implements Interfaces\Inter
 
     public function getInheritedMethods() : Collection
     {
-        /** @var Collection<MethodDescriptor> $inheritedMethods */
-        $inheritedMethods = new Collection();
+        $inheritedMethods = Collection::fromClassString(MethodDescriptor::class);
 
         /** @var self $parent */
         foreach ($this->getParent() as $parent) {

--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -139,7 +139,7 @@ class ProjectDescriptorBuilder
      */
     private function filterEachDescriptor(iterable $descriptor) : Collection
     {
-        $descriptors = new Collection();
+        $descriptors = Collection::fromClassString(DescriptorAbstract::class);
         foreach ($descriptor as $key => $item) {
             $item = $this->filterDescriptor($item);
             if (!$item) {

--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -64,8 +64,7 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
         /** @var Collection<Tag\MethodDescriptor> $methodTags */
         $methodTags = clone $this->getTags()->get('method', new Collection());
 
-        /** @var Collection<MethodDescriptor> $methods */
-        $methods = new Collection();
+        $methods = Collection::fromClassString(MethodDescriptor::class);
 
         /** @var Tag\MethodDescriptor $methodTag */
         foreach ($methodTags as $methodTag) {
@@ -106,8 +105,7 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
         $propertyTags->merge($this->getTags()->get('property-read', new Collection()));
         $propertyTags->merge($this->getTags()->get('property-write', new Collection()));
 
-        /** @var Collection<PropertyDescriptor> $properties */
-        $properties = new Collection();
+        $properties = Collection::fromClassString(PropertyDescriptor::class);
 
         /** @var Tag\PropertyDescriptor $propertyTag */
         foreach ($propertyTags as $propertyTag) {

--- a/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
+++ b/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
@@ -42,8 +42,7 @@ final class InitializeBuilderFromConfig
         $builder->setCustomSettings($configuration['phpdocumentor']['settings'] ?? []);
 
         foreach (($configuration['phpdocumentor']['versions'] ?? []) as $number => $version) {
-            /** @var Collection<GuideSetDescriptor> $documentationSets */
-            $documentationSets = new Collection();
+            $documentationSets = Collection::fromClassString(GuideSetDescriptor::class);
 
             foreach ($version['guides'] ?? [] as $guide) {
                 $documentationSets->add(new GuideSetDescriptor('', $guide['source'], $guide['output']));


### PR DESCRIPTION
Adds a way to generate Collection instance from the class-string which will populate it.

It allows replacing this:
```php
/** @var Collection<RandomClass> */
$coll = new Collection($elements);
```
with 
```php
$coll = new Collection(RandomClass::class, $elements);
```

and still keep every benefit of having a generic'd Collection. For now, the class-string is not saved inside the Collection. If we are one day in need of more control, we could save the class-string and use it to validate every insertion in the Collection.