### PR TITLE
File docblocks: fix license tags

### DIFF
--- a/bin/phpdoc.php
+++ b/bin/phpdoc.php
@@ -6,7 +6,6 @@
  * PHP Version 5.3
  *
  * @copyright 2010-2018 Mike van Riel / Naenius (http://www.naenius.com)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      https://phpdoc.org
  */
 

--- a/tests/data/ApiTagTest.php
+++ b/tests/data/ApiTagTest.php
@@ -9,7 +9,6 @@
  * @subpackage Unit_tests
  * @author     Mike van Riel <mike.vanriel@naenius.com>
  * @copyright  2010-2018 Mike van Riel / Naenius (http://www.naenius.com)
- * @license    http://www.opensource.org/licenses/mit-license.php MIT
  * @link       https://phpdoc.org
  */
 
@@ -58,7 +57,6 @@ function bla6()
  * @package    Transformer
  * @subpackage Unit_tests
  * @author     Mike van Riel <mike.vanriel@naenius.com>
- * @license    http://www.opensource.org/licenses/mit-license.php MIT
  * @link       https://phpdoc.org
  * @api
  */

--- a/tests/data/DocBlockFixture.php
+++ b/tests/data/DocBlockFixture.php
@@ -9,7 +9,6 @@
  * @subpackage Unit_tests
  * @author     Mike van Riel <mike.vanriel@naenius.com>
  * @copyright  2010-2018 Mike van Riel / Naenius (http://www.naenius.com)
- * @license    http://www.opensource.org/licenses/mit-license.php MIT
  * @link       https://phpdoc.org
  */
 
@@ -20,7 +19,6 @@
  * @package    Transformer
  * @subpackage Unit_tests
  * @author     Mike van Riel <mike.vanriel@naenius.com>
- * @license    http://www.opensource.org/licenses/mit-license.php MIT
  * @link       https://phpdoc.org
  */
 class phpDocumentor_Tests_Data_DocBlockFixture

--- a/tests/data/MultiplePackagesDocBlock.php
+++ b/tests/data/MultiplePackagesDocBlock.php
@@ -9,7 +9,6 @@
  * @author     Ben Selby <benmatselby@gmail.com>
  * @author     Mike van Riel <mike.vanriel@naenius.com>
  * @copyright  2010-2018 Mike van Riel / Naenius. (http://www.naenius.com)
- * @license    http://www.opensource.org/licenses/mit-license.php MIT
  * @link       https://phpdoc.org
  */
 
@@ -22,7 +21,6 @@
  * @author     Ben Selby <benmatselby@gmail.com>
  * @author     Mike van Riel <mike.vanriel@naenius.com>
  * @copyright  2010-2018 Mike van Riel / Naenius. (http://www.naenius.com)
- * @license    http://www.opensource.org/licenses/mit-license.php MIT
  * @link       https://phpdoc.org
  */
 class MultiplePackagesDocBlock

--- a/tests/data/NamespaceTestData.php
+++ b/tests/data/NamespaceTestData.php
@@ -9,7 +9,6 @@
  * @subpackage Tests
  * @author     Mike van Riel <mike.vanriel@naenius.com>
  * @copyright  2010-2018 Mike van Riel / Naenius (http://www.naenius.com)
- * @license    http://www.opensource.org/licenses/mit-license.php MIT
  * @link       https://phpdoc.org
  */
 
@@ -30,7 +29,6 @@ use My\Full\NSname;
  * @package    Parser
  * @subpackage Tests
  * @author     Mike van Riel <mike.vanriel@naenius.com>
- * @license    http://www.opensource.org/licenses/mit-license.php MIT
  * @link       https://phpdoc.org
  */
 class NamespaceTest
@@ -94,7 +92,6 @@ class NamespaceTest
  * @package    Parser
  * @subpackage Tests
  * @author     Mike van Riel <mike.vanriel@naenius.com>
- * @license    http://www.opensource.org/licenses/mit-license.php MIT
  * @link       https://phpdoc.org
  */
 class DocBlocTest

--- a/tests/features/assets/config/v2Target.xml
+++ b/tests/features/assets/config/v2Target.xml
@@ -7,7 +7,6 @@
   ~
   ~ @author    Mike van Riel <mike.vanriel@naenius.com>
   ~ @copyright 2010-2019 Mike van Riel / Naenius (http://www.naenius.com)
-  ~ @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~ @link      https://phpdoc.org
   ~
   ~

--- a/tests/features/assets/projects/ignore/src/Ignored.php
+++ b/tests/features/assets/projects/ignore/src/Ignored.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/projects/ignore/src/NotIgnored.php
+++ b/tests/features/assets/projects/ignore/src/NotIgnored.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/projects/ignore/test/IgnoredTest.php
+++ b/tests/features/assets/projects/ignore/test/IgnoredTest.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/projects/simple/src/Post.php
+++ b/tests/features/assets/projects/simple/src/Post.php
@@ -7,7 +7,6 @@
  *
  * @author    Mike van Riel <mike.vanriel@naenius.com>
  * @copyright 2010-2018 Mike van Riel / Naenius (http://www.naenius.com)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      https://phpdoc.org
  *
  *

--- a/tests/features/assets/singlefile/emptyFile.php
+++ b/tests/features/assets/singlefile/emptyFile.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 ?>

--- a/tests/features/assets/singlefile/functionOnly.php
+++ b/tests/features/assets/singlefile/functionOnly.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-${YEAR} Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/singlefile/invalidTag.php
+++ b/tests/features/assets/singlefile/invalidTag.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/singlefile/markers.php
+++ b/tests/features/assets/singlefile/markers.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/singlefile/multiParentInheritance.php
+++ b/tests/features/assets/singlefile/multiParentInheritance.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/singlefile/requireOnly.php
+++ b/tests/features/assets/singlefile/requireOnly.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 echo 'foo';

--- a/tests/features/assets/singlefile/syntax/AnonymousClassInObjectMethod.php
+++ b/tests/features/assets/singlefile/syntax/AnonymousClassInObjectMethod.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/singlefile/syntax/trait.php
+++ b/tests/features/assets/singlefile/syntax/trait.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 trait MyTrait

--- a/tests/features/assets/singlefile/syntax/variadic.php
+++ b/tests/features/assets/singlefile/syntax/variadic.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/singlefile/tags/ClassMagicProperties.php
+++ b/tests/features/assets/singlefile/tags/ClassMagicProperties.php
@@ -7,7 +7,6 @@
  *
  * @author    Mike van Riel <mike.vanriel@naenius.com>
  * @copyright 2010-2019 Mike van Riel / Naenius (http://www.naenius.com)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      https://phpdoc.org
  *
  *

--- a/tests/features/assets/singlefile/tags/MethodTag.php
+++ b/tests/features/assets/singlefile/tags/MethodTag.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/assets/singlefile/tags/return.php
+++ b/tests/features/assets/singlefile/tags/return.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  * @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      https://phpdoc.org
  */
 

--- a/tests/features/bootstrap/Ast/ApiContext.php
+++ b/tests/features/bootstrap/Ast/ApiContext.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  * @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      https://phpdoc.org
  */
 

--- a/tests/features/bootstrap/Ast/BaseContext.php
+++ b/tests/features/bootstrap/Ast/BaseContext.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  * @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      https://phpdoc.org
  */
 

--- a/tests/features/bootstrap/Ast/SeeTagContext.php
+++ b/tests/features/bootstrap/Ast/SeeTagContext.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/bootstrap/Ast/UsesTagContext.php
+++ b/tests/features/bootstrap/Ast/UsesTagContext.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/bootstrap/EnvironmentContext.php
+++ b/tests/features/bootstrap/EnvironmentContext.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 

--- a/tests/features/bootstrap/Template/TemplateContext.php
+++ b/tests/features/bootstrap/Template/TemplateContext.php
@@ -7,7 +7,6 @@
  *
  * @author    Mike van Riel <mike.vanriel@naenius.com>
  * @copyright 2010-2018 Mike van Riel / Naenius (http://www.naenius.com)
- * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      https://phpdoc.org
  *
  *

--- a/tests/functional/assets/core/fileLevel/emptyFile.php
+++ b/tests/functional/assets/core/fileLevel/emptyFile.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 ?>

--- a/tests/functional/assets/core/fileLevel/requireOnly.php
+++ b/tests/functional/assets/core/fileLevel/requireOnly.php
@@ -6,7 +6,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 echo 'foo';

--- a/tests/functional/assets/core/fileLevel/shebang.php
+++ b/tests/functional/assets/core/fileLevel/shebang.php
@@ -7,7 +7,6 @@
  *  file that was distributed with this source code.
  *
  *  @copyright 2010-2018 Mike van Riel<mike@phpdoc.org>
- *  @license   http://www.opensource.org/licenses/mit-license.php MIT
  *  @link      https://phpdoc.org
  */
 echo 'foo';

--- a/tests/unit/data/phpDocumentor2XMLWithEncoding.xml
+++ b/tests/unit/data/phpDocumentor2XMLWithEncoding.xml
@@ -7,7 +7,6 @@
   ~
   ~ @author    Mike van Riel <mike.vanriel@naenius.com>
   ~ @copyright 2010-2019 Mike van Riel / Naenius (http://www.naenius.com)
-  ~ @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~ @link      https://phpdoc.org
   ~
   ~

--- a/tests/unit/data/phpDocumentor2XMLWithMultipleIgnorePaths.xml
+++ b/tests/unit/data/phpDocumentor2XMLWithMultipleIgnorePaths.xml
@@ -6,7 +6,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 

--- a/tests/unit/data/phpDocumentor2XMLWithTarget.xml
+++ b/tests/unit/data/phpDocumentor2XMLWithTarget.xml
@@ -7,7 +7,6 @@
   ~
   ~ @author    Mike van Riel <mike.vanriel@naenius.com>
   ~ @copyright 2010-2019 Mike van Riel / Naenius (http://www.naenius.com)
-  ~ @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~ @link      https://phpdoc.org
   ~
   ~

--- a/tests/unit/data/phpDocumentor2XMLWithVisibility.xml
+++ b/tests/unit/data/phpDocumentor2XMLWithVisibility.xml
@@ -7,7 +7,6 @@
   ~
   ~ @author    Mike van Riel <mike.vanriel@naenius.com>
   ~ @copyright 2010-2019 Mike van Riel / Naenius (http://www.naenius.com)
-  ~ @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~ @link      https://phpdoc.org
   ~
   ~

--- a/tests/unit/data/phpDocumentor2XMLWithoutExtensions.xml
+++ b/tests/unit/data/phpDocumentor2XMLWithoutExtensions.xml
@@ -6,7 +6,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 

--- a/tests/unit/data/phpDocumentor3XML.xml
+++ b/tests/unit/data/phpDocumentor3XML.xml
@@ -7,7 +7,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 

--- a/tests/unit/data/phpDocumentor3XMLWithMultipleApis.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithMultipleApis.xml
@@ -7,7 +7,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 

--- a/tests/unit/data/phpDocumentor3XMLWithMultipleGuides.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithMultipleGuides.xml
@@ -7,7 +7,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 

--- a/tests/unit/data/phpDocumentor3XMLWithMultipleTemplates.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithMultipleTemplates.xml
@@ -7,7 +7,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 

--- a/tests/unit/data/phpDocumentor3XMLWithMultipleVersions.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithMultipleVersions.xml
@@ -7,7 +7,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 

--- a/tests/unit/data/phpDocumentor3XMLWithoutTemplate.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithoutTemplate.xml
@@ -7,7 +7,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 

--- a/tests/unit/data/phpDocumentor3XMLWithoutValues.xml
+++ b/tests/unit/data/phpDocumentor3XMLWithoutValues.xml
@@ -7,7 +7,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 

--- a/tests/unit/data/phpdoc.tpl.xml
+++ b/tests/unit/data/phpdoc.tpl.xml
@@ -6,7 +6,6 @@
   ~  file that was distributed with this source code.
   ~
   ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
-  ~  @license   http://www.opensource.org/licenses/mit-license.php MIT
   ~  @link      https://phpdoc.org
   -->
 


### PR DESCRIPTION
The URL used in the `@license` tags in various places was outdated. Fixed now.

~~Alternatively these could be removed as these tags only seems to exist in a very limited number of files in the codebase.~~

**Updated PR**: As these tags only seems to exist in a very limited number of files in the codebase, they have now been removed.
