### PR TITLE
Docs: improvements for "references - phpdoc - tags - filesource"

### DIFF
--- a/docs/references/phpdoc/tags/filesource.rst
+++ b/docs/references/phpdoc/tags/filesource.rst
@@ -1,25 +1,33 @@
 @filesource
 ===========
 
-The @filesource tag is used to tell phpDocumentor to include the source of the
+The ``@filesource`` tag is used to tell phpDocumentor to include the source of the
 current file in the parsing results.
 
 Syntax
 ------
+
+.. code-block::
 
     @filesource
 
 Description
 -----------
 
-The @filesource tag tells phpDocumentor to include the current file in the parsing
-output. As this only applies to the source code of the entire file MUST this
-tag be used in the file-level PHPDoc. Any other location will be ignored.
+The ``@filesource`` tag tells phpDocumentor to include the source of the current file
+in the output.
 
-When this tag is included will phpDocumentor compress the file contents and encode them
-using Base64 so that it can be handled by the transformer. Any template that
-is able to show the source code can then read the ``source`` sub-element in the
-associated ``file`` element in the Abstract Syntax Tree.
+As this only applies to the source code of the entire file, this tag MUST be used
+in the file-level PHPDoc. Any other location will be ignored.
+
+Effects in phpDocumentor
+------------------------
+
+When this tag is included, phpDocumentor will compress the file contents and encode it
+using Base64, so that it can be handled by the transformer.
+
+Any template that is able to show the source code can then read the ``source`` sub-element
+in the associated ``file`` element of the Abstract Syntax Tree.
 
 Examples
 --------
@@ -27,6 +35,7 @@ Examples
 .. code-block:: php
    :linenos:
 
+    <?php
     /**
      * @filesource
      */


### PR DESCRIPTION
Description:
* Split the text in "Description" and "Effects in phpDocumentor".
* Split the text in more paragraphs for improved readability.

Examples:
* Added the PHP open tag to reinforce that the tag can only be used in a file-level PHPDoc.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.