### PR TITLE
Docs: improvements for "references - phpdoc - tags - api"

### DIFF
--- a/docs/references/phpdoc/tags/api.rst
+++ b/docs/references/phpdoc/tags/api.rst
@@ -1,35 +1,44 @@
 @api
 ====
 
-The @api tag is used to declare Structural Elements as being suitable for
-consumption by third parties.
+The ``@api`` tag is used to highlight *Structural Elements* as being part of the
+primary public API of a package.
 
 Syntax
 ------
+
+.. code-block::
 
     @api
 
 Description
 -----------
 
-The @api tag represents those Structural Elements with a public visibility
-which are intended to be the public API components for a library or framework.
-Other Structural Elements with a public visibility serve to support the
-internal structure and are not recommended to be used by the consumer.
+The ``@api`` tag may be applied to public *Structural Elements* to highlight
+them in generated documentation, pointing the consumer to the primary public
+API components of a library or framework.
 
-The exact meaning of Structural Elements tagged with @api MAY differ per
-project. It is however RECOMMENDED that all tagged Structural Elements SHOULD
-NOT change after publication unless the new version is tagged as breaking
+When the ``@api`` tag is used, other *Structural Elements* with a public
+visibility serve to support the internal structure and are not recommended
+to be used by the consumer.
+
+The exact meaning of *Structural Elements* tagged with ``@api`` MAY differ per
+project. It is however RECOMMENDED that all ``@api`` tagged *Structural Elements*
+SHOULD NOT change after publication unless the new version is tagged as breaking
 Backwards Compatibility.
+
+See also the :doc:`internal` tag, which can be used to hide internal
+*Structural Elements* from generated documentation.
 
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements tagged with the @api tag will be shown in a separate
-sidebar section and the individual entry of will be marked as being an API element.
+*Structural Elements* tagged with the ``@api`` tag will be shown in a separate
+sidebar section and the individual entry will be marked as being an API element.
 
-    Not all templates might show the API sidebar section; it is recommended to
-    check this before using a specific template.
+    Not all templates may show the API sidebar section. If your project uses the
+    ``@api`` tag, it is recommended to verify your preferred template_ supports
+    the API sidebar before generating the documentation.
 
 Examples
 --------
@@ -37,14 +46,28 @@ Examples
 .. code-block:: php
    :linenos:
 
-    /**
-     * This method will not change until a major release.
-     *
-     * @api
-     *
-     * @return void
-     */
-     function showVersion()
-     {
-        <...>
-     }
+    class UserService
+    {
+        /**
+         * This method is public-API.
+         *
+         * This method will not change until a major release.
+         *
+         * @api
+         */
+        public function getUser()
+        {
+            <...>
+        }
+
+        /**
+         * This method is "package scope", not public-API.
+         */
+        public function callMefromAnotherClass()
+        {
+            <...>
+        }
+    }
+
+
+.. _template:      https://phpdoc.org/templates


### PR DESCRIPTION
Summary:
* Synced the text with the current text in PSR-19.

Description:
* Combined existing text with the current description in PSR-19 with minor adjustments for clarification.

Effects in phpDocumentor:
* Clarified the text about the API sidebar section vs templates.

Examples:
* Used the code examples from PSR-19 and added the original comment to the first example method.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Linked some text to related other documentation pages.
* Collected external links at the bottom of the document.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#51-api