### PR TITLE
Docs: improvements for "references - phpdoc - tags - subpackage"

### DIFF
--- a/docs/references/phpdoc/tags/subpackage.rst
+++ b/docs/references/phpdoc/tags/subpackage.rst
@@ -3,33 +3,32 @@
 
 .. important::
 
-   This tag is considered deprecated and may be removed in a future version of
-   phpDocumentor. It is recommended to use the :doc:`package` tag's ability to
-   provide multiple levels.
+   This tag is considered deprecated and support may be removed in a future version
+   of phpDocumentor. It is recommended to use the :doc:`package` tag's ability to
+   provide multiple levels instead.
 
-The @subpackage tag is used to categorize Structural Elements into
+The ``@subpackage`` tag is used to categorize *Structural Elements* into
 logical subdivisions.
 
 Syntax
 ------
+
+.. code-block::
 
     @subpackage [name]
 
 Description
 -----------
 
-The @subpackage tag can be used as a counterpart or supplement to Namespaces.
-Namespaces provide a functional subdivision of Structural Elements where
-the @subpackage tag can provide a *logical* subdivision in which way the
+The ``@subpackage`` tag can be used as a counterpart or supplement to `Namespaces`_.
+Namespaces provide a functional subdivision of *Structural Elements* where
+the ``@subpackage`` tag can provide a *logical* subdivision in which way the
 elements can be grouped with a different hierarchy.
 
-If, across the board, both logical and functional subdivisions are equal it is
-NOT RECOMMENDED to use the @subpackage tag to prevent maintenance overhead.
+If, across the board, both logical and functional subdivisions are equal, it is
+NOT RECOMMENDED to use the ``@subpackage`` tag to prevent maintenance overhead.
 
-The @subpackage tag MUST only be used in a select set of DocBlocks, as is
-described in the documentation for the :doc:`package` tag.
-
-The @subpackage tag MUST only be used in a select set of DocBlocks, as is
+The ``@subpackage`` tag MUST only be used in a select set of DocBlocks, as is
 described in the documentation for the :doc:`package` tag. It MUST also
 accompany a :doc:`package` tag and may occur only once per DocBlock.
 
@@ -39,7 +38,7 @@ This tag is considered superseded by the support for multiple levels in the
 Effects in phpDocumentor
 ------------------------
 
-Structural Elements tagged with the @subpackage tag are grouped and
+*Structural Elements* tagged with the ``@subpackage`` tag are grouped and
 organized in their own sidebar section.
 
 Examples
@@ -52,3 +51,5 @@ Examples
      * @package PSR
      * @subpackage Documentation\API
      */
+
+.. _Namespaces: https://www.php.net/language.namespaces


### PR DESCRIPTION
Description:
* Removed a duplicate sentence.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Linked some text to related other documentation pages.
* Linked some text to the PHP manual.