### PR TITLE
Docs: improvements for "references - phpdoc - tags - link"

### DIFF
--- a/docs/references/phpdoc/tags/link.rst
+++ b/docs/references/phpdoc/tags/link.rst
@@ -1,44 +1,48 @@
 @link
 =====
 
-.. important::
-
-   The effects of the inline version of this tag are not yet fully implemented
-   in phpDocumentor 3. There's only URI support (i.e. no support for
-   Structural Elements), and even that is available only in long descriptions.
-
-The @link tag indicates a custom relation between associated
-Structural Elements and a website, which is identified by an absolute
-URI.
+The ``@link`` tag indicates a custom relation between the associated
+*Structural Element* and a website, which is identified by an absolute URI.
 
 Syntax
 ------
 
+.. code-block::
+
     @link [URI] [<description>]
 
 or inline
+
+.. code-block::
 
    {@link [URI] [<description>]}
 
 Description
 -----------
 
-The @link tag can be used to define a relation, or link, between
-Structural Elements or part of the long description, when used inline,
-to an URI.
+The ``@link`` tag can be used to define a relation, or link, between the
+*Structural Element*, or part of the long description when used inline,
+to a URI.
 
-The URI MUST be complete and well-formed as specified in
-`RFC2396 <https://www.ietf.org/rfc/rfc2396.txt>`_.
+The URI MUST be complete and well-formed as specified in `RFC 2396`_.
 
-The @link tag MAY have a description appended to indicate the type of relation
+The ``@link`` tag MAY have a description appended to indicate the type of relation
 defined by this occurrence.
 
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements, or inline text in a long description, tagged with
-the @link tag will show a link in their description. If a description is
-provided with the tag then this will be used as link text instead of the URL itself.
+.. important::
+
+   The effects of the inline version of this tag are not yet fully implemented
+   in phpDocumentor 3. There's only URI support (i.e. no support for
+   *Structural Elements*), and even that is available only in long descriptions.
+
+*Structural Elements*, or inline text in a long description, tagged with
+the ``@link`` tag will show a link in their description.
+
+If a description is provided with the tag then this will be used as link text
+instead of the URL itself.
 
 Examples
 --------
@@ -51,7 +55,7 @@ Normal tag:
     /**
      * @link https://example.com/my/bar Documentation of Foo.
      *
-     * @return integer Indicates the number of items.
+     * @return int Indicates the number of items.
      */
     function count()
     {
@@ -66,13 +70,15 @@ Inline tag:
     /**
      * This method counts the occurrences of Foo.
      *
-     * When no more Foo ({@link https://example.com/my/bar}) are given this
-     * function will add one as there must always be one Foo.
+     * When no more Foo ({@link https://example.com/my/bar}) are given,
+     * this function will add one as there must always be one Foo.
      *
-     * @return integer Indicates the number of items.
+     * @return int Indicates the number of items.
      */
     function count()
     {
         <...>
     }
 
+
+.. _RFC 2396:      https://www.ietf.org/rfc/rfc2396.txt


### PR DESCRIPTION
Summary:
* Moved the note about support in phpDocumentor to the "Effects in phpDocumentor" section.

Effects in phpDocumentor:
* Split the text into two paragraphs for improved readability.

Example:
* Modernized the Type used in the `@return` tag.

Other:
* Verified the text with PSR 19.
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
    This also fixes the "internal" syntax resulting in an invalid email link.
* Collected external links at the bottom of the document.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#56-link

**Open question**:

I wonder if the note about support in phpDocumentor (now moved to "Effects in phpDocumentor") is still correct.
* Based on the specs the `@link` tag should only have support for URIs, not FQSEN, so why mention that as missing support ?
* IIRC, both stand-alone as well as inline `@link` tags seem to be supported in phpDocumentor 3, though some tweaking may still be needed, so is this note still relevant at all ?
* And if it is, it may be more helpful to be more specific about what is and isn't supported, so what can you tell me as input to update this ?