### PR TITLE
Docs: improvements for "references - phpdoc - tags - copyright"

### DIFF
--- a/docs/references/phpdoc/tags/copyright.rst
+++ b/docs/references/phpdoc/tags/copyright.rst
@@ -1,18 +1,20 @@
 @copyright
 ==========
 
-The @copyright tag is used to document the copyright information for
-Structural Elements.
+The ``@copyright`` tag is used to document the copyright information of any
+*Structural Element*.
 
 Syntax
 ------
+
+.. code-block::
 
     @copyright [description]
 
 Description
 -----------
 
-The @copyright tag defines who holds the copyright over Structural Elements.
+The ``@copyright`` tag defines who holds the copyright over the *Structural Element*.
 The copyright indicated with this tag applies to the Structural Elements
 with which it is associated and all child elements unless otherwise noted.
 
@@ -23,7 +25,7 @@ covered by this copyright and the organization involved.
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements tagged with the @copyright tag will show a *Copyright*
+Structural Elements tagged with the ``@copyright`` tag will show a *Copyright*
 header in their description containing the contents of this tag.
 
 Examples


### PR DESCRIPTION
Other:
* Minor text synchronization with PSR 19.
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#53-copyright

**Open question**:

I wonder if the "Effects in phpDocumentor" section is still correct as in the current "Default" template, I don't see any `@copyright` tags displayed.
* Is this on the to do list ?
* Is this no longer supported ?
* Should the section text be updated ?
* Should an issue be opened about support for this tag in phpDocumentor 3 ?