### PR TITLE
Docs: remove `:term:` annotations

### DIFF
--- a/docs/getting-started/changing-the-look-and-feel.rst
+++ b/docs/getting-started/changing-the-look-and-feel.rst
@@ -5,7 +5,7 @@ Overview
 --------
 
 With this tutorial, I want to show you how the look and feel of phpDocumentor can be changed using one of the
-existing :term:`templates` or by selecting a custom-made :term:`template`.
+existing templates or by selecting a custom-made template.
 
 What is a template?
 -------------------
@@ -13,11 +13,11 @@ What is a template?
 To be fair, the title of this tutorial is mildly misleading. Why? A template in phpDocumentor means so much
 more than just the look and feel of your generated documentation.
 
-A template in phpDocumentor is a series of actions, called :term:`transformations`, that is capable of crafting the
+A template in phpDocumentor is a series of actions, called *transformations*, that is capable of crafting the
 desired output. With this mechanism, it is possible to generate HTML, XML, PDF but also to copy files to a destination
 location or generate a report of errors found while scanning your project.
 
-This is possible because a :term:`template` is a collection of those :term:`transformations`; that can combine
+This is possible because a template is a collection of those transformations; that can combine
 the assets of a template and your project's structure information into a set of documentation.
 
 Selecting a template
@@ -116,7 +116,7 @@ A tutorial for creating your custom documentation with Twig is offered in the ch
 :doc:`creating-your-own-template-using-twig`, for a complete overview of all options and possibilities see the guide
 on :doc:`creating templates<../guides/templates>` how to accomplish this.
 
-If you want to tweak one or two things it is also possible to define :term:`transformations` directly in your
+If you want to tweak one or two things it is also possible to define transformations directly in your
 configuration file. This way you can override the index, copy files (such as PDFs) or generate additional documents.
 
 For example, here we see how a PDF (located at ``data/specification.pdf`` of the template folder) is copied to the

--- a/docs/getting-started/creating-your-own-template-using-twig.rst
+++ b/docs/getting-started/creating-your-own-template-using-twig.rst
@@ -13,7 +13,7 @@ produce HTML files that you can serve from your website.
 While building a template there are three important steps:
 
 1. Creating a template definition file.
-2. Defining all :term:`transformations` that your template must do.
+2. Defining all transformations that your template must do.
 3. Writing your Twig templates and providing assets.
 
 Each of these steps is covered in the following subchapters, so if you want to make your own template you can just read
@@ -27,7 +27,7 @@ on and follow along with the text.
 Create your template definition
 -------------------------------
 
-Simply put, a template is a combination of :term:`transformations` that will read the data that phpDocumentor has
+Simply put, a template is a combination of transformations that will read the data that phpDocumentor has
 aggregated and transform that into the output that you desire, such as an HTML page.
 
 In order for phpDocumentor to know what to do there is always a template definition file present, called

--- a/docs/getting-started/your-first-set-of-documentation.rst
+++ b/docs/getting-started/your-first-set-of-documentation.rst
@@ -11,13 +11,13 @@ Writing a DocBlock
 ------------------
 
 A DocBlock is a piece of inline *documentation* in your source code that informs you what a class, method or other
-:term:`Structural Element` its function is.
+Structural Element its function is.
 
 Which elements can be documented?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Before we discuss what a DocBlock looks like, let's first zoom into what you can document with them. phpDocumentor
-follows the PHPDoc definition and recognizes the following :term:`Structural Elements`:
+follows the PHPDoc definition and recognizes the following Structural Elements:
 
 * Function_
 * Constant_
@@ -28,7 +28,7 @@ follows the PHPDoc definition and recognizes the following :term:`Structural Ele
 * Property_
 * Method_
 
-In addition to the above the PHPDoc standard also supports :term:`DocBlocks` for *Files* and include/require statements,
+In addition to the above the PHPDoc standard also supports DocBlocks for *Files* and include/require statements,
 even though PHP itself does not know this concept.
 
 Each of these elements can have exactly one DocBlock associated with it, which directly precedes it. No code or
@@ -37,9 +37,9 @@ comments may be between a DocBlock and the start of an element's definition.
 What does a DocBlock look like?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:term:`DocBlocks` are always enclosed in a comment-type, called :term:`DocComment`, that starts with ``/**`` and ends
+DocBlocks are always enclosed in a comment-type, called DocComment, that starts with ``/**`` and ends
 with ``*/``. Each line in between the opening and closing statement should start with an asterisk (``*``). Every
-:term:`DocBlock` precedes exactly one :term:`Structural Element` and all contents of the :term:`DocBlock` apply to that
+DocBlock precedes exactly one Structural Element and all contents of the DocBlock apply to that
 associated element.
 
 For example:
@@ -60,7 +60,7 @@ For example:
 
    Quite often projects will want to document the license or function for an entire file instead of a single element.
    This can be accomplished by having a DocBlock as the first element encountered in a file. It is important to note that
-   whenever another :term:`Structural Element` directly follows the DocBlock that it is no longer recognized as a
+   whenever another Structural Element directly follows the DocBlock that it is no longer recognized as a
    File-level DocBlock but belonging to the subsequent element.
 
    The following DocBlock is a File-level DocBlock:
@@ -92,10 +92,10 @@ For example:
       {
       }
 
-DocBlocks are divided into the following three parts. Each of these parts is optional, except that a :term:`Description`
-may not exist without a :term:`Summary`.
+DocBlocks are divided into the following three parts. Each of these parts is optional, except that a Description
+may not exist without a Summary.
 
-:term:`Summary`
+Summary
   Sometimes called a short description, provides a brief introduction into the function of the associated element.
   A Summary ends
   in one of these situations:
@@ -103,12 +103,12 @@ may not exist without a :term:`Summary`.
     1. A dot is following by a line break, or
     2. Two subsequent line breaks are encountered.
 
-:term:`Description`
+Description
   Sometimes called the long description, can provide more information. Examples of additional information is a
   description of a function's algorithm, a usage example or description how a class fits in the whole of the
   application's architecture. The description ends when the first tag is encountered or when the DocBlock is closed.
 
-:term:`Tags` and :term:`annotations`
+Tags and Annotations
   These provide a way to succinctly and uniformly provide meta-information about the associated element. This could,
   for example, describe the type of information that is returned by a method or function. Each tag is preceded by an
   at-sign (`@`) and starts on a new line.
@@ -143,11 +143,11 @@ Line 2
   shows that a DocBlock starts with the opening sequence ``/**``.
 
 Line 3
-  has an example of a :term:`Summary`. This is, usually, a single line but may cover multiple lines as long as the end
+  has an example of a Summary. This is, usually, a single line but may cover multiple lines as long as the end
   of the summary, as defined in the previous chapter, is not reached.
 
 Line 5 and 6
-  show an example of a :term:`Description`, which may span multiple lines and can be formatted using the
+  show an example of a Description, which may span multiple lines and can be formatted using the
   Markdown_ markup language. Using Markdown_ you can make text bold, italic, add numbered lists and even provide code
   examples.
 

--- a/docs/guides/docblocks.rst
+++ b/docs/guides/docblocks.rst
@@ -5,7 +5,7 @@ Overview
 --------
 
 If all is well you have read the :doc:`Getting Started<../getting-started/your-first-set-of-documentation>` and got a
-basic idea on what a :term:`DocBlock` is and what you can do with it. In this guide I will repeat some of the bits and
+basic idea on what a DocBlock is and what you can do with it. In this guide I will repeat some of the bits and
 then dive a lot deeper in and discuss the details on what constitutes a DocBlock and what you can do with it.
 
 Anatomy of a DocBlock
@@ -14,13 +14,13 @@ Anatomy of a DocBlock
 Using a DocBlock you are able to effectively document your application's API (Application Programming Interface) by
 describing the function of, and relations between, elements in your source code, such as classes and methods.
 
-In reality a :term:`DocBlock` is in fact the name for a combination of a, so-called, :term:`DocComment` and a block of
-the :term:`PHPDoc` Domain Specific Language (DSL). A DocComment is the container that contains documentation that can
+In reality a DocBlock is in fact the name for a combination of a, so-called, DocComment and a block of
+the PHPDoc Domain Specific Language (DSL). A DocComment is the container that contains documentation that can
 be formatted according to the :doc:`PHPDoc Standard<../references/phpdoc/index>`.
 
 .. important::
 
-   A DocBlock is always associated with one, and just one, :term:`Structural Element` in PHP; so this may either be
+   A DocBlock is always associated with one, and just one, Structural Element in PHP; so this may either be
    a file, class, interface, trait, function, constant, method, property or variable.
 
 **DocComments**
@@ -44,7 +44,7 @@ That is easy, right?
 
 **PHPDoc**
 
-Something a little more extensive is the PHPDoc DSL. Inside :term:`DocComments` phpDocumentor, and many other tools with
+Something a little more extensive is the PHPDoc DSL. Inside DocComments phpDocumentor, and many other tools with
 it, expect to find a block of text that matches the :doc:`PHPDoc Standard<../references/phpdoc/index>`.
 
 Commonly a piece of PHPDoc consists of the following three parts in order of appearance:
@@ -102,7 +102,7 @@ The nice thing about this description is that you can format your text according
 `Github-flavoured Markdown`_. Using this format it is easy to make your text bold, add inline code examples or
 easily generate links to other sites.
 
-Another nifty feature is that you can use a series of :term:`Inline Tags` to refer to other parts of the documentation
+Another nifty feature is that you can use a series of Inline Tags to refer to other parts of the documentation
 (``{@see}``), inherit the description of a parent (``{@inheritDoc}``) and more. Once you finish reading this guide
 you should definitely take a look at the :doc:`../references/phpdoc/inline-tags/index` to see which `Inline Tags` there
 are and what they do.
@@ -187,7 +187,7 @@ descriptions.
 Annotations
 +++++++++++
 
-In addition to the above you might also encounter :term:`Annotations` when viewing DocBlocks. An :term:`Annotation` is
+In addition to the above you might also encounter Annotations when viewing DocBlocks. An Annotation is
 a specialized form of tag that not only documents a specific aspect of the associated element but also influences the
 way the application behaves.
 
@@ -203,7 +203,7 @@ the tag name is separated into two parts, a namespace and the actual annotation 
 .. important::
 
    Some annotation libraries support Annotations both with and without a namespace. When given the opportunity use a
-   namespace to prevent conflicts with existing tags in the :term:`PHPDoc Standard`.
+   namespace to prevent conflicts with existing tags in the PHPDoc Standard.
 
    When you are using the regular tag syntax it is recommended to prefix the tag with a name representing your
    application or organisation's name and a hyphen. For example::

--- a/docs/guides/running-phpdocumentor.rst
+++ b/docs/guides/running-phpdocumentor.rst
@@ -4,7 +4,7 @@ Running phpDocumentor
 In this guide we are going to explain how to generate documentation for your application and how to tune it to your
 liking. phpDocumentor supports a wide range of options related to the generation of documentation that can help you.
 
-phpDocumentor is a command-line application that supports several actions, called :term:`commands`, with which you can
+phpDocumentor is a command-line application that supports several actions, called *commands*, with which you can
 generate your documentation but also, for example, display a list of installed templates. In this guide we are only
 going to discuss the default command: ``project:run``, you can find a list of all supported commands in the
 :doc:`command reference<../references/commands/index>`
@@ -104,7 +104,7 @@ somewhere down the tree.
    Enclose any value for an option that provides a wildcard with double quotes to prevent your command line from
    interpreting them.
 
-When you want to provide a relative path, keep in mind that this is relative to the :term:`Project Root Folder`.
+When you want to provide a relative path, keep in mind that this is relative to the Project Root Folder.
 The project's root folder is the first folder that the provided folders have in common, so for
 ``-d "src/phpDocumentor,src/SomethingElse" this is the directory "src" and not the current working directory. When in doubt,
 check the output of phpDocumentor, it mentions the project's root folder after all files are collected.
@@ -167,7 +167,7 @@ Markers
 -------
 
 phpDocumentor is mostly about DocBlocks and processing inline documentation. However it will also collect
-:term:`markers`.
+markers.
 
 In short, a Marker is a single-line inline comment that starts with a single, identifying, word and has a description.
 Let's take a look at an example to make this less abstract::

--- a/docs/guides/types.rst
+++ b/docs/guides/types.rst
@@ -37,7 +37,7 @@ This means that any class may be addressed
 
       use phpDocumentor\Descriptor\ParamDescriptor as Param
 
-  Now you can refer to the class above as ``Param`` from any tag that refers to a :term:`Type`.
+  Now you can refer to the class above as ``Param`` from any tag that refers to a Type.
 
 .. warning::
 

--- a/docs/internals/flow.rst
+++ b/docs/internals/flow.rst
@@ -148,10 +148,10 @@ will remove all files from that cache that are not present in the file listing t
 contain any entries that are not intended to be documented.
 
 Once that is done phpDocumentor should have a description of your Project, represented by an instance of the
-ProjectDescriptor class, that may be pre-populated with the :term:`Abstract Syntax Tree` (other Descriptors) that were
+ProjectDescriptor class, that may be pre-populated with the Abstract Syntax Tree (other Descriptors) that were
 discovered during a previous run.
 
-When phpDocumentor is ready to create, or actually refresh, the :term:`AST` it will iterate over all files that were
+When phpDocumentor is ready to create, or actually refresh, the AST it will iterate over all files that were
 discovered. A hash is generated of each file and checked with the cache if this file is still *fresh*. Should the hash
 not exist in the Cache or it differs for a given file then phpDocumentor will create a new representation of that file
 and overwrite the previous one.
@@ -159,7 +159,7 @@ and overwrite the previous one.
 .. important::
 
    At this stage all links between elements, such as that of an ``@see`` tag, are still strings containing the
-   :term:`FQSEN` that references another element. It is not until much later, in the Linker, where the text references
+   FQSEN that references another element. It is not until much later, in the Linker, where the text references
    are converted into actual references to other objects.
 
    This is done because:

--- a/docs/references/phpdoc/basic-syntax.rst
+++ b/docs/references/phpdoc/basic-syntax.rst
@@ -42,7 +42,7 @@ This is an example of a DocBlock as it can be encountered:
 Which elements can have a DocBlock
 ----------------------------------
 
-:term:`Structural Elements` can all be preceded by a DocBlock. The following elements are counted as such:
+Structural Elements can all be preceded by a DocBlock. The following elements are counted as such:
 
     * namespace
     * require(_once)
@@ -55,7 +55,7 @@ Which elements can have a DocBlock
     * constant
     * variables, both local and global scope.
 
-A more detailed description of what :term:`Structural Elements` are and how DocBlocks apply to them can be found in
+A more detailed description of what Structural Elements are and how DocBlocks apply to them can be found in
 the :doc:`definitions`.
 
 Sections

--- a/docs/references/phpdoc/tags/api.rst
+++ b/docs/references/phpdoc/tags/api.rst
@@ -1,7 +1,7 @@
 @api
 ====
 
-The @api tag is used to declare :term:`Structural Elements` as being suitable for
+The @api tag is used to declare Structural Elements as being suitable for
 consumption by third parties.
 
 Syntax
@@ -12,20 +12,20 @@ Syntax
 Description
 -----------
 
-The @api tag represents those :term:`Structural Elements` with a public visibility
+The @api tag represents those Structural Elements with a public visibility
 which are intended to be the public API components for a library or framework.
-Other :term:`Structural Elements` with a public visibility serve to support the
+Other Structural Elements with a public visibility serve to support the
 internal structure and are not recommended to be used by the consumer.
 
-The exact meaning of :term:`Structural Elements` tagged with @api MAY differ per
-project. It is however RECOMMENDED that all tagged :term:`Structural Elements` SHOULD
+The exact meaning of Structural Elements tagged with @api MAY differ per
+project. It is however RECOMMENDED that all tagged Structural Elements SHOULD
 NOT change after publication unless the new version is tagged as breaking
 Backwards Compatibility.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` tagged with the @api tag will be shown in a separate
+Structural Elements tagged with the @api tag will be shown in a separate
 sidebar section and the individual entry of will be marked as being an API element.
 
     Not all templates might show the API sidebar section; it is recommended to

--- a/docs/references/phpdoc/tags/author.rst
+++ b/docs/references/phpdoc/tags/author.rst
@@ -1,7 +1,7 @@
 @author
 =======
 
-The @author tag is used to document the author of :term:`Structural Elements`.
+The @author tag is used to document the author of Structural Elements.
 
 Syntax
 ------
@@ -11,7 +11,7 @@ Syntax
 Description
 -----------
 
-The @author tag can be used to indicate who has created :term:`Structural Elements`
+The @author tag can be used to indicate who has created Structural Elements
 or has made significant modifications to them. This tag MAY also contain an
 e-mail address. If an e-mail address is provided it MUST follow
 the author's name and be contained in chevrons, or angle brackets, and MUST
@@ -21,7 +21,7 @@ adhere to the syntax defined in section 3.4.1 of
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` tagged with the @author tag will show an *Author*
+Structural Elements tagged with the @author tag will show an *Author*
 header in their description containing the contents of this tag.
 
 If an e-mail address is provided in the tag then the *Author* will link to the

--- a/docs/references/phpdoc/tags/category.rst
+++ b/docs/references/phpdoc/tags/category.rst
@@ -18,7 +18,7 @@ Description
 -----------
 
 The @category tag was meant in the original de-facto Standard to group several
-:term:`Structural Elements` their :doc:`package` tags into one category. These
+Structural Elements their :doc:`package` tags into one category. These
 categories could then be used to aid in the generation of API documentation.
 
 This was necessary since the @package tag, as defined in the original Standard,
@@ -27,13 +27,13 @@ SHOULD NOT be used.
 
 Please see the documentation for :doc:`package` for details of its usage.
 
-This tag MUST NOT occur more than once in a :term:`DocBlock`.
+This tag MUST NOT occur more than once in a DocBlock.
 
 Effects in phpDocumentor
 ------------------------
 
 The @category tag has no significant effect in phpDocumentor. It will be shown
-with the description information of associated :term:`Structural Elements` and
+with the description information of associated Structural Elements and
 is inherited by classes and interfaces.
 
 Examples

--- a/docs/references/phpdoc/tags/copyright.rst
+++ b/docs/references/phpdoc/tags/copyright.rst
@@ -2,7 +2,7 @@
 ==========
 
 The @copyright tag is used to document the copyright information for
-:term:`Structural elements`.
+Structural Elements.
 
 Syntax
 ------
@@ -12,8 +12,8 @@ Syntax
 Description
 -----------
 
-The @copyright tag defines who holds the copyright over :term:`Structural Elements`.
-The copyright indicated with this tag applies to the :term:`Structural Elements`
+The @copyright tag defines who holds the copyright over Structural Elements.
+The copyright indicated with this tag applies to the Structural Elements
 with which it is associated and all child elements unless otherwise noted.
 
 The format of the description is governed by the coding standard of each
@@ -23,7 +23,7 @@ covered by this copyright and the organization involved.
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` tagged with the @copyright tag will show a *Copyright*
+Structural Elements tagged with the @copyright tag will show a *Copyright*
 header in their description containing the contents of this tag.
 
 Examples

--- a/docs/references/phpdoc/tags/deprecated.rst
+++ b/docs/references/phpdoc/tags/deprecated.rst
@@ -1,7 +1,7 @@
 @deprecated
 ===========
 
-The @deprecated tag is used to indicate which :term:`Structural elements` are
+The @deprecated tag is used to indicate which Structural Elements are
 deprecated and are to be removed in a future version.
 
 Syntax
@@ -12,7 +12,7 @@ Syntax
 Description
 -----------
 
-The @deprecated tag declares that the associated :term:`Structural elements` will
+The @deprecated tag declares that the associated Structural Elements will
 be removed in a future version as it has become obsolete or its usage is otherwise
 not recommended.
 
@@ -24,12 +24,12 @@ MUST follow the same rules as those by the :doc:`version` tag's vector.
 It is RECOMMENDED (but not required) to provide an additional description stating
 why the associated element is deprecated.
 If it is superceded by another method it is RECOMMENDED to add a @see tag in the
-same :term:`PHPDoc` pointing to the new element.
+same PHPDoc pointing to the new element.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` tagged with the @deprecated tag will be listed in the
+Structural Elements tagged with the @deprecated tag will be listed in the
 *Deprecated elements* report and their name will be shown as strike through.
 
 Examples

--- a/docs/references/phpdoc/tags/example.rst
+++ b/docs/references/phpdoc/tags/example.rst
@@ -20,7 +20,7 @@ or inline
 Description
 -----------
 
-The @example tag can be used to demonstrate the use of :term:`Structural Elements`
+The @example tag can be used to demonstrate the use of Structural Elements
 by presenting the contents of files that use them.
 
 A location to a file MUST be specified. It can be specified as a relative or

--- a/docs/references/phpdoc/tags/filesource.rst
+++ b/docs/references/phpdoc/tags/filesource.rst
@@ -14,12 +14,12 @@ Description
 
 The @filesource tag tells phpDocumentor to include the current file in the parsing
 output. As this only applies to the source code of the entire file MUST this
-tag be used in the file-level :term:`PHPDoc`. Any other location will be ignored.
+tag be used in the file-level PHPDoc. Any other location will be ignored.
 
 When this tag is included will phpDocumentor compress the file contents and encode them
 using Base64 so that it can be handled by the transformer. Any template that
 is able to show the source code can then read the ``source`` sub-element in the
-associated ``file`` element in the :term:`Abstract Syntax Tree`.
+associated ``file`` element in the Abstract Syntax Tree.
 
 Examples
 --------

--- a/docs/references/phpdoc/tags/global.rst
+++ b/docs/references/phpdoc/tags/global.rst
@@ -20,8 +20,8 @@ usage.
 Syntax
 ------
 
-    @global [:term:`Type`] [name]
-    @global [:term:`Type`] [description]
+    @global [Type] [name]
+    @global [Type] [description]
 
 Description
 -----------
@@ -50,7 +50,7 @@ Function usage
 
 The function/method @global syntax MAY be used to document usage of global
 variables in a function, and MUST NOT have a $ starting the third word. The
-:term:`Type` will be ignored if a match is made between the declared global
+Type will be ignored if a match is made between the declared global
 variable and a variable documented in the project.
 
 A parser SHOULD display the optional description unmodified.

--- a/docs/references/phpdoc/tags/ignore.rst
+++ b/docs/references/phpdoc/tags/ignore.rst
@@ -1,7 +1,7 @@
 @ignore
 =======
 
-The @ignore tag is used to tell phpDocumentor that :term:`Structural Elements` are not
+The @ignore tag is used to tell phpDocumentor that Structural Elements are not
 to be processed by phpDocumentor.
 
 Syntax
@@ -12,7 +12,7 @@ Syntax
 Description
 -----------
 
-The @ignore tag tells phpDocumentor that the :term:`Structural Elements` associated
+The @ignore tag tells phpDocumentor that the Structural Elements associated
 with the tag are not to be processed. An example of use might be to prevent
 duplicate documenting of conditional constants.
 
@@ -22,7 +22,7 @@ why the associated element is to be ignored.
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` tagged with the @ignore tag will be not be processed.
+Structural Elements tagged with the @ignore tag will be not be processed.
 
 Examples
 --------

--- a/docs/references/phpdoc/tags/internal.rst
+++ b/docs/references/phpdoc/tags/internal.rst
@@ -1,7 +1,7 @@
 @internal
 =========
 
-The @internal tag is used to denote that associated :term:`Structural Elements`
+The @internal tag is used to denote that associated Structural Elements
 are elements internal to this application or library. It may also be used inside
 a long description to insert a piece of text that is only applicable for
 the developers of this software.
@@ -23,7 +23,7 @@ Description
 -----------
 
 The @internal tag can be used as counterpart of the @api tag, indicating that
-the associated :term:`Structural Elements` are used purely for the internal
+the associated Structural Elements are used purely for the internal
 workings of this piece of software.
 
 An additional use of @internal is to add internal comments or additional
@@ -32,16 +32,16 @@ to withhold certain business-critical or confusing information when generating
 documentation from the source code of this piece of software.
 
     It is NOT RECOMMENDED to store passwords or security sensitive information
-    in your :term:`DocBlock`. Not even with this tag.
+    in your DocBlock. Not even with this tag.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements`, or parts of the long description when the tag is
+Structural Elements, or parts of the long description when the tag is
 used inline, tagged with the @internal tag will be filtered out when creating
 the HTML output unless the ``--parseprivate`` command line argument is used.
 
-The :term:`Abstract Syntax Tree` will still contain the internal information.
+The Abstract Syntax Tree will still contain the internal information.
 Any consumer of this file is responsible for filtering the information.
 
 Examples

--- a/docs/references/phpdoc/tags/license.rst
+++ b/docs/references/phpdoc/tags/license.rst
@@ -2,7 +2,7 @@
 ========
 
 The @license tag is used to indicate which license is applicable for the associated
-:term:`Structural Elements`.
+Structural Elements.
 
 Syntax
 ------
@@ -13,9 +13,9 @@ Description
 -----------
 
 The @license tag provides the user with the name and URL of the license that is
-applicable to :term:`Structural Elements` and any of their child elements.
+applicable to Structural Elements and any of their child elements.
 
-It is NOT RECOMMENDED to apply @license tags to any :term:`PHPDoc` other than
+It is NOT RECOMMENDED to apply @license tags to any PHPDoc other than
 file-level PHPDocs as this may cause confusion which license applies at which
 time.
 
@@ -25,7 +25,7 @@ license.
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` tagged with the @license tag will show a link to the
+Structural Elements tagged with the @license tag will show a link to the
 given license in case an URL is provided or the name contains one of the following
 license forms:
 

--- a/docs/references/phpdoc/tags/link.rst
+++ b/docs/references/phpdoc/tags/link.rst
@@ -5,10 +5,10 @@
 
    The effects of the inline version of this tag are not yet fully implemented
    in phpDocumentor 3. There's only URI support (i.e. no support for
-   :term:`Structural Elements`), and even that is available only in long descriptions.
+   Structural Elements), and even that is available only in long descriptions.
 
 The @link tag indicates a custom relation between associated
-:term:`Structural Elements` and a website, which is identified by an absolute
+Structural Elements and a website, which is identified by an absolute
 URI.
 
 Syntax
@@ -24,7 +24,7 @@ Description
 -----------
 
 The @link tag can be used to define a relation, or link, between
-:term:`Structural Elements` or part of the long description, when used inline,
+Structural Elements or part of the long description, when used inline,
 to an URI.
 
 The URI MUST be complete and well-formed as specified in
@@ -36,7 +36,7 @@ defined by this occurrence.
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements`, or inline text in a long description, tagged with
+Structural Elements, or inline text in a long description, tagged with
 the @link tag will show a link in their description. If a description is
 provided with the tag then this will be used as link text instead of the URL itself.
 

--- a/docs/references/phpdoc/tags/method.rst
+++ b/docs/references/phpdoc/tags/method.rst
@@ -31,13 +31,13 @@ the return type to communicate that.
 There must be a return type, ``static`` on its own would mean that the method
 returns an instance of the child class which the method is called on.
 
-@method tags MUST NOT be used in a :term:`PHPDoc` that is not associated with
+@method tags MUST NOT be used in a PHPDoc that is not associated with
 a *class* or *interface*.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` of type *class* or *interface* tagged with the
+Structural Elements of type *class* or *interface* tagged with the
 @method tag will show an extra method in their method listing matching the
 data provided with this tag.
 

--- a/docs/references/phpdoc/tags/package.rst
+++ b/docs/references/phpdoc/tags/package.rst
@@ -1,7 +1,7 @@
 @package
 ========
 
-The @package tag is used to categorize :term:`Structural Elements` into logical
+The @package tag is used to categorize Structural Elements into logical
 subdivisions.
 
 Syntax
@@ -13,7 +13,7 @@ Description
 -----------
 
 The @package tag can be used as a counterpart or supplement to Namespaces.
-Namespaces provide a functional subdivision of :term:`Structural Elements` where
+Namespaces provide a functional subdivision of Structural Elements where
 the @package tag can provide a *logical* subdivision in which way the elements
 can be grouped with a different hierarchy.
 
@@ -28,7 +28,7 @@ RECOMMENDED to keep the depth at less or equal than six levels.
     separator for compatibility with existing projects. Despite this the
     backslash is RECOMMENDED as separator.
 
-Please note that the @package applies to different :term:`Structural Elements`
+Please note that the @package applies to different Structural Elements
 depending where it is defined.
 
 1. If the @package is defined in the *file-level* DocBlock then it only applies
@@ -45,12 +45,12 @@ depending where it is defined.
    This means that a function which is contained in a namespace with the
    @package tag assumes that package.
 
-This tag MUST NOT occur more than once in a :term:`PHPDoc`.
+This tag MUST NOT occur more than once in a PHPDoc.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` tagged with the @package tag are grouped and
+Structural Elements tagged with the @package tag are grouped and
 organized in their own sidebar section.
 
 Examples

--- a/docs/references/phpdoc/tags/param.rst
+++ b/docs/references/phpdoc/tags/param.rst
@@ -6,14 +6,14 @@ The @param tag is used to document a single argument of a function or method.
 Syntax
 ------
 
-    @param [:term:`Type`] [name] [<description>]
+    @param [Type] [name] [<description>]
 
 Description
 -----------
 
 With the @param tag it is possible to document the type and function of a
 single argument of a function or method. When provided it MUST contain a
-:term:`Type` to indicate what is expected; the description on the other hand is
+Type to indicate what is expected; the description on the other hand is
 OPTIONAL yet RECOMMENDED in case of complicated structures, such as associative
 arrays.
 
@@ -23,16 +23,16 @@ delimiting.
 It is RECOMMENDED when documenting to use this tag with every function and
 method. Exceptions to this recommendation are:
 
-This tag MUST NOT occur more than once per argument in a :term:`PHPDoc` and is
-limited to :term:`Structural Elements` of type method or function.
+This tag MUST NOT occur more than once per argument in a PHPDoc and is
+limited to Structural Elements of type method or function.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` of type method or function, that are tagged with the
+Structural Elements of type method or function, that are tagged with the
 @param tag, will have additional information in the section regarding Arguments.
 
-If the return :term:`Type` is a class that is documented by phpDocumentor, then
+If the return Type is a class that is documented by phpDocumentor, then
 a link to that class' documentation is provided.
 
 .. note::

--- a/docs/references/phpdoc/tags/property-read.rst
+++ b/docs/references/phpdoc/tags/property-read.rst
@@ -7,7 +7,7 @@ present that are read-only.
 Syntax
 ------
 
-    @property-read [:term:`Type`] [name] [<description>]
+    @property-read [Type] [name] [<description>]
 
 Description
 -----------
@@ -22,13 +22,13 @@ __get() method to provide it.
 In this situation, the child class would have a @property-read tag for each
 magic property.
 
-@property-read tags MUST NOT be used in a :term:`PHPDoc` that is not associated
+@property-read tags MUST NOT be used in a PHPDoc that is not associated
 with a *class* or *interface*.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` of type *class* or *interface* tagged with the
+Structural Elements of type *class* or *interface* tagged with the
 @property-read tag will show an extra property in their property listing
 matching the data provided with this tag.
 

--- a/docs/references/phpdoc/tags/property-write.rst
+++ b/docs/references/phpdoc/tags/property-write.rst
@@ -7,7 +7,7 @@ present that are write-only.
 Syntax
 ------
 
-    @property-write [:term:`Type`] [name] [<description>]
+    @property-write [Type] [name] [<description>]
 
 Description
 -----------
@@ -22,13 +22,13 @@ __set() method to provide it.
 In this situation, the child class would have a @property-write tag for each magic
 property.
 
-@property-write tags MUST NOT be used in a :term:`PHPDoc` that is not associated
+@property-write tags MUST NOT be used in a PHPDoc that is not associated
 with a *class* or *interface*.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` of type *class* or *interface* tagged with the
+Structural Elements of type *class* or *interface* tagged with the
 @property-write tag will show an extra property in their property listing
 matching the data provided with this tag.
 

--- a/docs/references/phpdoc/tags/property.rst
+++ b/docs/references/phpdoc/tags/property.rst
@@ -6,7 +6,7 @@ The @property tag allows a class to know which 'magic' properties are present.
 Syntax
 ------
 
-    @property [:term:`Type`] [name] [<description>]
+    @property [Type] [name] [<description>]
 
 Description
 -----------
@@ -20,13 +20,13 @@ __get() method to provide it.
 In this situation, the child class would have a @property tag for each magic
 property.
 
-@property tags MUST NOT be used in a :term:`PHPDoc` that is not associated with
+@property tags MUST NOT be used in a PHPDoc that is not associated with
 a *class* or *interface*.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` of type *class* or *interface* tagged with the
+Structural Elements of type *class* or *interface* tagged with the
 @property tag will show an extra property in their property listing matching the
 data provided with this tag.
 

--- a/docs/references/phpdoc/tags/return.rst
+++ b/docs/references/phpdoc/tags/return.rst
@@ -6,13 +6,13 @@ The @return tag is used to document the return value of functions or methods.
 Syntax
 ------
 
-    @return [:term:`Type`] [<description>]
+    @return [Type] [<description>]
 
 Description
 -----------
 
 With the @return tag it is possible to document the return type and function of a
-function or method. When provided it MUST contain a :term:`Type` to indicate
+function or method. When provided it MUST contain a Type to indicate
 what is returned; the description on the other hand is OPTIONAL yet
 RECOMMENDED in case of complicated return structures, such as associative arrays.
 
@@ -27,17 +27,17 @@ method. Exceptions to this recommendation are:
 2. **functions and methods without a `return` value**, the @return tag MAY be
    omitted here, in which case `@return void` is implied.
 
-This tag MUST NOT occur more than once in a :term:`PHPDoc` and is limited to
-:term:`Structural Elements` of type method or function.
+This tag MUST NOT occur more than once in a PHPDoc and is limited to
+Structural Elements of type method or function.
 
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` of type method or function, that are tagged with the
+Structural Elements of type method or function, that are tagged with the
 @return tag, will have an additional section *Returns* in their content description
-that shows the return :term:`Type` and description.
+that shows the return Type and description.
 
-If the return :term:`Type` is a class that is documented by phpDocumentor, then a link
+If the return Type is a class that is documented by phpDocumentor, then a link
 to that class' documentation is provided.
 
 Examples

--- a/docs/references/phpdoc/tags/see.rst
+++ b/docs/references/phpdoc/tags/see.rst
@@ -2,26 +2,26 @@
 ====
 
 The @see tag indicates a reference from the associated
-:term:`Structural Elements` to a website or other :term:`Structural Elements`.
+Structural Elements to a website or other Structural Elements.
 
 Syntax
 ------
 
-    @see [URI | :term:`FQSEN`] [<description>]
+    @see [URI | FQSEN] [<description>]
 
 or inline
 
-   {\@see [URI | :term:`FQSEN`] [<description>]}
+   {\@see [URI | FQSEN] [<description>]}
 
 Description
 -----------
 
 The @see tag can be used to define a reference to other
-:term:`Structural Elements` or to an URI.
+Structural Elements or to an URI.
 
-When defining a reference to another :term:`Structural Elements` you can provide
+When defining a reference to another Structural Elements you can provide
 a specific element by appending a double colon and providing the name of that
-element (also called the :term:`FQSEN`).
+element (also called the FQSEN).
 
 A URI MUST be complete and well-formed as specified in
 `RFC2396 <http://www.ietf.org/rfc/rfc2396.txt>`_.
@@ -34,7 +34,7 @@ The @see tag cannot refer to a namespace element.
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements`, or inline text in a long description, tagged with
+Structural Elements, or inline text in a long description, tagged with
 the @see tag will show a link in their description. If a description is
 provided with the tag then this will be used as link text instead of the URL
 itself.

--- a/docs/references/phpdoc/tags/since.rst
+++ b/docs/references/phpdoc/tags/since.rst
@@ -6,7 +6,7 @@
    The effects of this tag are not yet fully implemented in phpDocumentor 3.
 
 The @since tag indicates at which version did the associated
-:term:`Structural Elements` became available.
+Structural Elements became available.
 
 Syntax
 ------
@@ -17,7 +17,7 @@ Description
 -----------
 
 The @since tag can be used to indicate since which version specific
-:term:`Structural Elements` have become available.
+Structural Elements have become available.
 
 This information can be used to generate a set of API Documentation where the
 consumer is informed which application version is necessary for a specific
@@ -26,7 +26,7 @@ element.
 The version MUST follow the same rules as the :doc:`version` tag's vector and
 MAY have a description to provide additional information.
 
-This tag can occur multiple times within a :term:`PHPDoc`. In that case, each
+This tag can occur multiple times within a PHPDoc. In that case, each
 occurrence is treated as an entry to a change log. It is RECOMMENDED that you
 also provide a description to each such tag.
 

--- a/docs/references/phpdoc/tags/source.rst
+++ b/docs/references/phpdoc/tags/source.rst
@@ -5,7 +5,7 @@
 
    The effects of this tag are not yet fully implemented in phpDocumentor 3.
 
-The @source tag shows the source code of :term:`Structural Elements`.
+The @source tag shows the source code of Structural Elements.
 
 Syntax
 ------
@@ -16,7 +16,7 @@ Description
 -----------
 
 The @source tag can be used to communicate the implementation of
-:term:`Structural Elements` by presenting their source code, or more typically -
+Structural Elements by presenting their source code, or more typically -
 portions of it.
 
 If specified, the starting line MUST be a positive integer. Counting starts at

--- a/docs/references/phpdoc/tags/subpackage.rst
+++ b/docs/references/phpdoc/tags/subpackage.rst
@@ -7,7 +7,7 @@
    phpDocumentor. It is recommended to use the :doc:`package` tag's ability to
    provide multiple levels.
 
-The @subpackage tag is used to categorize :term:`Structural Elements` into
+The @subpackage tag is used to categorize Structural Elements into
 logical subdivisions.
 
 Syntax
@@ -19,7 +19,7 @@ Description
 -----------
 
 The @subpackage tag can be used as a counterpart or supplement to Namespaces.
-Namespaces provide a functional subdivision of :term:`Structural Elements` where
+Namespaces provide a functional subdivision of Structural Elements where
 the @subpackage tag can provide a *logical* subdivision in which way the
 elements can be grouped with a different hierarchy.
 
@@ -39,7 +39,7 @@ This tag is considered superseded by the support for multiple levels in the
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` tagged with the @subpackage tag are grouped and
+Structural Elements tagged with the @subpackage tag are grouped and
 organized in their own sidebar section.
 
 Examples

--- a/docs/references/phpdoc/tags/throws.rst
+++ b/docs/references/phpdoc/tags/throws.rst
@@ -1,18 +1,18 @@
 @throws
 =======
 
-The @throws tag is used to indicate whether :term:`Structural Elements` could
+The @throws tag is used to indicate whether Structural Elements could
 throw a specific type of exception.
 
 Syntax
 ------
 
-    @throws [:term:`Type`] [<description>]
+    @throws [Type] [<description>]
 
 Description
 -----------
 
-The @throws tag MAY be used to indicate that :term:`Structural Elements` could
+The @throws tag MAY be used to indicate that Structural Elements could
 throw a specific type of error.
 
 The type provided with this tag MUST represent an object of the class Exception

--- a/docs/references/phpdoc/tags/todo.rst
+++ b/docs/references/phpdoc/tags/todo.rst
@@ -2,7 +2,7 @@
 =====
 
 The @todo tag is used to indicate whether any development activities should
-still be executed on associated :term:`Structural Elements`.
+still be executed on associated Structural Elements.
 
 Syntax
 ------
@@ -13,7 +13,7 @@ Description
 -----------
 
 The @todo tag is used to indicate that an activity surrounding the associated
-:term:`Structural Elements` must still occur. Each tag MUST be accompanied by
+Structural Elements must still occur. Each tag MUST be accompanied by
 a description that communicates the intent of the original author; this could
 however be as short as providing an issue number.
 

--- a/docs/references/phpdoc/tags/uses.rst
+++ b/docs/references/phpdoc/tags/uses.rst
@@ -1,18 +1,18 @@
 @uses & @used-by
 ================
 
-The @uses tag indicates a reference to (and from) a single associated :term:`Structural Elements`.
+The @uses tag indicates a reference to (and from) a single associated Structural Elements.
 
 Syntax
 ------
 
-    @uses [:term:`FQSEN`] [<description>]
+    @uses [FQSEN] [<description>]
 
 Description
 -----------
 
 The @uses tag is used to describe a consuming relation between the current element and any other of the
-:term:`Structural Elements`.
+Structural Elements.
 
 @uses is similar to @see (see the documentation for @see for details on format and structure). The @uses tag differs
 from @see in that @see is a one-way link, meaning the documentation containing a @see tag contains a link to other
@@ -21,8 +21,8 @@ Structural Elements or URIs but no link back is implied.
 Documentation generators SHOULD create a @used-by tag in the documentation of the receiving element that links back to
 the element associated with the @uses tag.
 
-When defining a reference to another :term:`Structural Elements` you can refer to a specific element by providing the
-:term:`FQSEN`.
+When defining a reference to another Structural Elements you can refer to a specific element by providing the
+FQSEN.
 
 The @uses tag COULD have a description appended to provide more information regarding the usage of the destination
 element.
@@ -30,7 +30,7 @@ element.
 Effects in phpDocumentor
 ------------------------
 
-:term:`Structural Elements` tagged with the @uses tag will show a link in their description. If a description is
+Structural Elements tagged with the @uses tag will show a link in their description. If a description is
 provided with the tag then this will be shown as additional information.
 
 In addition, phpDocumentor generates a @used-by tag with the receiving element (if documented) referring back to the

--- a/docs/references/phpdoc/tags/version.rst
+++ b/docs/references/phpdoc/tags/version.rst
@@ -1,7 +1,7 @@
 @version
 ========
 
-The @version tag indicates the current version of :term:`Structural Elements`.
+The @version tag indicates the current version of Structural Elements.
 
 Syntax
 ------
@@ -12,7 +12,7 @@ Description
 -----------
 
 The @version tag can be used to indicate the current version of
-:term:`Structural Elements`.
+Structural Elements.
 
 This information can be used to generate a set of API Documentation where the
 consumer is informed about elements at a particular version.

--- a/docs/references/phpdoc/types.rst
+++ b/docs/references/phpdoc/types.rst
@@ -1,7 +1,7 @@
 Definition of a 'Type'
 ======================
 
-Many tags use a :term:`Type` as part of their definition (such as the @return tag).
+Many tags use a Type as part of their definition (such as the @return tag).
 These types differ from the official PHP definition to be able to represent all
 kinds of data.
 
@@ -22,7 +22,7 @@ ABNF
                                |"double"|"object"|"mixed"|"array"|"resource"|"scalar"
                                |"void"|"null"|"callback"|"false"|"true"|"self"
 
-When a :term:`Type` is used the user will expect a value, or set of values, as
+When a Type is used the user will expect a value, or set of values, as
 detailed below.
 
 Atomic (singular) type
@@ -53,7 +53,7 @@ Keyword
 
 A keyword defining the purpose of this type. Not every element is determined
 by a class but still worth of a classification to assist the developer in
-understanding the code covered by the :term:`PHPDoc`.
+understanding the code covered by the PHPDoc.
 
 .. NOTE::
 
@@ -228,7 +228,7 @@ The following keywords are recognized:
 Multiple types
 --------------
 
-When the :term:`Type` consists of multiple (sub-)types then these MUST be
+When the Type consists of multiple (sub-)types then these MUST be
 separated with the vertical bar sign (|).
 
 For example:
@@ -241,14 +241,14 @@ For example:
 Arrays
 ------
 
-The value represented by :term:`Type` can be an array. The type MUST be defined
+The value represented by Type can be an array. The type MUST be defined
 following the format of one of the following options:
 
 1. **unspecified**, no definition of the contents of the represented array is given.
    Example: ``@return array``
 
-2. **specified containing a single type**, the :term:`Type` definition informs
-   the reader of the type of each array element. Only one :term:`Type` is then
+2. **specified containing a single type**, the Type definition informs
+   the reader of the type of each array element. Only one Type is then
    expected as element for a given array.
 
    Example: ``@return int[]``


### PR DESCRIPTION
_Discussed with @jaapio prior to creating this PR._

Commit https://github.com/phpDocumentor/phpDocumentor/commit/2d7a2a6af470b7a79f3d31006cb51da7e0ab620e removed the `glossary.rst` file.

The net result of that was that the automatic linking to the Glossary via `:term:...` annotations was removed. However, due to something inscrutable in Sphinx, the "_:term:`Type`_" references were now being auto-linked to the Python documentation, which I don't believe was the intention.
This effect can be clearly seen on: https://docs.phpdoc.org/3.0/references/phpdoc/types.html

To prevent this unintentional linking, this commit removes all `:term:` annotations throughout the documentation.

If needs be, they can always be brought back in the future by reverting this commit.

Side-note: this also solves a significant amount of the warnings the build was generating - see: https://github.com/phpDocumentor/phpDocumentor/runs/747054719?check_suite_focus=true#step:5:1973