### PR TITLE
Docs: improvements for "references - phpdoc - tags - category"

### DIFF
--- a/docs/references/phpdoc/tags/category.rst
+++ b/docs/references/phpdoc/tags/category.rst
@@ -3,26 +3,28 @@
 
 .. important::
 
-   This tag is considered deprecated and may be removed in a future version of
-   phpDocumentor. It is recommended to use the :doc:`package` tag's ability to
-   provide multiple levels.
+   This tag is considered deprecated and support may be removed in a future version
+   of phpDocumentor. It is recommended to use the :doc:`package` tag's ability to
+   provide multiple levels instead.
 
-The @category tag is used to organize groups of packages together.
+The ``@category`` tag is used to organize groups of packages together.
 
 Syntax
 ------
+
+.. code-block::
 
     @category [description]
 
 Description
 -----------
 
-The @category tag was meant in the original de-facto Standard to group several
-Structural Elements their :doc:`package` tags into one category. These
+The ``@category`` tag was meant in the original de-facto Standard to group several
+*Structural Elements* by their :doc:`package` tags into one category. These
 categories could then be used to aid in the generation of API documentation.
 
-This was necessary since the @package tag, as defined in the original Standard,
-did not contain more than one hierarchy level; since this has changed this tag
+This was necessary since the :doc:`package` tag, as defined in the original Standard,
+did not allow for more than one hierarchy level. Since this has changed this tag
 SHOULD NOT be used.
 
 Please see the documentation for :doc:`package` for details of its usage.
@@ -32,7 +34,7 @@ This tag MUST NOT occur more than once in a DocBlock.
 Effects in phpDocumentor
 ------------------------
 
-The @category tag has no significant effect in phpDocumentor. It will be shown
+The ``@category`` tag has no significant effect in phpDocumentor. It will be shown
 with the description information of associated Structural Elements and
 is inherited by classes and interfaces.
 


### PR DESCRIPTION
Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Linked some text to related other documentation pages.