### PR TITLE
Docs: improvements for "getting started - installing"

### DIFF
--- a/docs/getting-started/installing.rst
+++ b/docs/getting-started/installing.rst
@@ -7,7 +7,7 @@ System Requirements
 phpDocumentor has several dependencies on other software packages. Please make sure that you have these
 installed before installing phpDocumentor.
 
--  `PHP 7.2.0`_
+-  `PHP 7.2.5`_ or higher
 -  Graphviz_ (optional)
 -  PlantUML_ (optional)
 
@@ -16,8 +16,9 @@ Phive
 
    $ phive install phpDocumentor
 
-For more information about phive have a look at their website_
-Now you have phpDocumentor installed and it can be executed directly.
+Once you run the command, phpDocumentor will be installed and it can be executed directly.
+
+For more information about phive have a look at their website_.
 
 
 PHAR
@@ -25,9 +26,9 @@ PHAR
 
 You can download the latest PHAR file from https://github.com/phpDocumentor/phpDocumentor/releases.
 
-The phar file can be used by simply invoking php and providing the phar file as a parameter::
+The phar file can be used by invoking php directly and providing the phar file as a parameter::
 
-  $ php phpDocumentor.phar -d . -t docs/api
+   $ php phpDocumentor.phar -d . -t docs/api
 
 
 Docker
@@ -36,8 +37,7 @@ Docker
 1. `$ docker pull phpdoc/phpdoc`
 2. `$ docker run --rm -v $(pwd):/data phpdoc/phpdoc`
 
-When the installation is finished you can invoke the ``phpdoc`` command from any path in your system. It is recommended
-to read the :doc:`../getting-started/index` section next as it will explain how to quickly start using phpDocumentor.
+When the installation is finished you can invoke the ``phpdoc`` command from any path in your system.
 
 Using Composer
 --------------
@@ -52,17 +52,22 @@ Using Composer
 Installing phpDocumentor using Composer_ is a matter of creating a directory to host your files and executing the
 following command::
 
-    $ composer require "phpdocumentor/phpdocumentor:^3.0"
+   $ composer require "phpdocumentor/phpdocumentor:^3.0"
 
-This command can also be used to add phpDocumentor to your existing composer-based project
+This command can also be used to add phpDocumentor to your existing composer-based project.
+
+After installation, you can invoke phpDocumentor from the root of your project using the ``vendor/bin/phpdoc`` command.
 
 .. hint::
 
    phpDocumentor uses a fair number of other libraries, if you do not want those dependencies imported into your
    own project it is advised to use one of the other installation methods.
 
+
+It is recommended to read the :doc:`../getting-started/your-first-set-of-documentation` section next as it will explain how to quickly start using phpDocumentor.
+
 .. _Composer:               https://getcomposer.org
-.. _`PHP 7.2.0`:            https://www.php.net
+.. _`PHP 7.2.5`:            https://www.php.net
 .. _Graphviz:               https://graphviz.org/download/
 .. _PlantUML:               https://plantuml.com/download
 .. _Twig:                   https://twig.sensiolabs.org


### PR DESCRIPTION
PHP version:
* Refer to the same minimum PHP version as specified in the `composer.json` file.
* Make it clear that it is a _minimum_ version.

Phive:
* As this was rendered as one paragraph, the sentences felt disconnected and confusing.
    Reversing the order and turning it into two paragraphs hopefully fixes that.

Phar:
* Invoking php isn't something you do "simply" if you're relatively new to PHP (or never use the command-line). Ablist language.

Docker:
* I think the "read next" sentence was intended to be at the end of the page ? Not at the end of this section ? Moved it.

Composer:
* Add instruction on how to invoke PHPDocumentor after installation.
    Most other installation methods already mention how to invoke after installation, but the Composer instructions did not.

Read next:
* Change the link to next section within the "Getting started" guide as this page is the first section, so the reader has already read half of it.

Other:
* Use consistent indentation for code samples.
* Minor punctuation fixes.