### PR TITLE
Docs: improvements for "references - phpdoc - tags - internal"

### DIFF
--- a/docs/references/phpdoc/tags/internal.rst
+++ b/docs/references/phpdoc/tags/internal.rst
@@ -1,34 +1,43 @@
 @internal
 =========
 
-The @internal tag is used to denote that associated Structural Elements
-are elements internal to this application or library. It may also be used inside
+The ``@internal`` tag is used to denote that associated *Structural Elements*
+are internal to the application or library. It may also be used inside
 a long description to insert a piece of text that is only applicable for
-the developers of this software.
+the developers of the software.
 
 Syntax
 ------
+
+.. code-block::
 
     @internal [description]
 
 or inline:
 
-    {@internal [description]}}
+.. code-block::
 
-The inline version of this tag may, contrary to other inline tags, contain
-text but also other inline tags. To increase readability and ease parsing should
-the tag be terminated with a double closing brace, instead of a single one.
+    {@internal [description]}
+
+Contrary to other inline tags, the inline version of this tag may contain
+other inline tags.
 
 Description
 -----------
 
-The @internal tag can be used as counterpart of the @api tag, indicating that
-the associated Structural Elements are used purely for the internal
-workings of this piece of software.
+The ``@internal`` tag indicates that the associated *Structural Element* is intended
+only for use within the application, library or package to which it belongs.
 
-An additional use of @internal is to add internal comments or additional
-description text inline to the Long Description. This may be done, for example,
-to withhold certain business-critical or confusing information when generating
+Authors MAY use this tag to indicate that an element with public visibility should
+be regarded as exempt from the API - for example:
+  * Library authors MAY regard breaking changes to internal elements as being exempt
+    from semantic versioning.
+  * Static analysis tools MAY indicate the use of internal elements from another
+    library/package with a warning or notice.
+
+An additional use of ``@internal`` is to add internal comments or additional
+description text inline to the Description. This may be done, for example,
+to withhold certain business-critical or confusing information, when generating
 documentation from the source code of this piece of software.
 
     It is NOT RECOMMENDED to store passwords or security sensitive information
@@ -37,19 +46,17 @@ documentation from the source code of this piece of software.
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements, or parts of the long description when the tag is
-used inline, tagged with the @internal tag will be filtered out when creating
+*Structural Elements*, or parts of the long description when the tag is
+used inline, tagged with the ``@internal`` tag will be filtered out when creating
 the HTML output unless the ``--parseprivate`` command line argument is used.
 
 The Abstract Syntax Tree will still contain the internal information.
-Any consumer of this file is responsible for filtering the information.
+Any consumer of this file is responsible for filtering the information correctly.
 
 Examples
 --------
 
-Mark the count function as being internal to this project:
-
-Normal tag:
+Normal tag:: Mark the ``count()`` function as being internal to this project:
 
 .. code-block:: php
    :linenos:
@@ -57,14 +64,14 @@ Normal tag:
     /**
      * @internal
      *
-     * @return integer Indicates the number of items.
+     * @return int Indicates the number of items.
      */
     function count()
     {
         <...>
     }
 
-Inline tag:
+Inline tag:: Include a note in the Description that would only show in Developer Docs:
 
 .. code-block:: php
    :linenos:
@@ -72,9 +79,11 @@ Inline tag:
     /**
      * Counts the number of Foo.
      *
-     * {@internal Silently adds one extra Foo to compensate for lack of Foo }}
+     * This method gets a count of the Foo.
+     * {@internal Developers should note that it silently
+     *            adds one extra Foo (see {@link http://example.com}).}
      *
-     * @return integer Indicates the number of items.
+     * @return int Indicates the number of items.
      */
     function count()
     {


### PR DESCRIPTION
Summary:
* Minor text clarification.

Syntax:
* Removed the double closing bracket.
* Removed the note about the double closing bracket.
    This practice has been superseded by IDEs and parsers becoming more intelligent and being able to handle the braces correctly.
* Synced the note about inline tags within the inline tag with the current text in PSR-19.

Description:
* Combined existing text with the current description in PSR-19.

Examples:
* Synced the descriptions of the code sampes with the current text in PSR-19.
* Synced the inline tag use code sample with PSR-19.
* Modernized the Types used in tags.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
    This also fixes the "internal" syntax resulting in an invalid email link.