### PR TITLE
Docs: improvements for "references - phpdoc - tags - return"

### DIFF
--- a/docs/references/phpdoc/tags/return.rst
+++ b/docs/references/phpdoc/tags/return.rst
@@ -1,43 +1,48 @@
 @return
 =======
 
-The @return tag is used to document the return value of functions or methods.
+The ``@return`` tag is used to document the `return value of functions or methods`_.
 
 Syntax
 ------
+
+.. code-block::
 
     @return [Type] [<description>]
 
 Description
 -----------
 
-With the @return tag it is possible to document the return type and function of a
-function or method. When provided it MUST contain a Type to indicate
-what is returned; the description on the other hand is OPTIONAL yet
-RECOMMENDED in case of complicated return structures, such as associative arrays.
+With the ``@return`` tag it is possible to document the return :doc:`Type <../types>`
+of a function or method. When provided it MUST contain a :doc:`Type <../types>`
+to indicate what is returned; the description on the other hand is OPTIONAL yet
+RECOMMENDED, for instance, in case of complicated return structures, such as
+associative arrays.
 
-The @return tag MAY have a multi-line description and does not need explicit
+The ``@return`` tag MAY have a multi-line description and does not need explicit
 delimiting.
 
-It is RECOMMENDED when documenting to use this tag with every function and
-method. Exceptions to this recommendation are:
+It is RECOMMENDED to use this tag with every function and
+method.
+Exceptions to this recommendation, as defined by the Coding Standard of any
+individual project, MAY be:
 
-1. **constructors**, the @return tag MAY be omitted here, in which case
-   `@return self` is implied.
-2. **functions and methods without a `return` value**, the @return tag MAY be
-   omitted here, in which case `@return void` is implied.
+1. **constructors**, the ``@return`` tag MAY be omitted here, in which case
+   ``@return self`` is implied.
+2. **functions and methods without a `return` value**, the ``@return`` tag MAY be
+   omitted here, in which case ``@return void`` is implied.
 
 This tag MUST NOT occur more than once in a PHPDoc and is limited to
-Structural Elements of type method or function.
+*Structural Elements* of type method or function.
 
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements of type method or function, that are tagged with the
-@return tag, will have an additional section *Returns* in their content description
-that shows the return Type and description.
+*Structural Elements* of type method or function, that are tagged with the
+``@return`` tag, will have an additional section *Returns* in their content
+description that shows the return *Type* and description.
 
-If the return Type is a class that is documented by phpDocumentor, then a link
+If the return *Type* is a class that is documented by phpDocumentor, then a link
 to that class' documentation is provided.
 
 Examples
@@ -49,7 +54,7 @@ Singular type:
    :linenos:
 
     /**
-     * @return integer Indicates the number of items.
+     * @return int Indicates the number of items.
      */
     function count()
     {
@@ -68,3 +73,5 @@ Function can return either of two types:
     {
         <...>
     }
+
+.. _return value of functions or methods: https://www.php.net/functions.returning-values


### PR DESCRIPTION
Summary:
* Added a link to the PHP manual page covering function return values.

Description:
* Minor text synchronization with PSR 19.

Examples:
* Modernized the Type used in the tag.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Linked some text to related other documentation pages.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#511-return

**Open question**:

The specs feel outdated. If the function declaration has return type declarations, that should be leading and the tag can be omitted.
The specs currently do not allow for that (both here as well as in PSR19).