### PR TITLE
experiment with Collection::get

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,10 +15,11 @@ parameters:
     - '#Call to an undefined method League\\Flysystem\\Filesystem::find()#'
     # Bad design of descriptors.
     - '#Access to an undefined property phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\DescriptorAbstract>>::\$[a-z]+#'
-    # Issue on the content of this collection https://github.com/phpDocumentor/phpDocumentor/pull/2249#issuecomment-581111947
-    - '#Parameter \#1 \$item of method phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\TagDescriptor>::add\(\) expects phpDocumentor\\Descriptor\\TagDescriptor, phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\DescriptorAbstract>\|phpDocumentor\\Descriptor\\DescriptorAbstract given\.#'
     # https://github.com/phpDocumentor/phpDocumentor/issues/2279
     - '#Instanceof between phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\InterfaceDescriptor\|phpDocumentor\\Reflection\\Fqsen>\|phpDocumentor\\Reflection\\Fqsen\|string\|null and phpDocumentor\\Descriptor\\InterfaceDescriptor will always evaluate to false\.#'
+    # PHPStan doesn't support @template D of T but will still complain if we put a D in a Collection of T !
+    - '#Parameter \#2 \$value of method phpDocumentor\\Descriptor\\Collection<T>::offsetSet\(\) expects T, D given\.#'
+
     -
             message: "#^Parameter \\#1 \\$value of method phpDocumentor\\\\GraphViz\\\\Graph\\:\\:setCenter\\(\\) expects bool, string given\\.$#"
             count: 1

--- a/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
@@ -43,11 +43,11 @@ class ElementsIndexBuilder implements CompilerPassInterface
         $elementCollection = new Collection();
         $project->getIndexes()->set('elements', $elementCollection);
 
-        $constantsIndex  = $project->getIndexes()->get('constants', new Collection());
-        $functionsIndex  = $project->getIndexes()->get('functions', new Collection());
-        $classesIndex    = $project->getIndexes()->get('classes', new Collection());
-        $interfacesIndex = $project->getIndexes()->get('interfaces', new Collection());
-        $traitsIndex     = $project->getIndexes()->get('traits', new Collection());
+        $constantsIndex  = $project->getIndexes()->fetch('constants', new Collection());
+        $functionsIndex  = $project->getIndexes()->fetch('functions', new Collection());
+        $classesIndex    = $project->getIndexes()->fetch('classes', new Collection());
+        $interfacesIndex = $project->getIndexes()->fetch('interfaces', new Collection());
+        $traitsIndex     = $project->getIndexes()->fetch('traits', new Collection());
 
         foreach ($project->getFiles() as $file) {
             $this->addElementsToIndexes($file->getConstants()->getAll(), [$constantsIndex, $elementCollection]);

--- a/src/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractor.php
+++ b/src/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractor.php
@@ -36,9 +36,9 @@ final class MarkerFromTagsExtractor implements CompilerPassInterface
     public function execute(ProjectDescriptor $project) : void
     {
         /** @var DescriptorAbstract $element */
-        foreach ($project->getIndexes()->get('elements', new Collection()) as $element) {
+        foreach ($project->getIndexes()->fetch('elements', new Collection()) as $element) {
             /** @var TagDescriptor[] $todos */
-            $todos = $element->getTags()->get('todo');
+            $todos = $element->getTags()->fetch('todo');
 
             if (!$todos) {
                 continue;

--- a/src/phpDocumentor/Compiler/Pass/NamespaceTreeBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/NamespaceTreeBuilder.php
@@ -46,8 +46,8 @@ class NamespaceTreeBuilder implements CompilerPassInterface
 
     public function execute(ProjectDescriptor $project) : void
     {
-        $project->getIndexes()->get('elements', new Collection())->set('~\\', $project->getNamespace());
-        $project->getIndexes()->get('namespaces', new Collection())->set('\\', $project->getNamespace());
+        $project->getIndexes()->fetch('elements', new Collection())->set('~\\', $project->getNamespace());
+        $project->getIndexes()->fetch('namespaces', new Collection())->set('\\', $project->getNamespace());
 
         foreach ($project->getFiles() as $file) {
             $this->addElementsOfTypeToNamespace($project, $file->getConstants()->getAll(), 'constants');
@@ -88,7 +88,7 @@ class NamespaceTreeBuilder implements CompilerPassInterface
                 $namespaceName = '\\';
             }
 
-            $namespace = $project->getIndexes()->get('namespaces', new Collection())->get($namespaceName);
+            $namespace = $project->getIndexes()->fetch('namespaces', new Collection())->fetch($namespaceName);
 
             if ($namespace === null) {
                 $namespace = new NamespaceDescriptor();
@@ -98,7 +98,7 @@ class NamespaceTreeBuilder implements CompilerPassInterface
                 $namespaceName = substr((string) $fqsen, 0, -strlen($fqsen->getName()) - 1);
                 $namespace->setNamespace($namespaceName);
                 $project->getIndexes()
-                    ->get('namespaces')
+                    ->fetch('namespaces')
                     ->set((string) $namespace->getFullyQualifiedStructuralElementName(), $namespace);
                 $this->addToParentNamespace($project, $namespace);
             }
@@ -120,8 +120,8 @@ class NamespaceTreeBuilder implements CompilerPassInterface
     private function addToParentNamespace(ProjectDescriptor $project, NamespaceDescriptor $namespace) : void
     {
         /** @var NamespaceDescriptor|null $parent */
-        $parent = $project->getIndexes()->get('namespaces')->get($namespace->getNamespace());
-        $project->getIndexes()->get('elements')->set(
+        $parent = $project->getIndexes()->fetch('namespaces')->fetch($namespace->getNamespace());
+        $project->getIndexes()->fetch('elements')->set(
             '~' . (string) $namespace->getFullyQualifiedStructuralElementName(),
             $namespace
         );
@@ -135,7 +135,7 @@ class NamespaceTreeBuilder implements CompilerPassInterface
                 $namespaceName = substr((string) $fqsen, 0, -strlen($parent->getName()) - 1);
                 $parent->setNamespace($namespaceName === '' ? '\\' : $namespaceName);
                 $project->getIndexes()
-                    ->get('namespaces')
+                    ->fetch('namespaces')
                     ->set((string) $parent->getFullyQualifiedStructuralElementName(), $parent);
                 $this->addToParentNamespace($project, $parent);
             }

--- a/src/phpDocumentor/Compiler/Pass/PackageTreeBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/PackageTreeBuilder.php
@@ -90,7 +90,7 @@ final class PackageTreeBuilder implements CompilerPassInterface
     {
         foreach ($elements as $element) {
             $packageName = '';
-            $packageTags = $element->getTags()->get('package');
+            $packageTags = $element->getTags()->fetch('package');
             if ($packageTags instanceof Collection) {
                 $packageTag = $packageTags->getIterator()->current();
                 if ($packageTag instanceof TagDescriptor) {
@@ -98,7 +98,7 @@ final class PackageTreeBuilder implements CompilerPassInterface
                 }
             }
 
-            $subpackageCollection = $element->getTags()->get('subpackage');
+            $subpackageCollection = $element->getTags()->fetch('subpackage');
             if ($subpackageCollection instanceof Collection && $subpackageCollection->count() > 0) {
                 $subpackageTag = $subpackageCollection->getIterator()->current();
                 if ($subpackageTag instanceof TagDescriptor) {
@@ -160,7 +160,7 @@ final class PackageTreeBuilder implements CompilerPassInterface
         $pointer = $packages['\\'];
         foreach ($parts as $part) {
             $fqnn .= '\\' . $part;
-            if ($pointer->getChildren()->get($part)) {
+            if ($pointer->getChildren()->fetch($part)) {
                 $pointer = $pointer->getChildren()->get($part);
                 continue;
             }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/AssemblerAbstract.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/AssemblerAbstract.php
@@ -47,7 +47,7 @@ abstract class AssemblerAbstract extends BaseAssembler
             }
 
             $target->getTags()
-                ->get($tag->getName(), new Collection())
+                ->fetch($tag->getName(), new Collection())
                 ->add($tagDescriptor);
         }
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
@@ -82,9 +82,9 @@ class FileAssembler extends AssemblerAbstract
             }
 
             $constantDescriptor->setLocation($fileDescriptor, $constant->getLocation()->getLineNumber());
-            if (count($constantDescriptor->getTags()->get('package', new Collection())) === 0) {
+            if (count($constantDescriptor->getTags()->fetch('package', new Collection())) === 0) {
                 $constantDescriptor->getTags()
-                    ->set('package', $fileDescriptor->getTags()->get('package', new Collection()));
+                    ->set('package', $fileDescriptor->getTags()->fetch('package', new Collection()));
             }
 
             $fileDescriptor->getConstants()->set(
@@ -108,9 +108,9 @@ class FileAssembler extends AssemblerAbstract
             }
 
             $functionDescriptor->setLocation($fileDescriptor, $function->getLocation()->getLineNumber());
-            if (count($functionDescriptor->getTags()->get('package', new Collection())) === 0) {
+            if (count($functionDescriptor->getTags()->fetch('package', new Collection())) === 0) {
                 $functionDescriptor->getTags()
-                    ->set('package', $fileDescriptor->getTags()->get('package', new Collection()));
+                    ->set('package', $fileDescriptor->getTags()->fetch('package', new Collection()));
             }
 
             $fileDescriptor->getFunctions()->set(
@@ -134,10 +134,10 @@ class FileAssembler extends AssemblerAbstract
             }
 
             $classDescriptor->setLocation($fileDescriptor, $class->getLocation()->getLineNumber());
-            if (count($classDescriptor->getTags()->get('package', new Collection())) === 0) {
+            if (count($classDescriptor->getTags()->fetch('package', new Collection())) === 0) {
                 $classDescriptor->getTags()->set(
                     'package',
-                    $fileDescriptor->getTags()->get('package', new Collection())
+                    $fileDescriptor->getTags()->fetch('package', new Collection())
                 );
             }
 
@@ -162,9 +162,9 @@ class FileAssembler extends AssemblerAbstract
             }
 
             $interfaceDescriptor->setLocation($fileDescriptor, $interface->getLocation()->getLineNumber());
-            if (count($interfaceDescriptor->getTags()->get('package', new Collection())) === 0) {
+            if (count($interfaceDescriptor->getTags()->fetch('package', new Collection())) === 0) {
                 $interfaceDescriptor->getTags()
-                    ->set('package', $fileDescriptor->getTags()->get('package', new Collection()));
+                    ->set('package', $fileDescriptor->getTags()->fetch('package', new Collection()));
             }
 
             $fileDescriptor->getInterfaces()->set(
@@ -188,9 +188,9 @@ class FileAssembler extends AssemblerAbstract
             }
 
             $traitDescriptor->setLocation($fileDescriptor, $trait->getLocation()->getLineNumber());
-            if (count($traitDescriptor->getTags()->get('package', new Collection())) === 0) {
+            if (count($traitDescriptor->getTags()->fetch('package', new Collection())) === 0) {
                 $traitDescriptor->getTags()
-                    ->set('package', $fileDescriptor->getTags()->get('package', new Collection()));
+                    ->set('package', $fileDescriptor->getTags()->fetch('package', new Collection()));
             }
 
             $fileDescriptor->getTraits()->set(

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
@@ -116,7 +116,7 @@ class FunctionAssembler extends AssemblerAbstract
         Argument $argument
     ) : ArgumentDescriptor {
         /** @var Collection<ParamDescriptor> $params */
-        $params = $functionDescriptor->getTags()->get('param', new Collection())->filter(ParamDescriptor::class);
+        $params = $functionDescriptor->getTags()->fetch('param', new Collection())->filter(ParamDescriptor::class);
 
         if (!$this->argumentAssembler->getBuilder()) {
             $this->argumentAssembler->setBuilder($this->builder);

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
@@ -97,7 +97,7 @@ class MethodAssembler extends AssemblerAbstract
     protected function addArgument(Argument $argument, MethodDescriptor $descriptor) : void
     {
         /** @var Collection<ParamDescriptor> $params */
-        $params = $descriptor->getTags()->get('param', new Collection())->filter(ParamDescriptor::class);
+        $params = $descriptor->getTags()->fetch('param', new Collection())->filter(ParamDescriptor::class);
 
         if (!$this->argumentAssembler->getBuilder()) {
             $this->argumentAssembler->setBuilder($this->builder);

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -178,7 +178,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     public function getMagicMethods() : Collection
     {
         /** @var Collection<MethodDescriptor> $methodTags */
-        $methodTags = $this->getTags()->get('method', new Collection());
+        $methodTags = $this->getTags()->fetch('method', new Collection());
 
         $methods = Collection::fromClassString(MethodDescriptor::class);
 
@@ -191,7 +191,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
             $method->setParent($this);
 
             /** @var Collection<ReturnDescriptor> $returnTags */
-            $returnTags = $method->getTags()->get('return', new Collection());
+            $returnTags = $method->getTags()->fetch('return', new Collection());
             $returnTags->add($methodTag->getResponse());
 
             foreach ($methodTag->getArguments() as $name => $argument) {
@@ -246,9 +246,9 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     {
         $tags = $this->getTags();
         /** @var Collection<Tag\PropertyDescriptor> $propertyTags */
-        $propertyTags = $tags->get('property', new Collection())->filter(Tag\PropertyDescriptor::class)
-            ->merge($tags->get('property-read', new Collection())->filter(Tag\PropertyDescriptor::class))
-            ->merge($tags->get('property-write', new Collection())->filter(Tag\PropertyDescriptor::class));
+        $propertyTags = $tags->fetch('property', new Collection())->filter(Tag\PropertyDescriptor::class)
+            ->merge($tags->fetch('property-read', new Collection())->filter(Tag\PropertyDescriptor::class))
+            ->merge($tags->fetch('property-write', new Collection())->filter(Tag\PropertyDescriptor::class));
 
         $properties = Collection::fromClassString(PropertyDescriptor::class);
 

--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -18,6 +18,7 @@ use ArrayIterator;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
+use OutOfRangeException;
 use Webmozart\Assert\Assert;
 use function array_filter;
 use function array_merge;
@@ -73,6 +74,24 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
     }
 
     /**
+     * Retrieves a specific item from the Collection with its index. If index is not found, an exception is thrown
+     *
+     * @param string|int $index
+     *
+     * @return mixed The contents of the element with the given index
+     *
+     * @phpstan-return T
+     */
+    public function get($index)
+    {
+        if (!isset($this->items[$index])) {
+            throw new OutOfRangeException($index . ' offset not found in Collection');
+        }
+
+        return $this->items[$index];
+    }
+
+    /**
      * Retrieves a specific item from the Collection with its index.
      *
      * Please note that this method (intentionally) has the side effect that whenever a key does not exist that it will
@@ -84,11 +103,13 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
      *
      * @return mixed The contents of the element with the given index and the provided default if the key doesn't exist.
      *
-     * @phpstan-param T $valueIfEmpty
+     * @phpstan-param D $valueIfEmpty
      *
-     * @phpstan-return ?T
+     * @phpstan-return T|D
+     *
+     * @template D
      */
-    public function get($index, $valueIfEmpty = null)
+    public function fetch($index, $valueIfEmpty = null)
     {
         if (!$this->offsetExists($index) && $valueIfEmpty !== null) {
             $this->offsetSet($index, $valueIfEmpty);

--- a/src/phpDocumentor/Descriptor/ConstantDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ConstantDescriptor.php
@@ -81,7 +81,7 @@ class ConstantDescriptor extends DescriptorAbstract implements Interfaces\Consta
     public function getType() : ?Type
     {
         if ($this->types === null) {
-            $var = $this->getVar()->get(0);
+            $var = $this->getVar()->fetch(0);
             if ($var instanceof VarDescriptor) {
                 return $var->getType();
             }
@@ -106,7 +106,7 @@ class ConstantDescriptor extends DescriptorAbstract implements Interfaces\Consta
     public function getVar() : Collection
     {
         /** @var Collection<VarDescriptor> $var */
-        $var = $this->getTags()->get('var', new Collection());
+        $var = $this->getTags()->fetch('var', new Collection());
         if ($var->count() !== 0) {
             return $var;
         }
@@ -143,7 +143,7 @@ class ConstantDescriptor extends DescriptorAbstract implements Interfaces\Consta
             /** @var ClassDescriptor|InterfaceDescriptor $parentClass */
             $parentClass = $associatedClass->getParent();
 
-            return $parentClass->getConstants()->get($this->getName());
+            return $parentClass->getConstants()->fetch($this->getName());
         }
 
         return null;

--- a/src/phpDocumentor/Descriptor/DescriptorAbstract.php
+++ b/src/phpDocumentor/Descriptor/DescriptorAbstract.php
@@ -284,7 +284,7 @@ abstract class DescriptorAbstract implements Filterable
     public function getAuthor() : Collection
     {
         /** @var Collection<AuthorDescriptor> $author */
-        $author = $this->getTags()->get('author', new Collection());
+        $author = $this->getTags()->fetch('author', new Collection());
         if ($author->count() !== 0) {
             return $author;
         }
@@ -305,7 +305,7 @@ abstract class DescriptorAbstract implements Filterable
     public function getVersion() : Collection
     {
         /** @var Collection<VersionDescriptor> $version */
-        $version = $this->getTags()->get('version', new Collection());
+        $version = $this->getTags()->fetch('version', new Collection());
         if ($version->count() !== 0) {
             return $version;
         }
@@ -326,7 +326,7 @@ abstract class DescriptorAbstract implements Filterable
     public function getCopyright() : Collection
     {
         /** @var Collection<TagDescriptor> $copyright */
-        $copyright = $this->getTags()->get('copyright', new Collection());
+        $copyright = $this->getTags()->fetch('copyright', new Collection());
         if ($copyright->count() !== 0) {
             return $copyright;
         }
@@ -393,7 +393,7 @@ abstract class DescriptorAbstract implements Filterable
         $tagName = substr($name, 3);
         $tagName[0] = strtolower($tagName[0]); // lowercase the first letter
 
-        return $this->getTags()->get($tagName, new Collection());
+        return $this->getTags()->fetch($tagName, new Collection());
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/Filter/StripIgnore.php
+++ b/src/phpDocumentor/Descriptor/Filter/StripIgnore.php
@@ -37,7 +37,7 @@ class StripIgnore implements FilterInterface
      */
     public function __invoke(?DescriptorAbstract $value) : ?DescriptorAbstract
     {
-        if ($value !== null && $value->getTags()->get('ignore')) {
+        if ($value !== null && $value->getTags()->fetch('ignore')) {
             return null;
         }
 

--- a/src/phpDocumentor/Descriptor/Filter/StripInternal.php
+++ b/src/phpDocumentor/Descriptor/Filter/StripInternal.php
@@ -58,7 +58,7 @@ class StripInternal implements FilterInterface
         $value->setDescription(preg_replace('/\{@internal\s(.+?)\}\}/', '', $value->getDescription()));
 
         // if internal elements are not allowed; filter this element
-        if ($value->getTags()->get('internal')) {
+        if ($value->getTags()->fetch('internal')) {
             return null;
         }
 

--- a/src/phpDocumentor/Descriptor/FunctionDescriptor.php
+++ b/src/phpDocumentor/Descriptor/FunctionDescriptor.php
@@ -54,7 +54,7 @@ class FunctionDescriptor extends DescriptorAbstract implements Interfaces\Functi
         $definedReturn->setType($this->returnType);
 
         /** @var Collection<ReturnDescriptor> $returnTags */
-        $returnTags = $this->getTags()->get('return', new Collection())->filter(ReturnDescriptor::class);
+        $returnTags = $this->getTags()->fetch('return', new Collection())->filter(ReturnDescriptor::class);
 
         if ($returnTags instanceof Collection && $returnTags->count() > 0) {
             return current($returnTags->getAll());

--- a/src/phpDocumentor/Descriptor/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/MethodDescriptor.php
@@ -172,7 +172,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
     public function getReturn() : Collection
     {
         /** @var Collection<ReturnDescriptor> $var */
-        $var = $this->getTags()->get('return', new Collection())->filter(ReturnDescriptor::class);
+        $var = $this->getTags()->fetch('return', new Collection())->filter(ReturnDescriptor::class);
         if ($var->count() !== 0) {
             return $var;
         }
@@ -191,7 +191,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
     public function getParam() : Collection
     {
         /** @var Collection<ParamDescriptor> $var */
-        $var = $this->getTags()->get('param', new Collection());
+        $var = $this->getTags()->fetch('param', new Collection());
         if ($var instanceof Collection && $var->count() > 0) {
             return $var;
         }
@@ -238,7 +238,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
             $parents = $parentClass instanceof ClassDescriptor ? [$parentClass] : $parentClass->getAll();
             foreach ($parents as $parent) {
                 /** @var MethodDescriptor|null $parentMethod */
-                $parentMethod = $parent->getMethods()->get($this->getName());
+                $parentMethod = $parent->getMethods()->fetch($this->getName());
                 if ($parentMethod instanceof self) {
                     $this->inheritedElement = $parentMethod;
 
@@ -256,7 +256,7 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
                 }
 
                 /** @var ?MethodDescriptor $parentMethod */
-                $parentMethod = $interface->getMethods()->get($this->getName());
+                $parentMethod = $interface->getMethods()->fetch($this->getName());
                 if ($parentMethod instanceof self) {
                     $this->inheritedElement = $parentMethod;
 

--- a/src/phpDocumentor/Descriptor/ProjectAnalyzer.php
+++ b/src/phpDocumentor/Descriptor/ProjectAnalyzer.php
@@ -133,6 +133,6 @@ TEXT;
      */
     protected function findAllElements(ProjectDescriptor $projectDescriptor) : Collection
     {
-        return $projectDescriptor->getIndexes()->get('elements', new Collection());
+        return $projectDescriptor->getIndexes()->fetch('elements', new Collection());
     }
 }

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor.php
@@ -218,7 +218,7 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
             return null;
         }
 
-        return $this->getIndexes()['elements']->get((string) $fqsen);
+        return $this->getIndexes()['elements']->fetch((string) $fqsen);
     }
 
     private function setPackage(PackageInterface $package) : void

--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -168,7 +168,7 @@ class ProjectDescriptorBuilder
             $this->getProjectDescriptor()->getFiles()->set($descriptor->getPath(), $descriptor);
         }
 
-        $namespaces = $this->getProjectDescriptor()->getIndexes()->get('namespaces', new Collection());
+        $namespaces = $this->getProjectDescriptor()->getIndexes()->fetch('namespaces', new Collection());
 
         foreach ($project->getNamespaces() as $namespace) {
             $namespaces->set((string) $namespace->getFqsen(), $this->buildDescriptor($namespace));

--- a/src/phpDocumentor/Descriptor/PropertyDescriptor.php
+++ b/src/phpDocumentor/Descriptor/PropertyDescriptor.php
@@ -125,7 +125,7 @@ class PropertyDescriptor extends DescriptorAbstract implements
     public function getVar() : Collection
     {
         /** @var Collection<VarDescriptor> $var */
-        $var = $this->getTags()->get('var', new Collection());
+        $var = $this->getTags()->fetch('var', new Collection());
         if ($var->count() !== 0) {
             return $var;
         }
@@ -162,7 +162,7 @@ class PropertyDescriptor extends DescriptorAbstract implements
             /** @var ClassDescriptor|InterfaceDescriptor $parentClass */
             $parentClass = $associatedClass->getParent();
 
-            return $parentClass->getProperties()->get($this->getName());
+            return $parentClass->getProperties()->fetch($this->getName());
         }
 
         return null;

--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -62,7 +62,7 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
     public function getMagicMethods() : Collection
     {
         /** @var Collection<Tag\MethodDescriptor> $methodTags */
-        $methodTags = $this->getTags()->get('method', new Collection());
+        $methodTags = $this->getTags()->fetch('method', new Collection());
 
         $methods = Collection::fromClassString(MethodDescriptor::class);
 
@@ -102,9 +102,9 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
     {
         $tags = $this->getTags();
         /** @var Collection<Tag\PropertyDescriptor> $propertyTags */
-        $propertyTags = $tags->get('property', new Collection())->filter(Tag\PropertyDescriptor::class)
-            ->merge($tags->get('property-read', new Collection())->filter(Tag\PropertyDescriptor::class))
-            ->merge($tags->get('property-write', new Collection())->filter(Tag\PropertyDescriptor::class));
+        $propertyTags = $tags->fetch('property', new Collection())->filter(Tag\PropertyDescriptor::class)
+            ->merge($tags->fetch('property-read', new Collection())->filter(Tag\PropertyDescriptor::class))
+            ->merge($tags->fetch('property-write', new Collection())->filter(Tag\PropertyDescriptor::class));
 
         $properties = Collection::fromClassString(PropertyDescriptor::class);
 

--- a/src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
@@ -61,9 +61,9 @@ final class GraphVizClassDiagram implements Generator
 
         $this->buildNamespaceTree($graph, $project->getNamespace());
 
-        $classes = $project->getIndexes()->get('classes', new Collection())->getAll();
-        $interfaces = $project->getIndexes()->get('interfaces', new Collection())->getAll();
-        $traits = $project->getIndexes()->get('traits', new Collection())->getAll();
+        $classes = $project->getIndexes()->fetch('classes', new Collection())->getAll();
+        $interfaces = $project->getIndexes()->fetch('interfaces', new Collection())->getAll();
+        $traits = $project->getIndexes()->fetch('traits', new Collection())->getAll();
 
         /** @var ClassDescriptor[]|InterfaceDescriptor[]|TraitDescriptor[] $containers */
         $containers = array_merge($classes, $interfaces, $traits);

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -241,7 +241,7 @@ class ApiContext extends BaseContext implements Context
     {
         $class = $this->findClassByFqsen($classFqsen);
         /** @var MethodDescriptor $method */
-        $method = $class->getMethods()->get($methodName, null);
+        $method = $class->getMethods()->fetch($methodName, null);
         $methodNames = implode(', ', array_keys($class->getMethods()->getAll()));
 
         $visibilityLevel = $this->getAst()->getSettings()->getVisibility();
@@ -263,7 +263,7 @@ class ApiContext extends BaseContext implements Context
     {
         $class = $this->findClassByFqsen($classFqsen);
         /** @var PropertyDescriptor $property */
-        $property = $class->getProperties()->get($propertyName, null);
+        $property = $class->getProperties()->fetch($propertyName, null);
         Assert::isInstanceOf($property, PropertyDescriptor::class);
         Assert::eq($propertyName, $property->getName());
     }
@@ -346,7 +346,7 @@ class ApiContext extends BaseContext implements Context
     private static function AssertTagCount($element, $tagName, $expectedNumber)
     {
         /** @var Collection $tagCollection */
-        $tagCollection = $element->getTags()->get($tagName, new Collection());
+        $tagCollection = $element->getTags()->fetch($tagName, new Collection());
 
         Assert::eq((int) $expectedNumber, $tagCollection->count());
         if ($expectedNumber > 0) {
@@ -465,7 +465,7 @@ class ApiContext extends BaseContext implements Context
     {
         $class = $this->findClassByFqsen($classFqsen);
         /** @var MethodDescriptor $method */
-        $method = $class->getMethods()->get($methodName, null);
+        $method = $class->getMethods()->fetch($methodName, null);
         Assert::isInstanceOf($method, MethodDescriptor::class);
         Assert::eq($methodName, $method->getName());
 

--- a/tests/features/bootstrap/Ast/SeeTagContext.php
+++ b/tests/features/bootstrap/Ast/SeeTagContext.php
@@ -32,7 +32,7 @@ final class SeeTagContext extends BaseContext implements Context
     public function classHasTagSeeReferencingUrl($classFqsen, $reference)
     {
         $class = $this->findClassByFqsen($classFqsen);
-        $seeTags = $class->getTags()->get('see', []);
+        $seeTags = $class->getTags()->fetch('see', []);
         $this->hasSeeTagReference($seeTags, $reference);
     }
 
@@ -55,7 +55,7 @@ final class SeeTagContext extends BaseContext implements Context
     {
         $count = 0;
         $class = $this->findClassByFqsen($classFqsen);
-        $seeTags = $class->getTags()->get('see', []);
+        $seeTags = $class->getTags()->fetch('see', []);
         /** @var SeeDescriptor $tag */
         foreach ($seeTags as $tag) {
             $r = (string) $tag->getReference();
@@ -76,7 +76,7 @@ final class SeeTagContext extends BaseContext implements Context
     public function functionHasSeeTagReferencing(string $function, string $reference)
     {
         $functionDescriptor = $this->findFunctionByFqsen($function);
-        $this->hasSeeTagReference($functionDescriptor->getTags()->get('see', []), $reference);
+        $this->hasSeeTagReference($functionDescriptor->getTags()->fetch('see', []), $reference);
     }
 
     /**

--- a/tests/features/bootstrap/Ast/UsesTagContext.php
+++ b/tests/features/bootstrap/Ast/UsesTagContext.php
@@ -31,7 +31,7 @@ final class UsesTagContext extends BaseContext implements Context
     public function classHasTagUsesReferencingUrl($classFqsen, $reference)
     {
         $class = $this->findClassByFqsen($classFqsen);
-        $usesTags = $class->getTags()->get('uses', []);
+        $usesTags = $class->getTags()->fetch('uses', []);
         $this->hasUsesTagReference($usesTags, $reference);
     }
 
@@ -53,7 +53,7 @@ final class UsesTagContext extends BaseContext implements Context
     {
         $count = 0;
         $class = $this->findClassByFqsen($classFqsen);
-        $usesTags = $class->getTags()->get('uses', []);
+        $usesTags = $class->getTags()->fetch('uses', []);
         /** @var UsesTag $tag */
         foreach ($usesTags as $tag) {
             $r = (string) $tag->getReference();
@@ -75,7 +75,7 @@ final class UsesTagContext extends BaseContext implements Context
     public function functionHasUsesTagReferencing(string $function, string $reference)
     {
         $functionDescriptor = $this->findFunctionByFqsen($function);
-        $this->hasUsesTagReference($functionDescriptor->getTags()->get('uses', []), $reference);
+        $this->hasUsesTagReference($functionDescriptor->getTags()->fetch('uses', []), $reference);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
@@ -293,7 +293,7 @@ class ElementsIndexBuilderTest extends MockeryTestCase
         );
 
         // class properties are not indexed separately
-        $this->assertNull($this->project->getIndexes()->get('properties'));
+        $this->assertNull($this->project->getIndexes()->fetch('properties'));
     }
 
     /**
@@ -336,6 +336,6 @@ class ElementsIndexBuilderTest extends MockeryTestCase
         );
 
         // class methods are not indexed separately
-        $this->assertNull($this->project->getIndexes()->get('methods'));
+        $this->assertNull($this->project->getIndexes()->fetch('methods'));
     }
 }

--- a/tests/unit/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractorTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractorTest.php
@@ -98,7 +98,7 @@ final class MarkerFromTagsExtractorTest extends MockeryTestCase
     protected function givenProjectHasFileDescriptor() : FileDescriptor
     {
         $fileDescriptor1 = new FileDescriptor('123');
-        $elementIndex = $this->project->getIndexes()->get('elements', new Collection());
+        $elementIndex = $this->project->getIndexes()->fetch('elements', new Collection());
         $elementIndex->add($fileDescriptor1);
 
         return $fileDescriptor1;
@@ -111,7 +111,7 @@ final class MarkerFromTagsExtractorTest extends MockeryTestCase
         $todoTag = new TagDescriptor('todo');
         $todoTag->setDescription($description);
 
-        $todoTags = $descriptor->getTags()->get('todo', []);
+        $todoTags = $descriptor->getTags()->fetch('todo', []);
         $todoTags[] = $todoTag;
         $descriptor->getTags()->set('todo', $todoTags);
     }
@@ -127,7 +127,7 @@ final class MarkerFromTagsExtractorTest extends MockeryTestCase
             $classDescriptor->setFile($fileDescriptor);
         }
 
-        $elementIndex = $this->project->getIndexes()->get('elements', new Collection());
+        $elementIndex = $this->project->getIndexes()->fetch('elements', new Collection());
         $elementIndex->add($classDescriptor);
 
         return $classDescriptor;

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/TraitAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/TraitAssemblerTest.php
@@ -54,6 +54,6 @@ final class TraitAssemblerTest extends MockeryTestCase
         static::assertEquals('\My\Space', $result->getNamespace());
         static::assertSame($traitFqsen, $result->getFullyQualifiedStructuralElementName());
         static::assertEquals('MyTrait', $result->getName());
-        static::assertInstanceOf(MethodDescriptor::class, $result->getMethods()->get('method', false));
+        static::assertInstanceOf(MethodDescriptor::class, $result->getMethods()->fetch('method', false));
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
@@ -237,7 +237,7 @@ final class ClassDescriptorTest extends MockeryTestCase
         $propertyMock->shouldReceive('getDescription')->andReturn($description);
         $propertyMock->shouldReceive('getType')->andReturn(new String_());
 
-        $this->fixture->getTags()->get('property', new Collection())->add($propertyMock);
+        $this->fixture->getTags()->fetch('property', new Collection())->add($propertyMock);
 
         $magicProperties = $this->fixture->getMagicProperties();
 
@@ -381,7 +381,7 @@ final class ClassDescriptorTest extends MockeryTestCase
         $methodMock->shouldReceive('getArguments')->andReturn(new Collection(['argument1' => $argument]));
         $methodMock->shouldReceive('isStatic')->andReturn($isStatic);
 
-        $this->fixture->getTags()->get('method', new Collection())->add($methodMock);
+        $this->fixture->getTags()->fetch('method', new Collection())->add($methodMock);
 
         $magicMethods = $this->fixture->getMagicMethods();
 

--- a/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
@@ -123,7 +123,7 @@ final class CollectionTest extends MockeryTestCase
         $this->assertEquals('abc', $this->fixture->get('a'));
         $this->assertCount(1, $this->fixture);
 
-        $this->assertEquals('def', $this->fixture->get(1, 'def'));
+        $this->assertEquals('def', $this->fixture->fetch(1, 'def'));
         $this->assertCount(2, $this->fixture);
     }
 

--- a/tests/unit/phpDocumentor/Descriptor/Filter/StripIgnoreTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Filter/StripIgnoreTest.php
@@ -46,7 +46,7 @@ final class StripIgnoreTest extends MockeryTestCase
     public function testStripsIgnoreTagFromDescription() : void
     {
         $descriptor = m::mock(DescriptorAbstract::class);
-        $descriptor->shouldReceive('getTags->get')->with('ignore')->andReturn(true);
+        $descriptor->shouldReceive('getTags->fetch')->with('ignore')->andReturn(true);
 
         $this->assertNull($this->fixture->__invoke($descriptor));
     }
@@ -57,7 +57,7 @@ final class StripIgnoreTest extends MockeryTestCase
     public function testDescriptorIsUnmodifiedIfThereIsNoIgnoreTag() : void
     {
         $descriptor = m::mock(DescriptorAbstract::class);
-        $descriptor->shouldReceive('getTags->get')->with('ignore')->andReturn(false);
+        $descriptor->shouldReceive('getTags->fetch')->with('ignore')->andReturn(false);
 
         $this->assertEquals($descriptor, $this->fixture->__invoke($descriptor));
     }

--- a/tests/unit/phpDocumentor/Descriptor/Filter/StripInternalTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Filter/StripInternalTest.php
@@ -47,7 +47,7 @@ final class StripInternalTest extends MockeryTestCase
     {
         $this->builderMock->shouldReceive('getProjectDescriptor->isVisibilityAllowed')->andReturn(false);
         $descriptor = m::mock(DescriptorAbstract::class);
-        $descriptor->shouldReceive('getTags->get')->with('internal')->andReturn(null);
+        $descriptor->shouldReceive('getTags->fetch')->with('internal')->andReturn(null);
 
         $descriptor->shouldReceive('getDescription')->andReturn('without {@internal blabla }}internal tag');
         $descriptor->shouldReceive('setDescription')->with('without internal tag');
@@ -62,7 +62,7 @@ final class StripInternalTest extends MockeryTestCase
     {
         $this->builderMock->shouldReceive('getProjectDescriptor->isVisibilityAllowed')->andReturn(false);
         $descriptor = m::mock(DescriptorAbstract::class);
-        $descriptor->shouldReceive('getTags->get')->with('internal')->andReturn(null);
+        $descriptor->shouldReceive('getTags->fetch')->with('internal')->andReturn(null);
 
         $descriptor->shouldReceive('getDescription')->andReturn('without {@internal bla{bla} }}internal tag');
         $descriptor->shouldReceive('setDescription')->with('without internal tag');
@@ -94,7 +94,7 @@ final class StripInternalTest extends MockeryTestCase
         $descriptor = m::mock(DescriptorAbstract::class);
         $descriptor->shouldReceive('getDescription');
         $descriptor->shouldReceive('setDescription');
-        $descriptor->shouldReceive('getTags->get')->with('internal')->andReturn(true);
+        $descriptor->shouldReceive('getTags->fetch')->with('internal')->andReturn(true);
 
         $this->assertNull($this->fixture->__invoke($descriptor));
     }

--- a/tests/unit/phpDocumentor/Descriptor/ProjectAnalyzerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectAnalyzerTest.php
@@ -107,7 +107,7 @@ TEXT;
         m\MockInterface $projectDescriptor,
         array $elements
     ) : void {
-        $projectDescriptor->shouldReceive('getIndexes->get')
+        $projectDescriptor->shouldReceive('getIndexes->fetch')
             ->with('elements', m::type(DescriptorCollection::class))
             ->andReturn(new Collection($elements));
     }


### PR DESCRIPTION
I would like to transform Collection::get() so it can never return null again.

There are four reasons for that:
- There are a lot of places where we chain get(). If it can return null, there is a risk of null pointer exception everywhere
- get() is used in __get(). Magic is obscure enough without adding the fact that sometimes an attribute will return null
- It's used with a default value and it will change the state of the Collection (semantically, it should not be a getter)
- Overall, it contributes to having null everywhere, Psalm complains very early and PHPStan will start complaining about that next level I believe.

To do that, I remove the possibility to pass a default value to get() and I check the existence of a value for the given offset. If there's not, an exception is thrown.

To cover all the cases I removed, I added a fetch() method who do pretty much the same thing as the old get() but I'll probably rework it a little. Every case where we use the default value or we expect that the collection may return null, I replaced get() by fetch().
Semantically, it means that every call to fetch() without default value should be checked for null if needed.

This is still a draft. I expect CI will throw some exceptions to me where I forgot to replace some get().