### PR TITLE
XSD: update phpdoc.org URL to https

### DIFF
--- a/data/xsd/phpdoc.xsd
+++ b/data/xsd/phpdoc.xsd
@@ -11,11 +11,11 @@
   -->
 
 <xs:schema
-        targetNamespace="http://www.phpdoc.org"
+        targetNamespace="https://www.phpdoc.org"
         attributeFormDefault="unqualified"
         elementFormDefault="qualified"
         xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:pd="http://www.phpdoc.org"
+        xmlns:pd="https://www.phpdoc.org"
         version="3.0"
 >
     <xs:simpleType name="dsn"><xs:restriction base="xs:string"/></xs:simpleType>

--- a/docs/references/configuration.rst
+++ b/docs/references/configuration.rst
@@ -50,8 +50,8 @@ Usually the following configuration suffices for your project::
     <phpdocumentor
             configVersion="3"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://www.phpdoc.org"
-            xsi:noNamespaceSchemaLocation="http://docs.phpdoc.org/latest/phpdoc.xsd"
+            xmlns="https://www.phpdoc.org"
+            xsi:noNamespaceSchemaLocation="https://docs.phpdoc.org/latest/phpdoc.xsd"
     >
         <paths>
             <output>build/api</output>
@@ -187,8 +187,8 @@ Appendix A: basic configuration example
     <phpdocumentor
             configVersion="3"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://www.phpdoc.org"
-            xsi:noNamespaceSchemaLocation="http://docs.phpdoc.org/latest/phpdoc.xsd"
+            xmlns="https://www.phpdoc.org"
+            xsi:noNamespaceSchemaLocation="https://docs.phpdoc.org/latest/phpdoc.xsd"
     >
         <paths>
             <output>build/api</output>

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -2,7 +2,7 @@
 <phpdocumentor
         configVersion="3"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns="http://www.phpdoc.org"
+        xmlns="https://www.phpdoc.org"
         xsi:noNamespaceSchemaLocation="data/xsd/phpdoc.xsd"
 >
     <title>phpDocumentor</title>

--- a/tests/unit/data/phpDocumentor3XML.xml
+++ b/tests/unit/data/phpDocumentor3XML.xml
@@ -13,7 +13,7 @@
 
 <phpdocumentor
         version="3"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.phpdoc.org"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://www.phpdoc.org"
         xsi:noNamespaceSchemaLocation="phpdoc.xsd"
 >
     <paths>

--- a/tests/unit/data/phpDocumentor3XMLWithMultipleApis.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithMultipleApis.xml
@@ -13,7 +13,7 @@
 
 <phpdocumentor
         version="3"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.phpdoc.org"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://www.phpdoc.org"
         xsi:noNamespaceSchemaLocation="phpdoc.xsd"
 >
     <paths>

--- a/tests/unit/data/phpDocumentor3XMLWithMultipleGuides.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithMultipleGuides.xml
@@ -13,7 +13,7 @@
 
 <phpdocumentor
         version="3"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.phpdoc.org"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://www.phpdoc.org"
         xsi:noNamespaceSchemaLocation="phpdoc.xsd"
 >
     <paths>

--- a/tests/unit/data/phpDocumentor3XMLWithMultipleTemplates.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithMultipleTemplates.xml
@@ -13,7 +13,7 @@
 
 <phpdocumentor
         version="3"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.phpdoc.org"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://www.phpdoc.org"
         xsi:noNamespaceSchemaLocation="phpdoc.xsd"
 >
     <paths>

--- a/tests/unit/data/phpDocumentor3XMLWithMultipleVersions.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithMultipleVersions.xml
@@ -13,7 +13,7 @@
 
 <phpdocumentor
         version="3"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.phpdoc.org"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://www.phpdoc.org"
         xsi:noNamespaceSchemaLocation="phpdoc.xsd"
 >
     <paths>

--- a/tests/unit/data/phpDocumentor3XMLWithoutTemplate.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithoutTemplate.xml
@@ -13,7 +13,7 @@
 
 <phpdocumentor
         version="3"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.phpdoc.org"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://www.phpdoc.org"
         xsi:noNamespaceSchemaLocation="phpdoc.xsd"
 >
     <paths>

--- a/tests/unit/data/phpDocumentor3XMLWithoutValues.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithoutValues.xml
@@ -13,7 +13,7 @@
 
 <phpdocumentor
         version="3"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.phpdoc.org"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://www.phpdoc.org"
         xsi:noNamespaceSchemaLocation="phpdoc.xsd"
 >
     <paths>


### PR DESCRIPTION
The website of phpdoc.org is served over HTTPS, so let's fix this in the XSD schema.

Includes fixing it in:
* All XML code examples in the documentation.
* The data fixtures for the unit tests.
* The `phpdoc.dist.xml` file for phpDocumentor itself.