### PR TITLE
Add Docker to .dependabot/config.yml

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -17,3 +17,6 @@ update_configs:
       - match:
           dependency_type: "all"
           update_type: "all"
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
Dependabot will check for Docker :whale: updates on the same weekly schedule as the other dependencies. 

The updates will need to **be manually approved and merged** though, as `automerged_updates` are not supported by Dependabot when using Docker.