### PR TITLE
GitHub Wiki-Template for phpDocumentor

### DIFF
--- a/data/templates/ghwiki/.gitignore
+++ b/data/templates/ghwiki/.gitignore
@@ -1,0 +1,9 @@
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db

--- a/data/templates/ghwiki/Classes.md.twig
+++ b/data/templates/ghwiki/Classes.md.twig
@@ -1,0 +1,229 @@
+`{{ node.path }}`
+
+---
+
+## {{ node.name }}
+{% if node.description %}{{ node.description|raw }}{% endif %}
+
+{% if method.deprecated %}`Deprecated !`
+
+> *{{ method.tags.deprecated[0].description }}*
+{% endif %}
+
+{% if node.abstract %}`abstract`{% endif %}{% if node.final %}`final`{% endif %}
+
+{% for tagName,tags in node.tags if tagName in ['example'] %}
+{% if loop.first %}### Examples
+{% endif %}
+{% for tag in tags %}
+#### {{ tag.description|escape }}
+```
+{{ tag.example|escape }}
+```{% endfor %}
+{% endfor %}
+
+#### Package
+{% if node.package.name is not empty and node.package.name != '\\' %}{{ node.package.parent.name != '\\' ? (node.package.parent.name ~ '\\' ~ node.package.name) : node.package.name }}{% endif %}
+
+{% for tagName,tags in node.tags if tagName in ['link', 'see'] %}
+{% if loop.first %}**See also**
+{% endif %}
+{% for tag in tags %}
+- [{{ tag.description ?: tag.reference }}]({{ (tag.reference|route('url')) ?: tag.link }})
+{% endfor %}
+{% endfor %}
+
+{% for tagName,tags in node.tags if tagName in ['uses'] %}
+{% if loop.first %}**Uses**
+{% endif %}
+{% for tag in tags %}
+- [{{ tag.description ?: tag.reference }}]({{ (tag.reference|route('url')) }})
+{% endfor %}
+{% endfor %}
+
+{% for interface in node.interfaces %}
+{% if loop.first %}### Implements
+{% endif %}
+[{{ interface.fullyQualifiedStructuralElementName }}]({{ interface|route('url') }})
+{% endfor %}
+
+{% for trait in node.usedTraits %}
+{% if loop.first %}### Uses traits
+{% endif %}
+{% if trait.fullyQualifiedStructuralElementName %}[{{ trait.fullyQualifiedStructuralElementName ?: trait }}]({{ trait|route('url') }}){% endif %}
+{% endfor %}
+
+{% for tagName,tags in node.tags if tagName not in ['link', 'see', 'uses', 'abstract', 'example', 'method', 'property', 'property-read', 'property-write', 'package', 'subpackage'] %}
+#### {{ tagName }}
+{% for tag in tags %}
+* {% if tag.version %}`{{ tag.version }}` {% endif %}{{ tag.description|raw }}
+{% endfor %}{% endfor %}
+
+### Overview
+
+#### Public Properties
+{% for property in node.inheritedProperties.merge(node.properties.merge(node.magicProperties))|sort_asc if property.visibility == 'public' %}[{{ property.name }}()](#{{ property.name }}){% if property.deprecated %} `deprecated`{% endif %} | {% else %}_No public properties found_{% endfor %}
+
+#### Constants
+{% for constant in node.inheritedConstants.merge(node.constants)|sort_asc %}[{{ constant.name }}()](#{{ constant.name }}){% if constant.deprecated %} `deprecated`{% else %} | {% endif %}{% else %}_No constants found_{% endfor %}
+
+#### Public Methods
+{% for method in node.inheritedMethods.merge(node.methods.merge(node.magicMethods))|sort_asc if method.visibility == 'public' %}[{{ method.name }}()](#{{ method.name }}){% if method.deprecated %} `deprecated`{% endif %} | {% else %}_No public methods found_{% endfor %}
+
+
+{% set constants = node.inheritedConstants.merge(node.constants) %}
+{% if constants|length > 0 %}### Constants
+
+{% for constant in constants|sort_asc %}
+#### {{ constant.name }}
+`{{ constant.name }} = {{ constant.value|raw }}{% if not (constant.types is empty) %} : {{ constant.types|join('|') }}{% endif %}`
+{% if (node.parent is not null and constant.parent.fullyQualifiedStructuralElementName != node.fullyQualifiedStructuralElementName) %}
+* Inherited from [{{ constant.parent.fullyQualifiedStructuralElementName }}](class-{{ constant.parent.fullyQualifiedStructuralElementName|split('\\')|last }})
+{% endif %}
+{% if constant.deprecated %}`deprecated` {{ constant.tags.deprecated[0].description }}{% endif %}
+
+{{ constant.summary }}
+
+{% if constant.description %}> {{ constant.description|raw }}{% endif %}
+
+{% if (node.parent is null) %}[{{ node.path }}](file-{{ node.path|split('/')|last|replace({'.php':".php.md", '.js':".js.md"}) }}){% endif %}
+
+{% for tagName,tags in constant.tags if tagName in ['link', 'see'] %}
+{% if loop.first %}**See also**
+{% endif %}
+{% for tag in tags %}
+- [{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') ?: tag.link }})
+{% endfor %}
+{% endfor %}
+{% for tagName,tags in constant.tags if tagName in ['uses'] %}
+{% if loop.first %}**Uses**
+{% endif %}
+{% for tag in tags %}[{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') }}){% endfor %}
+{% endfor %}
+{% for tagName,tags in constant.tags if tagName not in ['link', 'see', 'var', 'deprecated', 'uses'] %}
+{% if loop.first %}##### Tags
+{% endif %}
+{% for tag in tags %}
+- **{{ tagName }}**: {% if tag.version %}`{{ tag.version }}` {% endif %}{{ tag.description|raw }}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+
+{% set properties = node.inheritedProperties.merge(node.properties.merge(node.magicProperties)) %}
+{% if properties|length > 0 %}### Properties
+
+{% for property in properties|sort_asc %}
+#### {{ property.name }}
+
+{{ property.summary }}
+
+{% if property.description %}> {{ property.description|raw }}{% endif %}
+
+`{{ property.visibility }}` `${{ property.name }}{% if property.types %} : {{ property.types|join('|') }}{% endif %}`
+{% if (node.parent is not null and property.parent.fullyQualifiedStructuralElementName != node.fullyQualifiedStructuralElementName) %}
+* Inherited from [{{ property.parent.fullyQualifiedStructuralElementName }}](class-{{ property.parent.fullyQualifiedStructuralElementName|split('\\')|last }})
+{% endif %}
+{% if property.deprecated %}`deprecated` {{ property.tags.deprecated[0].description }}{% endif %}
+
+{% if property.types %}
+{{ property.types }}{% if property.var.0.description %}: {{ property.var.0.description }}{% endif %}
+{% endif %}
+
+{% for tagName,tags in property.tags if tagName in ['link', 'see'] %}
+{% if loop.first %}**See also**
+{% endif %}
+{% for tag in tags %}
+- [{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') ?: tag.link }})
+{% endfor %}
+{% endfor %}
+{% for tagName,tags in property.tags if tagName in ['uses'] %}
+{% if loop.first %}**Uses**
+{% endif %}
+{% for tag in tags %}[{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') }}){% endfor %}
+{% endfor %}
+{% for tagName,tags in property.tags if tagName not in ['link', 'see', 'access', 'var', 'deprecated', 'uses'] %}
+{% if loop.first %}##### Tags
+{% endif %}
+{% for tag in tags %}
+- **{{ tagName }}**: {% if tag.version %}`{{ tag.version }}` {% endif %}{{ tag.description|raw }}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+
+{% set methods = node.inheritedMethods.merge(node.methods.merge(node.magicMethods)) %}
+{% if methods|length > 0 %}### Methods
+
+{% for method in methods|sort_asc %}
+#### {{ method.name }}()
+
+{{ method.summary }}
+
+{% if method.description %}> {{ method.description|raw }}{% endif %}
+
+{% if (method.parent is not null and method.parent.fullyQualifiedStructuralElementName != method.fullyQualifiedStructuralElementName) %}
+* Inherited from [{{ method.parent.fullyQualifiedStructuralElementName }}](class-{{ method.parent.fullyQualifiedStructuralElementName|split('\\')|last }})
+{% endif %}
+
+`{{ method.visibility }}` `{{ method.name }}({% for argument in method.arguments %}{{ argument.types ? argument.types|join('|')~' ' }} {{ argument.isVariadic ? '...' }}${{ argument.name }}{{ argument.default ? ' = '~argument.default }}{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.types ? ': '~method.response.types|join('|') }}`
+{% if method.deprecated %}`deprecated`{% if method.tags.deprecated[0].version %} `>{{ method.tags.deprecated[0].version }}`{% endif %} {{ method.tags.deprecated[0].description }}{% endif %}
+{% if method.static %}`static` {% endif %}{% if method.abstract %}`abstract` {% endif %}{% if method.final %}`final` {% endif %}
+
+{% if (method.parent is null) %}[{{ method.path }}](file-{{ method.path|split('/')|last|replace({'.php':".php.md", '.js':".js.md"}) }}){% endif %}
+
+{% for tagName,tags in method.tags if tagName in ['link', 'see'] %}
+{% if loop.first %}**See also**
+{% endif %}
+{% for tag in tags %}
+- [{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') ?: tag.link }})
+{% endfor %}
+{% endfor %}
+{% for tagName,tags in method.tags if tagName in ['uses'] %}
+{% if loop.first %}**Uses**
+{% endif %}
+{% for tag in tags %}[{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') }}){% endfor %}
+{% endfor %}
+{% for tagName,tags in method.tags if tagName not in ['link', 'see', 'abstract', 'example', 'param', 'return', 'access', 'deprecated', 'throws', 'throw', 'uses'] %}
+{% if loop.first %}##### Tags
+{% endif %}
+{% for tag in tags %}
+- **{{ tagName }}**: {% if tag.version %}`{{ tag.version }}` {% endif %}{{ tag.description|raw }}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+{% if method.arguments|length > 0 %}##### Parameters
+{% for argument in method.arguments %}
+`{{ argument.types|raw }}` `${{ argument.name }} {{ argument.isVariadic ? '(variadic)' }}` {{ argument.description|raw }}
+{% endfor %}
+{% endif %}
+
+{% if method.tags.throws|length > 0 or method.tags.throw|length > 0 %}##### Throws
+{% for exception in method.tags.throws %}
+{{ exception.types|raw }}{% if exception.description %} – {{ exception.description|raw }}{% endif %}
+{% endfor %}
+{% for exception in method.tags.throw %}
+{{ exception.types|raw }}{% if exception.description %} – {{ exception.description|raw }}{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if method.response and method.response.types|join() != 'void' %}##### Returns
+{{ method.response.types|raw }}{% if exception.description %} – {{ method.response.description|raw }}{% endif %}
+{% endif %}
+
+{% for tagName,tags in method.tags if tagName in ['example'] %}
+{% if loop.first %}##### Examples{% endif %}
+{% for tag in tags %}
+**{{ tag.description|escape }}**
+```
+{{ tag.example|escape }}
+```
+{% endfor %}
+{% endfor %}
+
+***
+[\\](Home) » Classes » {{ node.name }}

--- a/data/templates/ghwiki/Deprecated.md.twig
+++ b/data/templates/ghwiki/Deprecated.md.twig
@@ -1,0 +1,24 @@
+**Navigation**
+{% for element in project.indexes.elements if element.deprecated %}
+{% if element.file.path != previousPath %}
+* [{{ element.file.path }}](#{{ element.file.path|replace({'/': "", '.': ""}) }})
+{% endif %}
+{% set previousPath = element.file.path %}
+{% endfor %}
+
+{% for element in project.indexes.elements if element.deprecated %}
+{% if element.file.path != previousPath %}
+## [{{ element.file.path }}](file-{{ element.file.name }})
+
+{{ element.tags.deprecated.count }} Deprecated elements
+{% endif %}
+{% for tag in element.tags.deprecated %}
+- {{ element.fullyQualifiedStructuralElementName }} (line {{ element.line }}): {{ tag.description|raw }}
+{% endfor %}
+{% set previousPath = element.file.path %}
+{% else %}
+`No deprecated elements have been found in this project.`
+{% endfor %}
+
+***
+[\\](Home) » Deprecated elements

--- a/data/templates/ghwiki/Errors.md.twig
+++ b/data/templates/ghwiki/Errors.md.twig
@@ -1,0 +1,27 @@
+**Navigation**
+{% set errorCount = 0 %}
+{% for file in project.files %}
+{% if file.allerrors.count > 0 %}
+* [{{ file.path }}](#{{ file.path|replace({'/': "", '.': ""}) }})
+{% endif %}
+{% set errorCount = errorCount + file.allerrors.count %}
+{% endfor %}
+
+{% if errorCount <= 0 %}
+`No errors have been found in this project.`
+{% endif %}
+
+{% for file in project.files %}
+{% if file.allerrors.count > 0 %}
+## [{{ file.path }}](file-{{ file.name }})
+
+{{ file.allerrors.count }} Compilation errors
+
+{% for error in file.allerrors %}
+- {{ error.severity }} (line {{ error.line }}): {{ error.code|trans(error.context) }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+
+***
+[\\](Home) » Compilation errors

--- a/data/templates/ghwiki/Files.md.twig
+++ b/data/templates/ghwiki/Files.md.twig
@@ -1,0 +1,66 @@
+## {{ node.summary }}
+{% if node.description %}{{ node.description|raw }}{% endif %}
+
+{% if node.package is not empty and node.package != '\\' %}#### Package
+{{ node.subpackage ? (node.package ~ '\\' ~ node.subpackage) : node.package }}{% endif %}
+
+{% for tagName,tags in node.tags if tagName not in ['link', 'see', 'package', 'subpackage'] %}
+{% if tagName %}#### {{ tagName }}
+{% for tag in tags %}
+{% if tag.version %}`{{ tag.version }}` {% endif %}{{ tag.description|raw }}
+{% endfor %}
+{% endif %}{% endfor %}
+
+{% for tagName,tags in node.tags if tagName in ['link', 'see'] %}
+{% if loop.first %}#### See also
+{% endif %}
+{% for tag in tags %}
+[{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') ?: tag.link }})
+{% endfor %}
+{% endfor %}
+
+
+{% if node.traits|length > 0 %}### Traits
+{% for trait in node.traits|sort_asc %}
+* {{ trait|raw }}{% if trait.summary %}: _{{ trait.summary }}_{% endif %}
+
+{% endfor %}
+{% endif %}
+
+
+{% if node.interfaces|length > 0 %}### Interfaces
+{% for interface in node.interfaces|sort_asc %}
+* {{ interface|raw }}{% if interface.summary %}: _{{ interface.summary }}_{% endif %}
+
+{% endfor %}
+{% endif %}
+
+
+{% if node.classes|length > 0 %}### Classes
+{% for class in node.classes|sort_asc %}
+* [{{ class.name|raw }}](classes/{{ class.name }}){% if class.summary %}: _{{ class.summary }}_{% endif %}
+
+{% endfor %}
+{% endif %}
+
+
+{% if node.constants|length > 0 %}### Constants
+{% for constant in node.constants|sort_asc %}
+* {{ constant.name }}{% if constant.deprecated %} `deprecated`{% endif %}
+
+{% endfor %}
+{% endif %}
+
+
+{% if node.functions|length > 0 %}### Methods
+{% for method in node.functions|sort_asc %}
+* {{ method.name }}{% if method.deprecated %} `deprecated`{% endif %}
+
+{% endfor %}
+{% endif %}
+
+{% if project.settings.shouldIncludeSource %}## Source
+[{{ node.name }}]({{ node.path }}{{ node.name }}){% endif %}
+
+***
+[\\](Home) » Files » `{{ node.path }}`

--- a/data/templates/ghwiki/Graphs.md.twig
+++ b/data/templates/ghwiki/Graphs.md.twig
@@ -1,0 +1,6 @@
+## Class Hierarchy Diagram
+
+![Class hierarchy diagram]({{ path('wiki/images/classes.svg') }})
+
+***
+[\\](Home) » Graphs

--- a/data/templates/ghwiki/Home.md.twig
+++ b/data/templates/ghwiki/Home.md.twig
@@ -1,0 +1,41 @@
+## {{ project.name }}
+Last update `{{ "now"|date('F jS, Y \\a\\t H:i') }}`
+
+{% if project.indexes.namespaces|length > 0 or not project.indexes.packages %}
+### Namespaces
+##### [\\](Namespaces)
+{% for namespace in project.indexes.namespaces|sort_asc if namespace.name != '\\' %}
+##### [{{ namespace.name|raw }}](ns-{{ namespace.name }})
+
+{% endfor %}
+{% endif %}
+
+{#% if project.indexes.traits|length > 0 %}
+### [Traits](Traits) => overview?
+{% endif %#}
+
+{#% if project.indexes.interfaces|length > 0 %}
+### [Interfaces](Interfaces) => overview?
+{% endif %#}
+
+{% if project.indexes.classes|length > 0 %}
+### Classes
+{% for class in project.indexes.classes|sort_asc %}
+##### [{{ class.name|raw }}](class-{{ class.name }})
+
+{% endfor %}
+{% endif %}
+
+{% if project.indexes.constants|length > 0 %}
+### Constants
+{% for constant in project.indexes.constants|sort_asc %}
+##### [{{ constant.name|raw }}](file-{{ node.path|split('/')|last|replace({'.php':".php.md", '.js':".js.md"}) }})
+{% endfor %}
+{% endif %}
+
+{#% if project.indexes.functions|length > 0 %}
+### Functions
+{% for function in project.indexes.functions|sort_asc %}
+##### [{{ function.name|raw }}](files/{{ node.path|split('/')|last|replace({'.php':".php.md", '.js':".js.md"}) }})
+{% endfor %}
+{% endif %#}

--- a/data/templates/ghwiki/Interfaces.md.twig
+++ b/data/templates/ghwiki/Interfaces.md.twig
@@ -1,0 +1,169 @@
+`{{ node.path }}`
+
+---
+
+## {{ node.summary }}
+{% if node.description %}{{ node.description|raw }}{% endif %}
+
+{% if method.deprecated %}`Deprecated !`
+
+> *{{ method.tags.deprecated[0].description }}*
+{% endif %}
+
+{% for tagName,tags in node.tags if tagName in ['example'] %}
+{% if loop.first %}### Examples
+{% endif %}
+{% for tag in tags %}
+#### {{ tag.description|escape }}
+```
+{{ tag.example|escape }}
+```{% endfor %}
+{% endfor %}
+
+#### Package
+{% if node.package is not empty and node.package != '\\' %}{{ node.subpackage ? (node.package ~ '\\' ~ node.subpackage) : node.package }}{% endif %}
+
+{% for parent in node.parent %}
+{% if loop.first %}#### Parents
+{% endif %}
+- [{{ parent.fullyQualifiedStructuralElementName }}]({{ parent|route('url') }})
+{% endfor %}
+
+{% for tagName,tags in node.tags if tagName in ['link', 'see'] %}
+{% if loop.first %}**See also**
+{% endif %}
+{% for tag in tags %}
+- [{{ tag.description ?: tag.reference }}]({{ (tag.reference|route('url')) ?: tag.link }})
+{% endfor %}
+{% endfor %}
+
+{% for tagName,tags in node.tags if tagName Name not in ['link', 'see', 'abstract', 'method', 'package', 'subpackage'] %}
+#### {{ tagName }}
+{% for tag in tags %}
+* {% if tag.version %}`{{ tag.version }}` {% endif %}{{ tag.description|raw }}
+{% endfor %}{% endfor %}
+
+
+### Overview
+
+#### Constants
+{% for constant in node.inheritedConstants.merge(node.constants)|sort_asc %}[{{ constant.name }}()](#{{ constant.name }}){% if constant.deprecated %} `deprecated`{% else %} | {% endif %}{% else %}_No constants found_{% endfor %}
+
+#### Public Methods
+{% for method in node.inheritedMethods.merge(node.methods)|sort_asc if method.visibility == 'public' %}[{{ method.name }}()](#{{ method.name }}){% if method.deprecated %} `deprecated`{% endif %} | {% else %}_No public methods found_{% endfor %}
+
+#### Proteced Methods
+{% for method in node.inheritedMethods.merge(node.methods)|sort_asc if method.visibility == 'protected' %}[{{ method.name }}()](#{{ method.name }}){% if method.deprecated %} `deprecated`{% endif %} | {% else %}_No protected methods found_{% endfor %}
+
+
+{% if node.constants|length > 0 %}### Constants
+
+{% for constant in node.inheritedConstants.merge(node.constants)|sort_asc %}
+#### {{ constant.name }}
+`{{ constant.name }} = {{ constant.value|raw }}{% if not (constant.types is empty) %} : {{ constant.types|join('|') }}{% endif %}`
+{% if (node.parent is not null and constant.parent.fullyQualifiedStructuralElementName != node.fullyQualifiedStructuralElementName) %}
+* Inherited from [{{ constant.parent.fullyQualifiedStructuralElementName }}](class-{{ constant.parent.fullyQualifiedStructuralElementName|replace({'\\':""}) }})
+{% endif %}
+{% if constant.deprecated %}`deprecated` {{ constant.tags.deprecated[0].description }}{% endif %}
+
+{{ constant.summary }}
+
+{% if constant.description %}> {{ constant.description|raw }}{% endif %}
+
+{% if (node.parent is null) %}[{{ node.path }}](file-{{ node.path|split('/')|last|replace({'.php':".php.md", '.js':".js.md"}) }}){% endif %}
+
+{% for tagName,tags in constant.tags if tagName in ['link', 'see'] %}
+{% if loop.first %}**See also**
+{% endif %}
+{% for tag in tags %}
+- [{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') ?: tag.link }})
+{% endfor %}
+{% endfor %}
+{% for tagName,tags in constant.tags if tagName in ['uses'] %}
+{% if loop.first %}**Uses**
+{% endif %}
+{% for tag in tags %}[{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') }}){% endfor %}
+{% endfor %}
+{% for tagName,tags in constant.tags if tagName not in ['link', 'see', 'var', 'deprecated', 'uses'] %}
+{% if loop.first %}##### Tags
+{% endif %}
+{% for tag in tags %}
+- **{{ tagName }}**: {% if tag.version %}`{{ tag.version }}` {% endif %}{{ tag.description|raw }}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+
+{% if node.inheritedMethods.merge(node.methods)|length > 0 %}### Methods
+
+{% for method in node.inheritedMethods.merge(node.methods)|sort_asc %}
+#### {{ method.name }}()
+
+{{ method.summary }}
+
+{% if method.description %}> {{ method.description|raw }}{% endif %}
+
+{% if (method.parent is not null and method.parent.fullyQualifiedStructuralElementName != method.fullyQualifiedStructuralElementName) %}
+* Inherited from [{{ method.parent.fullyQualifiedStructuralElementName }}](class-{{ method.parent.fullyQualifiedStructuralElementName|replace({'\\':""}) }})
+{% endif %}
+
+`{{ method.visibility }}` `{{ method.name }}({% for argument in method.arguments %}{{ argument.types ? argument.types|join('|')~' ' }} {{ argument.isVariadic ? '...' }}${{ argument.name }}{{ argument.default ? ' = '~argument.default }}{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.types ? ': '~method.response.types|join('|') }}`
+{% if method.deprecated %}`deprecated`{% if method.tags.deprecated[0].version %} `>{{ method.tags.deprecated[0].version }}`{% endif %} {{ method.tags.deprecated[0].description }}{% endif %}
+{% if method.static %}`static` {% endif %}{% if method.abstract %}`abstract` {% endif %}{% if method.final %}`final` {% endif %}
+
+{% if (method.parent is null) %}[{{ method.path }}](file-{{ method.path|split('/')|last|replace({'.php':".php.md", '.js':".js.md"}) }}){% endif %}
+
+{% for tagName,tags in method.tags if tagName in ['link', 'see'] %}
+{% if loop.first %}**See also**
+{% endif %}
+{% for tag in tags %}
+- [{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') ?: tag.link }})
+{% endfor %}
+{% endfor %}
+{% for tagName,tags in method.tags if tagName in ['uses'] %}
+{% if loop.first %}**Uses**
+{% endif %}
+{% for tag in tags %}[{{ tag.description ?: tag.reference }}]({{ tag.reference|route('url') }}){% endfor %}
+{% endfor %}
+{% for tagName,tags in method.tags if tagName not in ['link', 'see', 'abstract', 'example', 'param', 'return', 'access', 'deprecated', 'throws', 'throw', 'uses'] %}
+{% if loop.first %}##### Tags
+{% endif %}
+{% for tag in tags %}
+- **{{ tagName }}**: {% if tag.version %}`{{ tag.version }}` {% endif %}{{ tag.description|raw }}
+{% endfor %}
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+{% if method.arguments|length > 0 %}##### Parameters
+{% for argument in method.arguments %}
+`{{ argument.types|raw }}` `${{ argument.name }} {{ argument.isVariadic ? '(variadic)' }}` {{ argument.description|raw }}
+{% endfor %}
+{% endif %}
+
+{% if method.tags.throws|length > 0 or method.tags.throw|length > 0 %}##### Throws
+{% for exception in method.tags.throws %}
+{{ exception.types|raw }}{% if exception.description %} – {{ exception.description|raw }}{% endif %}
+{% endfor %}
+{% for exception in method.tags.throw %}
+{{ exception.types|raw }}{% if exception.description %} – {{ exception.description|raw }}{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if method.response and method.response.types|join() != 'void' %}##### Returns
+{{ method.response.types|raw }}{% if exception.description %} – {{ method.response.description|raw }}{% endif %}
+{% endif %}
+
+{% for tagName,tags in method.tags if tagName in ['example'] %}
+{% if loop.first %}##### Examples{% endif %}
+{% for tag in tags %}
+**{{ tag.description|escape }}**
+```
+{{ tag.example|escape }}
+```
+{% endfor %}
+{% endfor %}
+
+***
+[\\](Home) » Interfaces » {{ node.name }}

--- a/data/templates/ghwiki/Markers.md.twig
+++ b/data/templates/ghwiki/Markers.md.twig
@@ -1,0 +1,27 @@
+**Navigation**
+{% set markerCount = 0 %}
+{% for file in project.files %}
+{% if file.markers.count > 0 %}
+* [{{ file.path }}](#{{ file.path|replace({'/': "", '.': ""}) }})
+{% endif %}
+{% set markerCount = markerCount + file.markers.count %}
+{% endfor %}
+
+{% if markerCount <= 0 %}
+`No markers have been found in this project.`
+{% endif %}
+
+{% for file in project.files %}
+{% if file.markers.count > 0 %}
+## [{{ file.path }}](file-{{ file.name }})
+
+{{ file.markers.count }} Markers
+
+{% for marker in file.markers %}
+- [ ] {{ marker.type }} (line {{ marker.line }}): {{ marker.message|raw }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+
+***
+[\\](Home) » Markers

--- a/data/templates/ghwiki/Namespaces.md.twig
+++ b/data/templates/ghwiki/Namespaces.md.twig
@@ -1,0 +1,52 @@
+## {{ node.name }}
+{% if node.description %}{{ node.description|raw }}{% endif %}
+
+{% if node.children|length > 0 %}
+### Namespaces
+{% for namespace in node.children|sort_asc %}
+#### [{{ namespace.name }}](ns-{{ namespace.name|replace({'\\':""}) }})
+{% endfor %}{% endif %}
+
+{% if node.traits|length > 0 %}
+### Traits
+{% for trait in node.traits|sort_asc %}
+#### [{{ trait.name }}](trait-{{ trait.name }})
+{% if trait.summary %}*{{ trait.summary }}*
+
+{% endif %}{% endfor %}{% endif %}
+
+{% if node.interfaces|length > 0 %}
+### Interfaces
+{% for interface in node.interfaces|sort_asc %}
+#### [{{ interface.name }}](interface-{{ interface.name }})
+{% if interface.summary %}*{{ interface.summary }}*
+
+{% endif %}{% endfor %}{% endif %}
+
+{% if node.classes|length > 0 %}
+### Classes
+{% for class in node.classes|sort_asc %}
+#### [{{ class.name }}](class-{{ class.name }})
+{% if class.summary %}*{{ class.summary }}*
+
+{% endif %}{% endfor %}{% endif %}
+
+{% if node.constants|length > 0 %}
+### Constants
+{% for constant in node.constants|sort_asc %}
+* {{ constant.name }}{% if constant.summary %}: {{ constant.summary }}{% endif %}
+{% endfor %}{% endif %}
+
+{% if node.functions|length > 0 %}
+### Functions
+{% for key, method in node.functions|sort_asc %}
+* [{{ method.name }}](file-{{ method.path|split('/')|last }})
+{% endfor %}{% endif %}
+
+{% if project.settings.shouldIncludeSource %}                    
+## Source
+[{{ node.name }}]({{ node.path }}{{ node.name }})
+{% endif %}
+
+***
+[\\](Home) » [Namespaces](Namespaces) » [{{ node.parent.name }}](ns-{{ node.parent.name }})

--- a/data/templates/ghwiki/README.md
+++ b/data/templates/ghwiki/README.md
@@ -1,0 +1,40 @@
+# GitHub Wiki-Template for phpDocumentor
+
+## Introduction
+This is a custom template to use with [phpDocumentor](https://github.com/phpDocumentor/phpDocumentor).
+
+It is intended to create the code documentation as markdown files, fully compatible to serve as a [GitHub Wiki](https://help.github.com/en/github/building-a-strong-community/about-wikis) in a GitHub repository of your choice.
+
+### Example
+You can find a live example in this GitHub repository: [zorgch/zorg-code/wiki](https://github.com/zorgch/zorg-code/wiki)
+
+## Installation and usage
+### Pre-requisites
+* [phpDocumentor](https://github.com/phpDocumentor/phpDocumentor/releases) must be installed or available using its `.phar`
+* You have a GitHub Wiki [cloned locally](https://help.github.com/en/github/building-a-strong-community/adding-or-editing-wiki-pages#adding-or-editing-wiki-pages-locally)
+
+### Generate GitHub Wiki Markdown from your code
+1. Download & unpack - or clone - this repository to your computer
+2. Specifiy this template `phpDocumentor-Template-ghwiki` while generating your code documentation using `phpDocumentor`:
+
+`php ./phpDocumentor.phar -d "/path/to/my/sourcecode" -t "/path/to/local/github-wiki" --template="/path/to/phpDocumentor-Template-ghwiki" --cache-folder "/path/to/store/cache" --title "My code project"`
+  * _NOTE_: you may get an error at the end of the parsing - which you can just ignore, all work was done:
+  `ERROR In PathGenerator.php line 120: Variable substitution in path /namespaces/{{name}}.md failed, variable "name" did not return a value`
+3. The target directory `/github-wiki` consists of various markdown (.md) files now
+4. Review, commit & push your local GitHub Wiki repository changes
+5. Browse to the Wiki on the corresponding GitHub repository to see your code documentation online
+
+### Result
+Consider that GitHub Wiki pages are in a flat file hierarchy. Fortunately you still can use folders in the repository itself - so you can have a clean structure in the Wiki repository, but when linking between files it must behave like all Wiki pages are in a single, flat hierarchy.
+
+#### Outputted file hierarchy
+The output consists of the following files hierarchy:
+
+#### GitHub Wiki pages handling
+As mentioned, due to GitHub Wiki pages behaving not within any hierarchy, linking between Wiki pages is done...
+* by referencing the file name of the page
+* leaving away the `.md` extension
+
+So use `class-MyClass` to link to the file `/wiki/classes/class-MyClass.md`.
+
+Or `file-myconfigs.inc.php` to link to the file `/wiki/files/file-myconfigs.inc.php.md`.

--- a/data/templates/ghwiki/_Footer.md.twig
+++ b/data/templates/ghwiki/_Footer.md.twig
@@ -1,0 +1,3 @@
+Documentation generated on {{ "now"|date('F jS, Y \\a\\t H:i') }}.
+
+Powered by [phpDocumentor](https://www.phpdoc.org/) with template [GitHub-wiki](https://github.com/oliveratgithub/phpDocumentor-Template-ghwiki).

--- a/data/templates/ghwiki/_Sidebar.md.twig
+++ b/data/templates/ghwiki/_Sidebar.md.twig
@@ -1,0 +1,34 @@
+### [API documentation](Home)
+
+{% if project.namespace.children|length > 0 %}
+{% for namespace in project.namespace.children|sort_asc %}
+[{{ namespace.name }}](ns-{{ namespace.name }})
+
+{% endfor %}
+{% endif %}
+
+---
+### Graphs
+
+[Class Hierarchy Diagram]({{ path('Graphs') }})
+
+---
+### Reports
+
+{% set errorCount = 0 %}
+{% for file in project.files %}
+{% set errorCount = errorCount + file.allerrors.count %}
+{% endfor %}
+[Errors ({{ errorCount }})]({{ path('Errors') }})
+
+{% set deprecatedCount = 0 %}
+{% for element in project.indexes.elements if element.deprecated %}
+{% set deprecatedCount = deprecatedCount + element.tags.deprecated.count %}
+{% endfor %}
+[Deprecated ({{ deprecatedCount }})]({{ path('Deprecated') }})
+
+{% set markerCount = 0 %}
+{% for file in project.files %}
+{% set markerCount = markerCount + file.markers.count %}
+{% endfor %}
+[Markers ({{ markerCount }})]({{ path('Markers') }})

--- a/data/templates/ghwiki/template.xml
+++ b/data/templates/ghwiki/template.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<template>
+  <author>oliveratgithub</author>
+  <email>github@raduner.ch</email>
+  <version>1.0.0</version>
+  <copyright>GNU GPLv3</copyright>
+  <description>This template transforms your phpDocu into markdown based GitHub Wiki pages ready to push to a GitHub repository</description>
+  <transformations>
+    <transformation writer="twig" query="namespace" source="Namespaces.md.twig" artifact="Namespaces.md" />
+    <transformation writer="twig" query="indexes.classes" source="Classes.md.twig" artifact="classes/class-{{name}}.md" />
+    <transformation writer="twig" query="indexes.traits" source="Classes.md.twig" artifact="traits/trait-{{name}}.md" />
+    <transformation writer="twig" query="files" source="Files.md.twig" artifact="files/file-{{name}}.md" />
+    <transformation writer="twig" source="Markers.md.twig" artifact="Markers.md"/>
+    <transformation writer="twig" source="Errors.md.twig" artifact="Errors.md"/>
+    <transformation writer="twig" source="Deprecated.md.twig" artifact="Deprecated.md"/>
+    <transformation writer="twig" source="Graphs.md.twig" artifact="Graphs.md"/>
+    <transformation writer="twig" source="Home.md.twig" artifact="Home.md"/>
+    <transformation writer="twig" source="_Sidebar.md.twig" artifact="_Sidebar.md"/>
+    <transformation writer="twig" source="_Footer.md.twig" artifact="_Footer.md"/>
+    <transformation query="copy" writer="FileIo" source="/images" artifact="images"/>
+    <transformation writer="Graph" source="class" artifact="images/classes.svg" />
+    <transformation writer="twig" query="indexes.namespaces" source="Namespaces.md.twig" artifact="namespaces/ns-{{name}}.md" />
+    <transformation writer="twig" query="indexes.interfaces" source="Interfaces.md.twig" artifact="interfaces/interface-{{name}}.md" />
+  </transformations>
+  <parameters>
+    <parameter key="twig-debug">true</parameter>
+  </parameters>
+</template>


### PR DESCRIPTION
New template folder `templates/ghwiki` with all source files

Merged from [oliveratgithub/phpDocumentor](https://github.com/oliveratgithub/phpDocumentor) which was updated with the template from [oliveratgithub/phpDocumentor-Template-ghwiki](https://github.com/oliveratgithub/phpDocumentor-Template-ghwiki)

fyi @devcorrelator