### PR TITLE
drop magic in Collection

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,8 +13,6 @@ parameters:
     - '#.*NodeDefinition::addDefaultsIfNotSet.*#'
 
     - '#Call to an undefined method League\\Flysystem\\Filesystem::find()#'
-    # Bad design of descriptors.
-    - '#Access to an undefined property phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\DescriptorAbstract>>::\$[a-z]+#'
     # https://github.com/phpDocumentor/phpDocumentor/issues/2279
     - '#Instanceof between phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\InterfaceDescriptor\|phpDocumentor\\Reflection\\Fqsen>\|phpDocumentor\\Reflection\\Fqsen\|string\|null and phpDocumentor\\Descriptor\\InterfaceDescriptor will always evaluate to false\.#'
     # PHPStan doesn't support @template D of T but will still complain if we put a D in a Collection of T !

--- a/src/phpDocumentor/Compiler/Linker/Linker.php
+++ b/src/phpDocumentor/Compiler/Linker/Linker.php
@@ -81,7 +81,7 @@ class Linker implements CompilerPassInterface
 
     public function execute(ProjectDescriptor $project) : void
     {
-        $this->descriptorRepository->setObjectAliasesList($project->getIndexes()->elements->getAll());
+        $this->descriptorRepository->setObjectAliasesList($project->getIndexes()->get('elements')->getAll());
         $this->substitute($project);
     }
 

--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -155,18 +155,6 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
     }
 
     /**
-     * Retrieves an item as if it were a property of the collection.
-     *
-     * @return mixed
-     *
-     * @phpstan-return ?T
-     */
-    public function __get(string $name)
-    {
-        return $this->get($name);
-    }
-
-    /**
      * Checks whether an item in this collection exists.
      *
      * @param string|int $offset The index to check on.

--- a/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
@@ -112,13 +112,11 @@ final class CollectionTest extends MockeryTestCase
 
     /**
      * @covers ::get
-     * @covers ::__get
      * @covers ::offsetGet
      */
     public function testRetrievalOfItems() : void
     {
         $this->fixture['a'] = 'abc';
-        $this->assertEquals('abc', $this->fixture->__get('a'));
         $this->assertEquals('abc', $this->fixture['a']);
         $this->assertEquals('abc', $this->fixture->get('a'));
         $this->assertCount(1, $this->fixture);


### PR DESCRIPTION
this PR drops the __get method in Collection.

It was used once and it doesn't bring a lot of value compared to get() or fetch()