### PR TITLE
Docs: improvements for "references - phpdoc - tags - deprecated"

### DIFF
--- a/docs/references/phpdoc/tags/deprecated.rst
+++ b/docs/references/phpdoc/tags/deprecated.rst
@@ -1,35 +1,36 @@
 @deprecated
 ===========
 
-The @deprecated tag is used to indicate which Structural Elements are
+The ``@deprecated`` tag is used to indicate which *Structural Elements* are
 deprecated and are to be removed in a future version.
 
 Syntax
 ------
 
-    @deprecated [<version>] [<description>]
+.. code-block::
+
+    @deprecated [<Semantic Version>] [<description>]
 
 Description
 -----------
 
-The @deprecated tag declares that the associated Structural Elements will
+The ``@deprecated`` tag declares that the associated Structural Element(s) will
 be removed in a future version as it has become obsolete or its usage is otherwise
-not recommended.
+not recommended, effective from the "Semantic Version" if provided.
 
-This tag MAY also contain a version number up till which it is guaranteed to be
-included in the software. Starting with the given version, the function will be
-removed or may be removed without further notice. If specified, the version number
-MUST follow the same rules as those by the :doc:`version` tag's vector.
+If specified, the version number MUST follow the same rules as a version number used
+by the :doc:`version` tag's vector.
 
-It is RECOMMENDED (but not required) to provide an additional description stating
-why the associated element is deprecated.
-If it is superceded by another method it is RECOMMENDED to add a @see tag in the
-same PHPDoc pointing to the new element.
+This tag MAY provide an additional description stating why the associated
+element is deprecated.
+
+If the associated element is superseded by another, it is RECOMMENDED to add a
+:doc:`see` tag in the same PHPDoc pointing to the new element.
 
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements tagged with the @deprecated tag will be listed in the
+Structural Elements tagged with the ``@deprecated`` tag will be listed in the
 *Deprecated elements* report and their name will be shown as strike through.
 
 Examples


### PR DESCRIPTION
Syntax:
* Replaced "version" with "Semantic Version" as per PSR 19.

Description:
* Combined existing text with the current description in PSR-19 with minor adjustments for clarification.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Linked some text to related other documentation pages.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#54-deprecated