### PR TITLE
PHPCS config: minor tweaks

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,10 +4,12 @@
 
     <file>src</file>
     <file>tests/unit</file>
-    <exclude-pattern>*\.(css|js)$</exclude-pattern>
     <exclude-pattern>*/src/phpDocumentor/Guides/*$</exclude-pattern>
-    <exclude-pattern>*/src/phpDocumentor/Pipeline/Stage/RenderGuide.php$</exclude-pattern>
+    <exclude-pattern>*/src/phpDocumentor/Pipeline/Stage/RenderGuide\.php$</exclude-pattern>
     <arg value="p"/>
+    <arg name="extensions" value="php"/>
+    <arg name="basepath" value="."/>
+    <arg name="parallel" value="12"/>
 
     <rule ref="phpDocumentor">
         <!-- Should be removed/fixed again once we pass the round of checks -->
@@ -40,31 +42,31 @@
     </rule>
 
     <rule ref="SlevomatCodingStandard.Functions.StaticClosure.ClosureNotStatic">
-        <exclude-pattern>*/tests/unit/phpDocumentor/Console/ApplicationTest.php</exclude-pattern>
+        <exclude-pattern>*/tests/unit/phpDocumentor/Console/ApplicationTest\.php$</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity">
-        <exclude-pattern>*/src/*/ResolveInlineLinkAndSeeTags.php</exclude-pattern>
-        <exclude-pattern>*/src/*/*Assembler*.php</exclude-pattern>
+        <exclude-pattern>*/src/*/ResolveInlineLinkAndSeeTags\.php$</exclude-pattern>
+        <exclude-pattern>*/src/*/*Assembler*\.php$</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming">
-        <exclude-pattern>*/src/*/*Interface.php</exclude-pattern>
+        <exclude-pattern>*/src/*/*Interface\.php$</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix">
-        <exclude-pattern>*/src/*/Abstract*.php</exclude-pattern>
+        <exclude-pattern>*/src/*/Abstract*\.php$</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousSuffix">
-        <exclude-pattern>*/src/*/*Abstract.php</exclude-pattern>
+        <exclude-pattern>*/src/*/*Abstract\.php$</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousTraitNaming.SuperfluousSuffix">
-        <exclude-pattern>src/phpDocumentor/Transformer/Writer/*Trait.php</exclude-pattern>
+        <exclude-pattern>src/phpDocumentor/Transformer/Writer/*Trait\.php$</exclude-pattern>
     </rule>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod.Found">
-        <exclude-pattern>src/phpDocumentor/Kernel.php</exclude-pattern>
+        <exclude-pattern>src/phpDocumentor/Kernel\.php$</exclude-pattern>
     </rule>
 
     <!-- Should be removed/fixed again once we pass the round of checks -->


### PR DESCRIPTION
* Exclude the `css` and `js` files via the `extensions` argument instead of via an `exclude-pattern`.
* Run up to 12 scans in parallel if the OS allows for it, to speed up the run.
* Clean up the reports by only showing relative paths from the project root instead of absolute paths.
* Make some `exclude-pattern`s more stable. Exclude patterns in PHPCS are a special type of PCRE regex where `*` is automatically replaced by `.*`. However, all other regex special characters do need escaping to prevent unintentionally matching too much.