### PR TITLE
Docs: improvements for "references - phpdoc - tags - method"

### DIFF
--- a/docs/references/phpdoc/tags/method.rst
+++ b/docs/references/phpdoc/tags/method.rst
@@ -1,45 +1,50 @@
 @method
 =======
 
-The @method allows a class to know which 'magic' methods are callable.
+The ``@method`` tag allows a class to know which 'magic' methods are callable.
 
 Syntax
 ------
+
+.. code-block::
 
     @method [[static] return type] [name]([[type] [parameter]<, ...>]) [<description>]
 
 Description
 -----------
 
-The @method tag is used in situation where a class contains the ``__call()``
-or ``__callStatic()`` magic method and defines some definite uses.
+The ``@method`` tag is used in situations where a class contains the
+`__call() <https://www.php.net/language.oop5.overloading#object.call>`_ or
+`__callStatic() <https://www.php.net/language.oop5.overloading#object.callstatic>`_
+magic method and defines some definite uses.
 
-An example of this is a child class whose parent has a __call() to have dynamic
-getters or setters for predefined properties. The child knows which getters and
-setters need to be present but relies on the parent class to use the __call()
-method to provide it. In this situation, the child class would have a @method
-tag for each magic setter or getter method.
+An example of this is a child class whose parent has a ``__call()`` method defined
+to have dynamic getters or setters for predefined properties. The child knows
+which getters and setters need to be present, but relies on the parent class to
+use the `__call() <https://www.php.net/language.oop5.overloading#object.call>`_
+method to provide this functionality. In this situation, the child class would have
+a ``@method`` tag for each magic setter or getter method.
 
-The @method tag allows the author to communicate the type of the arguments and
-return value by including those types in the signature.
+The ``@method`` tag allows the author to communicate the :doc:`Type <../types>` of
+the arguments and return value by including those types in the signature.
 
-When the intended method does not have a return value then the return type MAY
-be omitted; in which case 'void' is implied.
+When the intended method does not have a return value then the return
+:doc:`type <../types>` MAY be omitted; in which case 'void' is implied.
 
 If the intended method is static, the ``static`` keyword can be placed before
 the return type to communicate that.
-There must be a return type, ``static`` on its own would mean that the method
-returns an instance of the child class which the method is called on.
+In that case, a return type MUST be provided, as ``static`` on its own would mean
+that the method returns an instance of the child class which the method is called on.
 
-@method tags MUST NOT be used in a PHPDoc that is not associated with
+``@method`` tags MUST NOT be used in a PHPDoc unless it is associated with
 a *class* or *interface*.
 
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements of type *class* or *interface* tagged with the
-@method tag will show an extra method in their method listing matching the
-data provided with this tag.
+*Structural Elements* of type *class* or *interface* tagged with the ``@method``
+tag will show an extra method in their method listing matching the data
+provided with this tag.
 
 Examples
 --------
@@ -57,12 +62,11 @@ Examples
 
     /**
      * @method string getString()
-     * @method void setInteger(integer $integer)
-     * @method setString(integer $integer)
+     * @method void setInteger(int $integer)
+     * @method setString(int $integer)
      * @method static string staticGetter()
      */
     class Child extends Parent
     {
         <...>
     }
-


### PR DESCRIPTION
Description:
* Minor textual improvements.
* Added links to the PHP manual pages covering the relevant magic methods.
    As the link _text_ starts with an underscore, I wasn't sure having those links at the bottom of the page would work as there they would need to be prefixed with an underscore, so, in this case, for these specific links, I've left them inline.
* Rephrased the "MUST NOT" phrase to use "can ONLY" for clarity.

Examples:
* Modernized the Types used in the tags.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Linked some text to related other documentation pages.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#57-method
