### PR TITLE
ConstantDescriptor can't have FileDescriptor as parent

### DIFF
--- a/src/phpDocumentor/Descriptor/ConstantDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ConstantDescriptor.php
@@ -63,7 +63,7 @@ class ConstantDescriptor extends DescriptorAbstract implements
     }
 
     /**
-     * @return ClassDescriptor|InterfaceDescriptor|FileDescriptor|null
+     * @return ClassDescriptor|InterfaceDescriptor|null
      */
     public function getParent() : ?DescriptorAbstract
     {

--- a/src/phpDocumentor/Transformer/Router/Router.php
+++ b/src/phpDocumentor/Transformer/Router/Router.php
@@ -85,8 +85,7 @@ class Router
             );
         }
 
-        if ($node instanceof ConstantDescriptor
-            && ($node->getParent() instanceof FileDescriptor || !$node->getParent())) {
+        if ($node instanceof ConstantDescriptor && $node->getParent() === null) {
             return $this->generateUrlForDescriptor(
                 'namespace',
                 (string) $node->getNamespace(),
@@ -94,8 +93,7 @@ class Router
             );
         }
 
-        if ($node instanceof ConstantDescriptor
-            && !($node->getParent() instanceof FileDescriptor || !$node->getParent())) {
+        if ($node instanceof ConstantDescriptor && $node->getParent() !== null) {
             return $this->generateUrlForDescriptor(
                 'class',
                 (string) $node->getParent()->getFullyQualifiedStructuralElementName(),


### PR DESCRIPTION
This PR removes FileDescriptor as a parent of ConstantDescriptor. This case can't happen because of this check: https://github.com/phpDocumentor/phpDocumentor/blob/master/src/phpDocumentor/Descriptor/ConstantDescriptor.php#L50

The FileDescriptor is pushed to ConstantDescriptor's location instead.

I changed two conditions in Router that were checking for FileDescriptor according to this.