### PR TITLE
Fix build

### DIFF
--- a/src/phpDocumentor/Descriptor/FileDescriptor.php
+++ b/src/phpDocumentor/Descriptor/FileDescriptor.php
@@ -15,7 +15,6 @@ namespace phpDocumentor\Descriptor;
 
 use phpDocumentor\Descriptor\Validation\Error;
 use phpDocumentor\Reflection\Fqsen;
-use function method_exists;
 
 /**
  * Represents a file in the project.
@@ -302,7 +301,7 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
         }
 
         foreach ($types as $element) {
-            if($element instanceof ClassDescriptor ||
+            if ($element instanceof ClassDescriptor ||
                 $element instanceof InterfaceDescriptor ||
                 $element instanceof TraitDescriptor
             ) {
@@ -311,8 +310,7 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
                 }
             }
 
-
-            if($element instanceof ClassDescriptor ||
+            if ($element instanceof ClassDescriptor ||
                 $element instanceof InterfaceDescriptor
             ) {
                 foreach ($element->getConstants() as $item) {
@@ -320,12 +318,14 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
                 }
             }
 
-            if($element instanceof ClassDescriptor ||
-                $element instanceof TraitDescriptor
+            if (!$element instanceof ClassDescriptor &&
+                !$element instanceof TraitDescriptor
             ) {
-                foreach ($element->getProperties() as $item) {
-                    $errors = $errors->merge($item->getErrors());
-                }
+                continue;
+            }
+
+            foreach ($element->getProperties() as $item) {
+                $errors = $errors->merge($item->getErrors());
             }
         }
 

--- a/src/phpDocumentor/Descriptor/FileDescriptor.php
+++ b/src/phpDocumentor/Descriptor/FileDescriptor.php
@@ -302,22 +302,30 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
         }
 
         foreach ($types as $element) {
-            foreach ($element->getMethods() as $item) {
-                $errors = $errors->merge($item->getErrors());
+            if($element instanceof ClassDescriptor ||
+                $element instanceof InterfaceDescriptor ||
+                $element instanceof TraitDescriptor
+            ) {
+                foreach ($element->getMethods() as $item) {
+                    $errors = $errors->merge($item->getErrors());
+                }
             }
 
-            if (method_exists($element, 'getConstants')) {
+
+            if($element instanceof ClassDescriptor ||
+                $element instanceof InterfaceDescriptor
+            ) {
                 foreach ($element->getConstants() as $item) {
                     $errors = $errors->merge($item->getErrors());
                 }
             }
 
-            if (!method_exists($element, 'getProperties')) {
-                continue;
-            }
-
-            foreach ($element->getProperties() as $item) {
-                $errors = $errors->merge($item->getErrors());
+            if($element instanceof ClassDescriptor ||
+                $element instanceof TraitDescriptor
+            ) {
+                foreach ($element->getProperties() as $item) {
+                    $errors = $errors->merge($item->getErrors());
+                }
             }
         }
 


### PR DESCRIPTION
On last version, Psalm detects a new error.

It comes from calling getMethods, getConstants and getProperties on a DescriptorAbstract.

DescriptorAbstract implements __call method so Psalm thinks any undeclared method will return __call's return type.

To avoid that, I checked with instanceof each specific Descriptor to let Psalm knows what he's dealing with.