### PR TITLE
Docs: consistency in referring to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ v3 is still under development and is not stable enough to use in a daily develop
 
 ### Nightly builds
 
-Phpdocumentor doesn't have a nightly release.
+PhpDocumentor doesn't have a nightly release.
 However, during each pipeline a [phar] artifact is built.
 If you want to test the bleeding edge version of phpDocumentor, have a look in the [actions] section of this repository.
 Each successful QA workflow has a download at the right upper corner.
@@ -45,7 +45,7 @@ Each successful QA workflow has a download at the right upper corner.
 Installation
 ------------
 
-phpDocumentor requires PHP 7.2 or higher to run.
+PhpDocumentor requires PHP 7.2 or higher to run.
 However, code of earlier PHP versions can be analyzed.
 
 All templates provided with phpDocumentor have support for Class diagrams based on the read code base.

--- a/docs/DESIGN.rst
+++ b/docs/DESIGN.rst
@@ -41,7 +41,7 @@ using Sphinx_. For more information on installing Sphinx_ we would like to refer
    In the future we will migrate towards Scrybe_ but given the current state of that project it is currently
    not possible.
 
-For our API Documentation we eat our own dogfood and generate it using phpDocumentor2.
+For our API Documentation we eat our own dogfood and generate it using phpDocumentor 3.
 
 Style Guide
 -----------

--- a/docs/getting-started/changing-the-look-and-feel.rst
+++ b/docs/getting-started/changing-the-look-and-feel.rst
@@ -93,7 +93,7 @@ directory you can customize parts of the generated HTML. For example, when you w
 you create an empty file named `breadcrumbs.html.twig` in `.phpdoc/template/`.
 Have a look in the `template directory`_ which other files can be overwritten.
 
-Besides the templates phpdocumentor allows you to customize the looks of the included templates just by modifying the CSS.
+Besides the templates phpDocumentor allows you to customize the looks of the included templates just by modifying the CSS.
 To do this you have to create a file named `template.css.twig` in `.phpdoc/template/css`. The minimal contents should be as
 below. The `base::` prefix allows you to extend files from the original template.
 

--- a/docs/references/phpdoc/tags/example.rst
+++ b/docs/references/phpdoc/tags/example.rst
@@ -3,7 +3,7 @@
 
 .. important::
 
-   The effects of this tag are not yet fully implemented in PhpDocumentor2.
+   The effects of this tag are not yet fully implemented in phpDocumentor 3.
 
 The @example tag shows the code of a specified example file, or optionally, just
 a portion of it.
@@ -27,7 +27,7 @@ A location to a file MUST be specified. It can be specified as a relative or
 absolute URI, or as a relative or absolute file path. Use double quotes around
 the location to explicitly specify that it is a file path.
 
-To expand a relative URI or filepath, PhpDocumentor looks into multiple folders,
+To expand a relative URI or filepath, phpDocumentor looks into multiple folders,
 until it finds an existing and readable file matching the one specified. The
 folders being analyzed (in this order) are:
 -  A specific folder, specified at the configuration file or command line.

--- a/docs/references/phpdoc/tags/global.rst
+++ b/docs/references/phpdoc/tags/global.rst
@@ -3,12 +3,12 @@
 
 .. important::
 
-   This tag is not included in phpDocumentor 2.0 and may be included in a
+   This tag is not included in phpDocumentor 3.0 and may be included in a
    subsequent version.
 
 .. note::
 
-   This definition is not yet official for phpDocumentor2; slight changes may
+   This definition is not yet official for phpDocumentor 3; slight changes may
    be made to this definition to match new standards. These changes will however
    remain compatible with this definition.
 

--- a/docs/references/phpdoc/tags/link.rst
+++ b/docs/references/phpdoc/tags/link.rst
@@ -4,7 +4,7 @@
 .. important::
 
    The effects of the inline version of this tag are not yet fully implemented
-   in PhpDocumentor2. There's only URI support (i.e. no support for
+   in phpDocumentor 3. There's only URI support (i.e. no support for
    :term:`Structural Elements`), and even that is available only in long descriptions.
 
 The @link tag indicates a custom relation between associated

--- a/docs/references/phpdoc/tags/since.rst
+++ b/docs/references/phpdoc/tags/since.rst
@@ -3,7 +3,7 @@
 
 .. important::
 
-   The effects of this tag are not yet fully implemented in PhpDocumentor2.
+   The effects of this tag are not yet fully implemented in phpDocumentor 3.
 
 The @since tag indicates at which version did the associated
 :term:`Structural Elements` became available.

--- a/docs/references/phpdoc/tags/source.rst
+++ b/docs/references/phpdoc/tags/source.rst
@@ -3,7 +3,7 @@
 
 .. important::
 
-   The effects of this tag are not yet fully implemented in PhpDocumentor2.
+   The effects of this tag are not yet fully implemented in phpDocumentor 3.
 
 The @source tag shows the source code of :term:`Structural Elements`.
 


### PR DESCRIPTION
Consistency updates to:
* Always use the following capitalization for the project name `phpDocumentor`, with the exception of when the term is used at the start of a sentence, in which case `PhpDocumentor` is used.
* Change any references to v2 to v3.