### PR TITLE
Improvements

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -12,6 +12,8 @@
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />
+            <!-- Symfony file -->
+            <file name="src/phpDocumentor/Kernel.php"/>
             <!-- This specific file seems a work in progress -->
             <file name="src/phpDocumentor/Guides/Generator/HtmlForPdfGenerator.php"/>
         </ignoreFiles>
@@ -48,6 +50,7 @@
         <PossiblyInvalidIterator errorLevel="info" />
         <PossiblyInvalidMethodCall errorLevel="info" />
         <PossiblyNullArgument errorLevel="info" />
+        <PossiblyNullIterator errorLevel="info" />
         <PossiblyNullOperand errorLevel="info" />
         <PossiblyNullPropertyAssignmentValue errorLevel="info" />
         <PossiblyNullReference errorLevel="info" />
@@ -119,5 +122,13 @@
                 <file name="src/phpDocumentor/Console/Command/Project/RunCommand.php"/>
             </errorLevel>
         </UnusedClosureParam>
+
+        <MixedMethodCall>
+            <errorLevel type="suppress">
+                <!-- Big chunks of chained method calls with unclear return types -->
+                <file name="src/phpDocumentor/Configuration/Definition/Version2.php"/>
+                <file name="src/phpDocumentor/Configuration/Definition/Version3.php"/>
+            </errorLevel>
+        </MixedMethodCall>
     </issueHandlers>
 </psalm>

--- a/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
+++ b/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration;
 
+use League\Uri\Contracts\UriInterface;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
 use function array_map;
@@ -23,7 +24,7 @@ use function end;
 use function explode;
 use function implode;
 
-final class CommandlineOptionsMiddleware
+final class CommandlineOptionsMiddleware implements MiddlewareInterface
 {
     /** @var array<string|string[]> */
     private $options;
@@ -49,7 +50,7 @@ final class CommandlineOptionsMiddleware
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    public function __invoke(array $configuration) : array
+    public function __invoke(array $configuration, ?UriInterface $uri) : array
     {
         $configuration = $this->overwriteDestinationFolder($configuration);
         $configuration = $this->disableCache($configuration);

--- a/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
+++ b/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
@@ -50,7 +50,7 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    public function __invoke(array $configuration, ?UriInterface $uri) : array
+    public function __invoke(array $configuration, ?UriInterface $uri = null) : array
     {
         $configuration = $this->overwriteDestinationFolder($configuration);
         $configuration = $this->disableCache($configuration);

--- a/src/phpDocumentor/Configuration/ConfigurationFactory.php
+++ b/src/phpDocumentor/Configuration/ConfigurationFactory.php
@@ -28,7 +28,7 @@ use function sprintf;
      * A series of callables that take the configuration array as parameter and should return that array or a modified
      * version of it.
      *
-     * @var array<callable(mixed[], ?UriInterface) : mixed[]>
+     * @var list<MiddlewareInterface>
      */
     private $middlewares = [];
 
@@ -51,10 +51,8 @@ use function sprintf;
 
     /**
      * Adds a middleware callback that allows the consumer to alter the configuration array when it is constructed.
-     *
-     * @param callable(mixed[], ?UriInterface) : mixed[] $middleware
      */
-    public function addMiddleware(callable $middleware) : void
+    public function addMiddleware(MiddlewareInterface $middleware) : void
     {
         $this->middlewares[] = $middleware;
     }

--- a/src/phpDocumentor/Configuration/ConfigurationFactory.php
+++ b/src/phpDocumentor/Configuration/ConfigurationFactory.php
@@ -28,7 +28,7 @@ use function sprintf;
      * A series of callables that take the configuration array as parameter and should return that array or a modified
      * version of it.
      *
-     * @var callable[]
+     * @var array<callable(mixed[], ?UriInterface) : mixed[]>
      */
     private $middlewares = [];
 
@@ -51,6 +51,8 @@ use function sprintf;
 
     /**
      * Adds a middleware callback that allows the consumer to alter the configuration array when it is constructed.
+     *
+     * @param callable(mixed[], ?UriInterface) : mixed[] $middleware
      */
     public function addMiddleware(callable $middleware) : void
     {

--- a/src/phpDocumentor/Configuration/MiddlewareInterface.php
+++ b/src/phpDocumentor/Configuration/MiddlewareInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link http://phpdoc.org
+ */
+
+namespace phpDocumentor\Configuration;
+
+
+use League\Uri\Contracts\UriInterface;
+
+interface MiddlewareInterface
+{
+    /**
+     * @param array<string, array<string, array<string, mixed>>> $configuration
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    public function __invoke(array $configuration, ?UriInterface $uri) : array;
+}

--- a/src/phpDocumentor/Configuration/MiddlewareInterface.php
+++ b/src/phpDocumentor/Configuration/MiddlewareInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration;
 
-
 use League\Uri\Contracts\UriInterface;
 
 interface MiddlewareInterface
@@ -23,5 +22,5 @@ interface MiddlewareInterface
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    public function __invoke(array $configuration, ?UriInterface $uri) : array;
+    public function __invoke(array $configuration, ?UriInterface $uri = null) : array;
 }

--- a/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
+++ b/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
@@ -19,7 +19,7 @@ final class PathNormalizingMiddleware implements MiddlewareInterface
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    public function __invoke(array $configuration, ?UriInterface $uri) : array
+    public function __invoke(array $configuration, ?UriInterface $uri = null) : array
     {
         $configuration = $this->makeDsnRelativeToConfig($configuration, $uri);
 

--- a/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
+++ b/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration;
 
-use League\Uri\Uri;
+use League\Uri\Contracts\UriInterface;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
 use function ltrim;
@@ -12,14 +12,14 @@ use function rtrim;
 use function strpos;
 use function substr;
 
-final class PathNormalizingMiddleware
+final class PathNormalizingMiddleware implements MiddlewareInterface
 {
     /**
      * @param array<string, array<string, array<string, mixed>>> $configuration
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    public function __invoke(array $configuration, ?Uri $uri) : array
+    public function __invoke(array $configuration, ?UriInterface $uri) : array
     {
         $configuration = $this->makeDsnRelativeToConfig($configuration, $uri);
 
@@ -49,7 +49,7 @@ final class PathNormalizingMiddleware
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    private function makeDsnRelativeToConfig(array $configuration, ?Uri $uri) : array
+    private function makeDsnRelativeToConfig(array $configuration, ?UriInterface $uri) : array
     {
         if ($uri === null) {
             return $configuration;
@@ -130,7 +130,7 @@ final class PathNormalizingMiddleware
         return $path;
     }
 
-    public function normalizeCachePath(?Uri $uri, Path $cachePath) : Path
+    public function normalizeCachePath(?UriInterface $uri, Path $cachePath) : Path
     {
         if ($cachePath::isAbsolutePath((string) $cachePath)) {
             return $cachePath;

--- a/src/phpDocumentor/Configuration/ProvideTemplateOverridePathMiddleware.php
+++ b/src/phpDocumentor/Configuration/ProvideTemplateOverridePathMiddleware.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration;
 
-use League\Uri\Uri;
+use League\Uri\Contracts\UriInterface;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
 use phpDocumentor\Transformer\Writer\Twig\EnvironmentFactory;
 use function file_exists;
 
-final class ProvideTemplateOverridePathMiddleware
+final class ProvideTemplateOverridePathMiddleware implements MiddlewareInterface
 {
     /** @var EnvironmentFactory */
     private $environmentFactory;
@@ -21,11 +21,11 @@ final class ProvideTemplateOverridePathMiddleware
     }
 
     /**
-     * @param array<string, array<string, array<mixed>>> $configuration
+     * @param array<string, array<string, array<string, mixed>>> $configuration
      *
-     * @return array<string, array<string, array<mixed>>>
+     * @return array<string, array<string, array<string, mixed>>>
      */
-    public function __invoke(array $configuration, ?Uri $uri) : array
+    public function __invoke(array $configuration, ?UriInterface $uri) : array
     {
         $path = $this->normalizePath($uri, new Path('.phpdoc/template'));
         if (file_exists((string) $path)) {
@@ -35,7 +35,7 @@ final class ProvideTemplateOverridePathMiddleware
         return $configuration;
     }
 
-    public function normalizePath(?Uri $uri, Path $path) : Path
+    public function normalizePath(?UriInterface $uri, Path $path) : Path
     {
         if ($uri === null) {
             return $path;

--- a/src/phpDocumentor/Configuration/ProvideTemplateOverridePathMiddleware.php
+++ b/src/phpDocumentor/Configuration/ProvideTemplateOverridePathMiddleware.php
@@ -25,7 +25,7 @@ final class ProvideTemplateOverridePathMiddleware implements MiddlewareInterface
      *
      * @return array<string, array<string, array<string, mixed>>>
      */
-    public function __invoke(array $configuration, ?UriInterface $uri) : array
+    public function __invoke(array $configuration, ?UriInterface $uri = null) : array
     {
         $path = $this->normalizePath($uri, new Path('.phpdoc/template'));
         if (file_exists((string) $path)) {

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
@@ -81,8 +81,8 @@ class AssemblerFactory
     /**
      * Registers an assembler instance to this factory.
      *
-     * @param callable $matcher A callback function accepting the criteria as only parameter and which must
-     *     return a boolean.
+     * @param callable(object) : bool $matcher A callback function accepting the criteria as only parameter and which
+     *     must return a boolean.
      * @param AssemblerInterface $assembler An instance of the Assembler that will be returned if the callback returns
      *     true with the provided criteria.
      */
@@ -95,8 +95,8 @@ class AssemblerFactory
      * Registers an assembler instance to this factory that is to be executed after all other assemblers have been
      * checked.
      *
-     * @param callable $matcher A callback function accepting the criteria as only parameter and which must
-     *     return a boolean.
+     * @param callable(object) : bool $matcher A callback function accepting the criteria as only parameter and which
+     *     must return a boolean.
      * @param AssemblerInterface $assembler An instance of the Assembler that will be returned if the callback returns
      *     true with the provided criteria.
      */

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
@@ -81,12 +81,12 @@ class AssemblerFactory
     /**
      * Registers an assembler instance to this factory.
      *
-     * @param callable(object) : bool $matcher A callback function accepting the criteria as only parameter and which
+     * @param Matcher<mixed> $matcher A callback function accepting the criteria as only parameter and which
      *     must return a boolean.
      * @param AssemblerInterface $assembler An instance of the Assembler that will be returned if the callback returns
      *     true with the provided criteria.
      */
-    public function register(callable $matcher, AssemblerInterface $assembler) : void
+    public function register(Matcher $matcher, AssemblerInterface $assembler) : void
     {
         $this->assemblers[] = new AssemblerMatcher($matcher, $assembler);
     }
@@ -95,12 +95,12 @@ class AssemblerFactory
      * Registers an assembler instance to this factory that is to be executed after all other assemblers have been
      * checked.
      *
-     * @param callable(object) : bool $matcher A callback function accepting the criteria as only parameter and which
+     * @param Matcher<mixed> $matcher A callback function accepting the criteria as only parameter and which
      *     must return a boolean.
      * @param AssemblerInterface $assembler An instance of the Assembler that will be returned if the callback returns
      *     true with the provided criteria.
      */
-    public function registerFallback(callable $matcher, AssemblerInterface $assembler) : void
+    public function registerFallback(Matcher $matcher, AssemblerInterface $assembler) : void
     {
         $this->fallbackAssemblers[] = new AssemblerMatcher($matcher, $assembler);
     }

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerMatcher.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerMatcher.php
@@ -20,12 +20,16 @@ use phpDocumentor\Reflection\Php\File;
 
 final class AssemblerMatcher
 {
-    /** @var callable */
+    /** @var callable(object) : bool */
     private $matcher;
 
     /** @var AssemblerInterface */
     private $assembler;
 
+    /**
+     * @param callable(object) : bool $matcher
+     * @param AssemblerInterface $assembler
+     */
     public function __construct(callable $matcher, AssemblerInterface $assembler)
     {
         $this->matcher   = $matcher;

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerMatcher.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerMatcher.php
@@ -28,7 +28,6 @@ final class AssemblerMatcher
 
     /**
      * @param Matcher<mixed> $matcher
-     * @param AssemblerInterface $assembler
      */
     public function __construct(Matcher $matcher, AssemblerInterface $assembler)
     {

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerMatcher.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerMatcher.php
@@ -20,17 +20,17 @@ use phpDocumentor\Reflection\Php\File;
 
 final class AssemblerMatcher
 {
-    /** @var callable(object) : bool */
+    /** @var Matcher<mixed> */
     private $matcher;
 
     /** @var AssemblerInterface */
     private $assembler;
 
     /**
-     * @param callable(object) : bool $matcher
+     * @param Matcher<mixed> $matcher
      * @param AssemblerInterface $assembler
      */
-    public function __construct(callable $matcher, AssemblerInterface $assembler)
+    public function __construct(Matcher $matcher, AssemblerInterface $assembler)
     {
         $this->matcher   = $matcher;
         $this->assembler = $assembler;

--- a/src/phpDocumentor/Descriptor/Builder/Matcher.php
+++ b/src/phpDocumentor/Descriptor/Builder/Matcher.php
@@ -17,7 +17,7 @@ final class Matcher
     /**
      * @param class-string<StaticT> $type
      *
-     * @return static<StaticT>
+     * @return Matcher<StaticT>
      *
      * @template StaticT
      */

--- a/src/phpDocumentor/Parser/Middleware/CacheMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/CacheMiddleware.php
@@ -46,6 +46,8 @@ final class CacheMiddleware implements Middleware
      * Executes this middle ware class.
      * A middle ware class MUST return a File object or call the $next callable.
      *
+     * @param callable(Command): object $next
+     *
      * @return File
      *
      * @throws InvalidArgumentException

--- a/src/phpDocumentor/Parser/Middleware/EmittingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/EmittingMiddleware.php
@@ -18,7 +18,7 @@ use phpDocumentor\Parser\Event\PreFileEvent;
 use phpDocumentor\Reflection\Middleware\Command;
 use phpDocumentor\Reflection\Middleware\Middleware;
 use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
-use function assert;
+use Webmozart\Assert\Assert;
 use function class_exists;
 
 final class EmittingMiddleware implements Middleware
@@ -28,7 +28,7 @@ final class EmittingMiddleware implements Middleware
      */
     public function execute(Command $command, callable $next) : object
     {
-        assert($command instanceof CreateCommand);
+        Assert::isInstanceOf($command, CreateCommand::class);
 
         if (class_exists(Dispatcher::class)) {
             Dispatcher::getInstance()->dispatch(

--- a/src/phpDocumentor/Parser/Middleware/EmittingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/EmittingMiddleware.php
@@ -23,6 +23,9 @@ use function class_exists;
 
 final class EmittingMiddleware implements Middleware
 {
+    /**
+     * @param callable(Command): object $next
+     */
     public function execute(Command $command, callable $next) : object
     {
         assert($command instanceof CreateCommand);

--- a/src/phpDocumentor/Parser/Middleware/ErrorHandlingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/ErrorHandlingMiddleware.php
@@ -32,6 +32,9 @@ final class ErrorHandlingMiddleware implements Middleware
         $this->logger = $logger;
     }
 
+    /**
+     * @param callable(Command): object $next
+     */
     public function execute(Command $command, callable $next) : object
     {
         assert($command instanceof CreateCommand);

--- a/src/phpDocumentor/Parser/Middleware/ErrorHandlingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/ErrorHandlingMiddleware.php
@@ -20,7 +20,7 @@ use phpDocumentor\Reflection\Php\File;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Throwable;
-use function assert;
+use Webmozart\Assert\Assert;
 
 final class ErrorHandlingMiddleware implements Middleware
 {
@@ -37,7 +37,7 @@ final class ErrorHandlingMiddleware implements Middleware
      */
     public function execute(Command $command, callable $next) : object
     {
-        assert($command instanceof CreateCommand);
+        Assert::isInstanceOf($command, CreateCommand::class);
 
         $filename = $command->getFile()->path();
         $this->log('Starting to parse file: ' . $filename);

--- a/src/phpDocumentor/Parser/Middleware/ReEncodingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/ReEncodingMiddleware.php
@@ -18,6 +18,7 @@ use phpDocumentor\Reflection\Middleware\Command;
 use phpDocumentor\Reflection\Middleware\Middleware;
 use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
 use Symfony\Component\String\ByteString;
+use Webmozart\Assert\Assert;
 
 final class ReEncodingMiddleware implements Middleware
 {
@@ -34,9 +35,7 @@ final class ReEncodingMiddleware implements Middleware
      */
     public function execute(Command $command, callable $next) : object
     {
-        if (!$command instanceof CreateCommand) {
-            return $next($command);
-        }
+        Assert::isInstanceOf($command, CreateCommand::class);
 
         $file = new ReEncodedFile(
             $command->getFile()->path(),

--- a/src/phpDocumentor/Parser/Middleware/ReEncodingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/ReEncodingMiddleware.php
@@ -29,6 +29,9 @@ final class ReEncodingMiddleware implements Middleware
         $this->encoding = $encoding;
     }
 
+    /**
+     * @param callable(Command): object $next
+     */
     public function execute(Command $command, callable $next) : object
     {
         if (!$command instanceof CreateCommand) {

--- a/src/phpDocumentor/Parser/Middleware/StopwatchMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/StopwatchMiddleware.php
@@ -41,6 +41,8 @@ final class StopwatchMiddleware implements Middleware
 
     /**
      * Executes this middleware class.
+     *
+     * @param callable(Command): object $next
      */
     public function execute(Command $command, callable $next) : object
     {

--- a/src/phpDocumentor/Parser/Middleware/StopwatchMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/StopwatchMiddleware.php
@@ -15,9 +15,11 @@ namespace phpDocumentor\Parser\Middleware;
 
 use phpDocumentor\Reflection\Middleware\Command;
 use phpDocumentor\Reflection\Middleware\Middleware;
+use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Webmozart\Assert\Assert;
 use function end;
 use function number_format;
 use function sprintf;
@@ -46,6 +48,8 @@ final class StopwatchMiddleware implements Middleware
      */
     public function execute(Command $command, callable $next) : object
     {
+        Assert::isInstanceOf($command, CreateCommand::class);
+
         $result = $next($command);
 
         $lap       = $this->stopwatch->lap('parser.parse');

--- a/src/phpDocumentor/Transformer/Writer/Pathfinder.php
+++ b/src/phpDocumentor/Transformer/Writer/Pathfinder.php
@@ -29,7 +29,7 @@ final class Pathfinder
      * element. This method will silently fail if an invalid query was provided; in such a case the given object
      * is returned.
      *
-     * @param Traversable<string, mixed>|Descriptor $object
+     * @param Traversable<string, Descriptor>|Descriptor $object
      *
      * @return Traversable<mixed>|list<mixed>
      */
@@ -51,7 +51,7 @@ final class Pathfinder
     /**
      * Walks an object graph and/or array using a twig query string.
      *
-     * @param Traversable<string, mixed>|Descriptor $object
+     * @param Traversable<string, Descriptor>|Descriptor $object
      * @param string $query A path to walk separated by dots, i.e. `namespace.namespaces`.
      *
      * @return mixed

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -157,6 +157,7 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
      */
     public function getFilters() : array
     {
+        /** @var Parsedown $parser */
         $parser = Parsedown::instance();
         $routeRenderer = $this->routeRenderer;
 

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -196,7 +196,7 @@ final class LinkRenderer
     /**
      * Returns a series of anchors and strings for the given collection of routable items.
      *
-     * @param iterable<mixed> $value
+     * @param iterable<array<Type>|Type|DescriptorAbstract|Fqsen|Path|string|iterable<mixed>> $value
      *
      * @return list<string>
      */

--- a/tests/unit/phpDocumentor/Configuration/ConfigurationFactoryTest.php
+++ b/tests/unit/phpDocumentor/Configuration/ConfigurationFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration;
 
+use League\Uri\Contracts\UriInterface;
 use League\Uri\Uri;
 use org\bovigo\vfs\vfsStream;
 use phpDocumentor\Configuration\Exception\InvalidConfigPathException;
@@ -53,8 +54,12 @@ final class ConfigurationFactoryTest extends TestCase
      */
     public function testCreatingTheDefaultConfigurationDoesNotApplyAnyMiddleware() : void
     {
-        $middleware = static function (array $values) {
-            return $values + ['anotherExample'];
+        $middleware = new class implements MiddlewareInterface
+        {
+            public function __invoke(array $values, ?UriInterface $uri = null) : array
+            {
+                return $values + ['anotherExample'];
+            }
         };
 
         $configuration = ['exampleConfig'];
@@ -159,8 +164,12 @@ final class ConfigurationFactoryTest extends TestCase
      */
     public function testCreatingAConfigurationUsingTheGivenUriAppliesAnyMiddleware() : void
     {
-        $middleware = static function (array $values) {
-            return $values + ['anotherExample'];
+        $middleware = new class implements MiddlewareInterface
+        {
+            public function __invoke(array $values, ?UriInterface $uri = null) : array
+            {
+                return $values + ['anotherExample'];
+            }
         };
 
         // using __FILE__ so that it passes the file does not exist scenario


### PR DESCRIPTION
This PR introduce a MiddlewareInterface to standardize Middlewares in phpDocumentor/Configuration.

I realized later that there's also a Middleware Interface in phpDocumentor/Reflection. They seem unrelated if I'm not mistaken.

I replaced some usage of League/Uri by UriInterface that was already used at some point to standardize.

I replaced the type "callable" by Matcher when applicable. It's much more clear what's going on.

I replaced some assert() usage by Assert also to standardize things between classes.

There's only one class that implements Command so I asserted that every command is a CreateCommand but I expect this to fail at some point. It's very unclear what's done here for me but I think there was an attempt to have other Commands at some point, should we keep this possibility?

EDIT: forgot to create as draft. This is not ready to be merged. And possibly never will :)