### PR TITLE
Improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -5,29 +5,29 @@ about: If something isn't working as expected 🤔.
 
 <!-- Provide a general summary of the issue in the Title above -->
 
-## Expected Behavior
-<!-- Please describe what you expected to be happening here. -->
+## Expected behavior
+<!-- Please describe what you expected to happen here. -->
 
 
-## Actual Behavior
+## Actual behavior
 <!-- What is happening currently -->
 
-## Steps to Reproduce the Problem
+## Steps to reproduce the problem
 
-  1.
-  2.
-  3.
+1.
+2.
+3.
 
 ## Your environment
 
-Include as many relevant details about the environment you experienced the bug in and how to reproduce it.
-Since many issue might only occur on a specific code base it would be very helpfull if you link to your project
-or add any code that is involved in to the issue.
+<!--
+Include as many relevant details about the environment you experienced the bug in.
+Because many issues only occur on a specific code base, please add a link to your project, or attach the project code that is      involved to this issue report. -->
 
 * Version used: 3.0.0-alpha1
 * Install method
-* php version
-* Operating system and version (e.g. Ubuntu 16.04, Windows 7):
+* PHP version
+* Operating system and version (e.g. Ubuntu 20.04, Windows 10):
 * Link to your project:
-* ...
+* Attach code that is involved
 * ...

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -22,7 +22,8 @@ about: If something isn't working as expected 🤔.
 
 <!--
 Include as many relevant details about the environment you experienced the bug in.
-Because many issues only occur on a specific code base, please add a link to your project, or attach the project code that is      involved to this issue report. -->
+Because many issues only occur on a specific code base, please add a link to your project, or attach the project code that is involved to this issue report.
+-->
 
 * Version used: 3.0.0-alpha1
 * Install method


### PR DESCRIPTION
- Remove capitalization on second words in the headers
- Remove spaces before the 1. 2. 3. in the markdown list (this makes no difference to the markdown rendering on GitHub, but helps with adding new steps)
- Capitalize PHP
- Update references to Ubuntu and Windows versions
- Comment out the "Include as many relevant details blurb
- Rewrite "Include as many relevant details" blurb for readability