### PR TITLE
Template Default: normalize the CSS section headers

### DIFF
--- a/data/templates/default/css/base.css.twig
+++ b/data/templates/default/css/base.css.twig
@@ -71,7 +71,7 @@
 }
 
 /* Grid
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 {% include 'components/section.css.twig' %}
 
 .phpdocumentor-column,
@@ -232,7 +232,7 @@
 }
 
 /* Base Styles
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 body {
     color: var(--text-color);
     font-family: var(--font-primary);
@@ -247,7 +247,7 @@ body {
 }
 
 /* Typography
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 .phpdocumentor h1,
 .phpdocumentor h2,
 .phpdocumentor h3,
@@ -307,7 +307,7 @@ body {
 }
 
 /* Links
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 .phpdocumentor a {
     color: var(--link-color-primary);
 }
@@ -317,7 +317,7 @@ body {
 }
 
 /* Buttons
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 .phpdocumentor-button {
     background-color: var(--button-color);
     border: 1px solid var(--button-border-color);
@@ -363,7 +363,7 @@ body {
 }
 
 /* Forms
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 .phpdocumentor-field {
     background-color: var(--form-field-color);
     border: 1px solid var(--form-field-border-color);
@@ -421,7 +421,7 @@ input[type="radio"].phpdocumentor-field {
 }
 
 /* Lists
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 div.phpdocumentor-list > ul,
 ul.phpdocumentor-list {
     list-style: circle inside;
@@ -454,7 +454,7 @@ li.phpdocumentor-list {
 {% include 'components/breadcrumbs.css.twig' %}
 
 /* Code
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 .phpdocumentor-code {
     background: var(--code-background-color);
     border: 1px solid var(--code-border-color);
@@ -469,7 +469,7 @@ pre > .phpdocumentor-code {
 }
 
 /* Tables
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 th.phpdocumentor-heading,
 td.phpdocumentor-cell {
     border-bottom: 1px solid var(--table-separator-color);
@@ -488,7 +488,7 @@ td.phpdocumentor-cell:last-child {
 }
 
 /* Spacing
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 .phpdocumentor-button {
     margin-bottom: var(--spacing-md);
 }
@@ -510,7 +510,7 @@ td.phpdocumentor-cell:last-child {
 }
 
 /* Utilities
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 .phpdocumentor-full-width {
     box-sizing: border-box;
     width: 100%;
@@ -530,7 +530,7 @@ td.phpdocumentor-cell:last-child {
 }
 
 /* Misc
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 .phpdocumentor-line {
     border-top: 1px solid #E1E1E1;
     border-width: 0;
@@ -549,7 +549,7 @@ td.phpdocumentor-cell:last-child {
 }
 
 /* Elements
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 
 {% include 'components/header.css.twig' %}
 {% include 'components/header-title.css.twig' %}
@@ -561,7 +561,7 @@ td.phpdocumentor-cell:last-child {
 }
 
 /* Other
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 
 .phpdocumentor-content h1 .headerlink,
 .phpdocumentor-content h2 .headerlink,
@@ -587,7 +587,7 @@ td.phpdocumentor-cell:last-child {
 }
 
 /* Media Queries
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 /*
 Note: The best way to structure the use of media queries is to create the queries
 near the relevant code. For example, if you wanted to change the styles for buttons

--- a/data/templates/default/css/template.css.twig
+++ b/data/templates/default/css/template.css.twig
@@ -124,7 +124,7 @@
 }
 
 /* Media Queries
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
+-------------------------------------------------- */
 /*
 Note: The best way to structure the use of media queries is to create the queries
 near the relevant code. For example, if you wanted to change the styles for buttons


### PR DESCRIPTION
Saving the files as utf-8 is one thing, using unicode characters as part of the chapter markers is another (and not necessary).

I realize the diff may be confusing, so attaching some screenshots from an editor which doesn't support unicode:

**Before**:
![image](https://user-images.githubusercontent.com/663378/83947293-637b6700-a816-11ea-918f-1f9fea48df9f.png)

**After**:
![image](https://user-images.githubusercontent.com/663378/83947316-860d8000-a816-11ea-9e23-c6dc2c6edd2f.png)


