### PR TITLE
Inline docs: php.net - use language agnostic links and more

### DIFF
--- a/src/phpDocumentor/Application.php
+++ b/src/phpDocumentor/Application.php
@@ -90,7 +90,7 @@ final class Application
      * This is done to prevent any warnings being outputted in relation to using
      * date/time functions.
      *
-     * @link http://php.net/manual/en/function.date-default-timezone-get.php for more information how PHP determines the
+     * @link https://www.php.net/function.date-default-timezone-get for more information how PHP determines the
      *     default timezone.
      */
     private function setTimezone() : void

--- a/src/phpDocumentor/Transformer/Template.php
+++ b/src/phpDocumentor/Transformer/Template.php
@@ -210,7 +210,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
     /**
      * Offset to unset.
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @link https://www.php.net/arrayaccess.offsetunset
      *
      * @param int|string $offset Index of item to unset.
      */
@@ -222,7 +222,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
     /**
      * Whether a offset exists.
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @link https://www.php.net/arrayaccess.offsetexists
      *
      * @param int|string $offset An offset to check for.
      *
@@ -236,7 +236,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
     /**
      * Count the number of transformations.
      *
-     * @link http://php.net/manual/en/countable.count.php
+     * @link https://www.php.net/countable.count
      *
      * @return int The count as an integer.
      */


### PR DESCRIPTION
Follow up on #2376, but now for phpDocumentor's own inline documentation.

* Fix links to the PHP manual to be language agnostic, so the site will automatically serve in the user's preferred language.
    Ref: https://www.php.net/urlhowto.php
* Fix the links to use `https`.