### PR TITLE
Docs: improvements for "references - phpdoc - tags - package"

### DIFF
--- a/docs/references/phpdoc/tags/package.rst
+++ b/docs/references/phpdoc/tags/package.rst
@@ -1,37 +1,35 @@
 @package
 ========
 
-The @package tag is used to categorize Structural Elements into logical
+The ``@package`` tag is used to categorize *Structural Elements* into logical
 subdivisions.
 
 Syntax
 ------
+
+.. code-block::
 
     @package [level 1]\\[level 2]\\[etc.]
 
 Description
 -----------
 
-The @package tag can be used as a counterpart or supplement to Namespaces.
-Namespaces provide a functional subdivision of Structural Elements where
-the @package tag can provide a *logical* subdivision in which way the elements
+The ``@package`` tag can be used as a counterpart or supplement to Namespaces_.
+Namespaces provide a functional subdivision of *Structural Elements* where
+the ``@package`` tag can provide a *logical* subdivision in which way the elements
 can be grouped with a different hierarchy.
 
 If, across the board, both logical and functional subdivisions are equal is it
-NOT RECOMMENDED to use the @package tag, to prevent maintenance overhead.
+NOT RECOMMENDED to use the ``@package`` tag to prevent maintenance overhead.
 
-Each level in the logical hierarchy MUST separated with a backslash (``\``) to
+Each level in the logical hierarchy MUST be separated with a backslash (``\``) to
 be familiar to Namespaces. A hierarchy MAY be of endless depth but it is
 RECOMMENDED to keep the depth at less or equal than six levels.
 
-    Note: phpDocumentor also allows the underscore (``_``) and dot (``.``) as
-    separator for compatibility with existing projects. Despite this the
-    backslash is RECOMMENDED as separator.
-
-Please note that the @package applies to different Structural Elements
+Please note that the ``@package`` tag applies to different *Structural Elements*
 depending where it is defined.
 
-1. If the @package is defined in the *file-level* DocBlock then it only applies
+1. If the *package* is defined in the *file-level* DocBlock then it only applies
    to the following elements in the applicable file:
 
    * global functions
@@ -39,19 +37,26 @@ depending where it is defined.
    * global variables
    * requires and includes
 
-2. If the @package is defined in a *namespace-level* or *class-level* DocBlock
-   then the package applies to that namespace, class or interface and their
+2. If the *package* is defined in a *namespace-level* or *class-level* DocBlock
+   then the package applies to that namespace, class, trait or interface and their
    contained elements.
    This means that a function which is contained in a namespace with the
-   @package tag assumes that package.
+   ``@package`` tag assumes that package.
 
-This tag MUST NOT occur more than once in a PHPDoc.
+The ``@package`` tag MUST NOT occur more than once in a PHPDoc.
 
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements tagged with the @package tag are grouped and
+*Structural Elements* tagged with the ``@package`` tag are grouped and
 organized in their own sidebar section.
+
+.. note::
+
+    Aside from the backslash (``\``), phpDocumentor also allows the
+    underscore (``_``) and dot (``.``) as separators for compatibility
+    with existing projects. Despite this the backslash is RECOMMENDED
+    as separator.
 
 Examples
 --------
@@ -62,3 +67,5 @@ Examples
     /**
      * @package PSR\Documentation\API
      */
+
+.. _Namespaces: https://www.php.net/language.namespaces


### PR DESCRIPTION
Description:
* Verified the text with PSR-19.
* Linked "Namespaces" to the PHP manual, similar to such links in other tag documentation pages.
* Move the note about phpDocumentor supporting additional separators to the "Effects in phpDocumentor" section.

Note: in PSR19, all references to file level docblocks have been removed, including the one here outlining the different impact. I've elected to leave this in place though for the time being.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Collected external links at the bottom of the document.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#58-package