### PR TITLE
Docs: include instead of duplicate for "index"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,1 @@
-Welcome
-=======
-
-Welcome to the complete documentation for phpDocumentor.
-
-With these tutorials, guides and references we try to provide you with all the information that you need to optimally
-document your code and leverage phpDocumentor to generate an extensive set of documentation for your application.
-
-The documentation is divided into 5 sections,
-
-1. :doc:`getting-started/index`, which is a series of concise tutorials that will help you get running within minutes.
-2. :doc:`guides/index`, these chapters provide in-depth information in the usage and all features of phpDocumentor.
-3. :doc:`references/index`, here you can find the nitty-gritty lists of commonly used components, options and
-   configuration.
-4. :doc:`internals/index`, care to contribute to phpDocumentor or interested in its architecture? Then this section
-   is for you.
+.. include:: welcome.rst


### PR DESCRIPTION
Include the text from `welcome.rst` to remove duplication.