### PR TITLE
Docs: php.net - use language agnostic links and more

### DIFF
--- a/docs/getting-started/your-first-set-of-documentation.rst
+++ b/docs/getting-started/your-first-set-of-documentation.rst
@@ -208,13 +208,13 @@ There are a lot more options to phpDocumentor and you can define them all in a :
 and include that in your project but that is out of scope for this tutorial. If you'd like to know more on running
 phpDocumentor; see the guide on :doc:`../guides/running-phpdocumentor` for more information.
 
-.. _Function:       http://php.net/manual/en/language.functions.php
-.. _Constant:       http://php.net/manual/en/language.constants.php
-.. _Class:          http://php.net/manual/en/language.oop5.basic.php
-.. _Interface:      http://php.net/manual/en/language.oop5.interfaces.php
-.. _Trait:          http://php.net/manual/en/language.oop5.traits.php
-.. _Class constant: http://php.net/manual/en/language.oop5.constants.php
-.. _Property:       http://php.net/manual/en/language.oop5.properties.php
-.. _Method:         http://php.net/manual/en/language.oop5.basic.php
+.. _Function:       https://www.php.net/language.functions
+.. _Constant:       https://www.php.net/language.constants
+.. _Class:          https://www.php.net/language.oop5.basic
+.. _Interface:      https://www.php.net/language.oop5.interfaces
+.. _Trait:          https://www.php.net/language.oop5.traits
+.. _Class constant: https://www.php.net/language.oop5.constants
+.. _Property:       https://www.php.net/language.oop5.properties
+.. _Method:         https://www.php.net/language.oop5.basic
 .. _Markdown:       http://daringfireball.com
 .. _templates:      http://phpdoc.org/templates

--- a/docs/guides/types.rst
+++ b/docs/guides/types.rst
@@ -48,7 +48,7 @@ This means that any class may be addressed
 Of course this is only a short introduction on class name resolution with PHP. When you want to know more on how PHP
 resolves class names, please read the `php manual on namespacing`_.
 
-.. _php manual on namespacing: http://php.net
+.. _php manual on namespacing: https://www.php.net/language.namespaces
 
 Primitives
 ~~~~~~~~~~

--- a/docs/references/phpdoc/tags/var.rst
+++ b/docs/references/phpdoc/tags/var.rst
@@ -43,4 +43,4 @@ Even compound statements may be documented:
       protected $name, $description;
     }
 
-.. _property: http://www.php.net/manual/en/language.oop5.properties.php
+.. _property: https://www.php.net/language.oop5.properties

--- a/docs/references/phpdoc/types.rst
+++ b/docs/references/phpdoc/types.rst
@@ -90,7 +90,7 @@ The following keywords are recognized:
 
 8.  **resource**, the element to which this type applies is a resource per
     the definition of PHP at
-    http://www.php.net/manual/en/language.types.resource.php.
+    https://www.php.net/language.types.resource.
 
 9.  **void**, this type is commonly only used when defining the return type of a
     method or function.
@@ -180,7 +180,7 @@ The following keywords are recognized:
 
 11. **callable**, the element to which this type applies is a pointer to a
     function call. This may be any type of callback as defined in the PHP manual
-    at http://php.net/manual/en/language.pseudo-types.php.
+    at https://www.php.net/language.types.callable.
 
 12. **false** or **true**, the element to which this type applies will have
     the value true or false. No other value will be returned from this


### PR DESCRIPTION
* Fix links to the PHP manual to be language agnostic, so the site will automatically serve in the user's preferred language.
    Ref: https://www.php.net/urlhowto.php
* Fix the links to use `https`.
* Add a "missing link" (guides/types)
* Make a link more specific (`callable` in references/phpdoc/types)