### PR TITLE
Docs: improvements for "references - phpdoc - tags - param"

### DIFF
--- a/docs/references/phpdoc/tags/param.rst
+++ b/docs/references/phpdoc/tags/param.rst
@@ -1,56 +1,58 @@
 @param
 ======
 
-The @param tag is used to document a single argument of a function or method.
+The ``@param`` tag is used to document a single `argument of a function or method`_.
 
 Syntax
 ------
+
+.. code-block::
 
     @param [Type] [name] [<description>]
 
 Description
 -----------
 
-With the @param tag it is possible to document the type and function of a
-single argument of a function or method. When provided it MUST contain a
-Type to indicate what is expected; the description on the other hand is
-OPTIONAL yet RECOMMENDED in case of complicated structures, such as associative
-arrays.
+With the ``@param`` tag it is possible to document the :doc:`Type <../types>`
+and function of a single `argument of a function or method`_. When provided it
+MUST contain a :doc:`Type <../types>` to indicate what is expected.
+The description is OPTIONAL yet RECOMMENDED, for instance, in case of
+complicated structures, such as associative arrays.
 
-The @param tag MAY have a multi-line description and does not need explicit
+The ``@param`` tag MAY have a multi-line description and does not need explicit
 delimiting.
 
 It is RECOMMENDED when documenting to use this tag with every function and
-method. Exceptions to this recommendation are:
+method.
 
 This tag MUST NOT occur more than once per argument in a PHPDoc and is
-limited to Structural Elements of type method or function.
+limited to *Structural Elements* of type method or function.
 
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements of type method or function, that are tagged with the
-@param tag, will have additional information in the section regarding Arguments.
+*Structural Elements* of type method or function, that are tagged with the
+``@param`` tag, will have additional information in the section regarding Parameters.
 
-If the return Type is a class that is documented by phpDocumentor, then
-a link to that class' documentation is provided.
+If the parameter *Type* is a class that is documented by phpDocumentor,
+then a link to that class' documentation is provided.
 
 .. note::
 
-   phpDocumentor supports @param tags which omit the name, this is
+   phpDocumentor supports ``@param`` tags which omit the name, this is
    NOT RECOMMENDED but provided for compatibility with existing projects.
 
 .. note::
 
-   phpDocumentor will try to analyze correct usage and presence of the @param
+   phpDocumentor will try to analyze correct usage and presence of the ``@param``
    tag; as such it will provide error information in the following scenarios:
 
-   * An @param is provided but no argument was found matching the @param.
-   * The name of the @param does not match the name of argument at the same
+   * A ``@param`` is provided but no argument was found matching the ``@param``.
+   * The name of the ``@param`` does not match the name of argument at the same
      position.
    * A mismatch between the type hint, if present, and the type declaration was
      detected.
-   * The type declaration is *type*; this is an invalid type and often provided
+   * The type declaration is ``type``; this is an invalid type and often provided
      by IDEs.
 
 Examples
@@ -62,11 +64,17 @@ Examples
     /**
      * Counts the number of items in the provided array.
      *
-     * @param mixed[] $items Array structure to count the elements of.
+     * @param mixed[] $items     Array structure to count the elements of.
+     * @param bool    $recursive Optional. Whether or not to recursively
+     *                           count elements in nested arrays.
+     *                           Defaults to `false`.
      *
      * @return int Returns the number of elements.
      */
-    function count(array $items)
+    function count(array $items, bool $recursive = false)
     {
         <...>
     }
+
+
+.. _argument of a function or method: https://www.php.net/functions.arguments

--- a/docs/references/phpdoc/tags/param.rst
+++ b/docs/references/phpdoc/tags/param.rst
@@ -44,16 +44,10 @@ then a link to that class' documentation is provided.
 
 .. note::
 
-   phpDocumentor will try to analyze correct usage and presence of the ``@param``
-   tag; as such it will provide error information in the following scenarios:
-
-   * A ``@param`` is provided but no argument was found matching the ``@param``.
-   * The name of the ``@param`` does not match the name of argument at the same
-     position.
-   * A mismatch between the type hint, if present, and the type declaration was
-     detected.
-   * The type declaration is ``type``; this is an invalid type and often provided
-     by IDEs.
+   phpDocumentor will not verify whether a documented type is in line with
+   a declared type.
+   Such verification, if desired, can be executed by static analyzer tools
+   like `PHPStan`_ or `PHP_CodeSniffer`_.
 
 Examples
 --------
@@ -78,3 +72,5 @@ Examples
 
 
 .. _argument of a function or method: https://www.php.net/functions.arguments
+.. _PHPStan:                          https://phpstan.org/
+.. _PHP_CodeSniffer:                  https://github.com/squizlabs/php_codesniffer/


### PR DESCRIPTION
Summary:
* Added a link to the PHP manual page covering function arguments.

Description:
* Removed a redundant phrase - "Exceptions to this recommendation are:". Might have been orphaned after a previous edit ?

Example:
* Added a second argument with a different Type and a multi-line description.

Other:
* Verified the text with PSR 19.
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Linked some text to related other documentation pages.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#59-param

**Open question**:

The specs feel outdated. If the function declaration has parameter type declarations, those should be leading and the tags can be omitted.
The specs currently do not explicitly allow for that.

In PSR-19, the following phrase has been added to the first paragraph of the description, which sort of allows for that.
Should this phrase be added or not ?

> The "name" is required only when some @param tags are omitted due to all useful info
> already being visible in the code signature itself.