### PR TITLE
Docs: improvements for "references - phpdoc - tags - ignore"

### DIFF
--- a/docs/references/phpdoc/tags/ignore.rst
+++ b/docs/references/phpdoc/tags/ignore.rst
@@ -1,28 +1,30 @@
 @ignore
 =======
 
-The @ignore tag is used to tell phpDocumentor that Structural Elements are not
+The ``@ignore`` tag is used to tell phpDocumentor that *Structural Elements* are not
 to be processed by phpDocumentor.
 
 Syntax
 ------
+
+.. code-block::
 
     @ignore [<description>]
 
 Description
 -----------
 
-The @ignore tag tells phpDocumentor that the Structural Elements associated
-with the tag are not to be processed. An example of use might be to prevent
-duplicate documenting of conditional constants.
+The ``@ignore`` tag tells phpDocumentor that the *Structural Elements* associated
+with the tag should not to be processed. An typical use-case would be to prevent
+showing duplicate documentation for conditional constants.
 
-It is RECOMMENDED (but not required) to provide an additional description stating
+It is RECOMMENDED, but not required, to provide an additional description stating
 why the associated element is to be ignored.
 
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements tagged with the @ignore tag will be not be processed.
+*Structural Elements* tagged with the ``@ignore`` tag will be not be processed.
 
 Examples
 --------
@@ -34,10 +36,10 @@ Examples
         /**
          * This define will either be 'Unix' or 'Windows'
          */
-        define("OS","Unix");
+        define("RUNTIME_OS","Unix");
     } else {
         /**
          * @ignore
          */
-        define("OS","Windows");
+        define("RUNTIME_OS","Windows");
     }


### PR DESCRIPTION
Description:
* Minor textual improvements.

Example:
* Made the constant name slightly longer. Short names for global constants are bad practice as they will easily conflict.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.