### PR TITLE
Docs: improvements for "references - phpdoc - tags - author"

### DIFF
--- a/docs/references/phpdoc/tags/author.rst
+++ b/docs/references/phpdoc/tags/author.rst
@@ -1,31 +1,32 @@
 @author
 =======
 
-The @author tag is used to document the author of Structural Elements.
+The ``@author`` tag is used to document the author of *Structural Elements*.
 
 Syntax
 ------
+
+.. code-block::
 
     @author [name] [<email address>]
 
 Description
 -----------
 
-The @author tag can be used to indicate who has created Structural Elements
-or has made significant modifications to them. This tag MAY also contain an
+The ``@author`` tag can be used to indicate who has created a *Structural Element*
+or has made significant modifications to it. This tag MAY also contain an
 e-mail address. If an e-mail address is provided it MUST follow
 the author's name and be contained in chevrons, or angle brackets, and MUST
-adhere to the syntax defined in section 3.4.1 of
-`RFC5322 <https://www.ietf.org/rfc/rfc5322.txt>`_.
+adhere to the syntax defined in section 3.4.1 of `RFC 5322`_ or `RFC 2822`_.
 
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements tagged with the @author tag will show an *Author*
+*Structural Elements* tagged with the ``@author`` tag will show an *Author*
 header in their description containing the contents of this tag.
 
-If an e-mail address is provided in the tag then the *Author* will link to the
-mail address instead of displaying it.
+If an e-mail address is provided in the tag then the name of the *Author* will
+link to the e-mail address instead of displaying it.
 
 Examples
 --------
@@ -37,3 +38,7 @@ Examples
      * @author My Name
      * @author My Name <my.name@example.com>
      */
+
+
+.. _RFC 2822:      https://www.ietf.org/rfc/rfc2822.txt
+.. _RFC 5322:      https://www.ietf.org/rfc/rfc5322.txt


### PR DESCRIPTION
Description:
* Mention both RFC 5322 as well as RFC 2822.
    This document originally referred to RFC 5322, while PSR 19 refers to RFC 2822.
    As RFC 5322 supersedes RFC 2822, RFC 5322 would seem the most correct, however, then the text would contradict PSR 19.
    So, for now, I've elected to mention both. I imagine it might be an idea to send in a PR to PSR 19 to update the RFC reference.

Effects in phpDocumentor:
* Minor clarification about the linking.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Collected external links at the bottom of the document.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#52-author

**Open question**:

I wonder if the "Effects in phpDocumentor" section is still correct as in the current "Default" template, I don't see any `@author` tags displayed.
* Is this on the to do list ?
* Is this no longer supported ?
* Should the section text be updated ?
* Should an issue be opened about support for this tag in phpDocumentor 3 ?