### PR TITLE
Composer v2.0: remove `--no-suggest flag` as its going to be deprecated

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+          composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: composer-require-checker
         uses: docker://phpga/composer-require-checker-ga
@@ -113,7 +113,7 @@ jobs:
 
     - name: Install Composer dependencies
       run: |
-        composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+        composer install --no-progress --prefer-dist --optimize-autoloader
 
     - name: Install phive
       run: make install-phive
@@ -193,7 +193,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+          composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: PHPStan
         uses: phpDocumentor/phpstan-ga@master
@@ -244,7 +244,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+          composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Psalm
         run: psalm --output-format=github
@@ -293,7 +293,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+          composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: warm cache
         uses: docker://phpdoc/phar-ga:master
@@ -387,7 +387,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+          composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Build example project using Clean template
         run: ./bin/phpdoc --template=clean -vvv --config=data/examples/MariosPizzeria/phpdoc.xml --target=build/clean
@@ -448,7 +448,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+          composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Build example project using Clean template
         run: ./bin/phpdoc --template=clean --config=data/examples/MariosPizzeria/phpdoc.xml --target=build/clean
@@ -517,7 +517,7 @@ jobs:
 
     - name: Install Composer dependencies
       run: |
-        composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+        composer install --no-progress --prefer-dist --optimize-autoloader
 
     - name: Install PHAR dependencies
       env:


### PR DESCRIPTION
From the upgrade guide for Composer v2.0:
> Deprecated --no-suggest flag as it is not needed anymore

https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-composer-cli-users