### PR TITLE
fix psalm issues on last version

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -119,5 +119,12 @@
                 <file name="src/phpDocumentor/Console/Command/Project/RunCommand.php"/>
             </errorLevel>
         </UnusedClosureParam>
+
+        <DeprecatedClass>
+            <errorLevel type="suppress">
+                <!-- MountManager will be removed in Flysystem V2 -->
+                <referencedClass name="League\Flysystem\MountManager"/>
+            </errorLevel>
+        </DeprecatedClass>
     </issueHandlers>
 </psalm>

--- a/src/phpDocumentor/Guides/Generator/JsonGenerator.php
+++ b/src/phpDocumentor/Guides/Generator/JsonGenerator.php
@@ -189,7 +189,7 @@ class JsonGenerator
         ];
     }
 
-    private function getNextPrevInformation(string $parserFilename) : ?array
+    private function getNextPrevInformation(string $parserFilename) : array
     {
         $meta = $this->getMetaEntry($parserFilename, true);
         $parentFile = $meta->getParent();

--- a/src/phpDocumentor/Path.php
+++ b/src/phpDocumentor/Path.php
@@ -38,7 +38,7 @@ final class Path
      */
     public function __construct(string $path)
     {
-        Assert::stringNotEmpty(
+        Assert::notEmpty(
             $path,
             sprintf('"%s" is not a valid path', $path)
         );


### PR DESCRIPTION
While working on #2388, I noticed some issues in the last version of Psalm (more precisely, the last master of Psalm because the last release crash when analyzing the project)

It fixes 3 issues:
- MountManager is deprecated on the current version of Flysystem because it will be removed in the next major. This will have to be refactored if we want to upgrade the dependancy. I ignored the issue for now
- JsonGenerator::getNextPrevInformation does not return null but declared "?array" anyway. We then use it on array destructuration so Psalm is not happy about that. I removed the null type
- Path::__construct used Assert::StringNotEmpty which makes two psalm assertions: `string` and `!empty`. The parameter is already strongly typed to string so `string` assertion is redundant. Using only notEmpty solves the issue