### PR TITLE
Docs: improvements for "references - phpdoc - tags - var"

### DIFF
--- a/docs/references/phpdoc/tags/var.rst
+++ b/docs/references/phpdoc/tags/var.rst
@@ -1,46 +1,108 @@
 @var
 ====
 
-You may use the @var tag to document the "Type" of properties, sometimes called class variables.
+You may use the ``@var`` tag to document the :doc:`Type <../types>` of
+the following *Structural Elements*:
+
+* Constants, both class and global scope
+* Properties
+* Variables, both global and local scope
 
 Syntax
 ------
 
-    @var ["Type"] [$element_name] [<description>]
+.. code-block::
+
+    @var ["Type"] [element_name] [<description>]
 
 Description
 -----------
 
-The @var tag defines which type of data is represented by the value of a property_.
+The ``@var`` tag defines which :doc:`Type <../types>` of data is represented
+by the value of a constant_, property_ or variable_.
 
-The @var tag MUST contain the name of the element it documents. An exception to this is when property declarations only
-refer to a single property. In this case the name of the property MAY be omitted.
+Each constant or property definition or variable where the :doc:`Type <../types>`
+is ambiguous or unknown SHOULD be preceded by a DocBlock containing the ``@var``
+tag. Any other variable MAY be preceded with a DocBlock containing the ``@var`` tag.
 
-This is used when compound statements are used to define a series of properties. Such a compound statement can only have
-one DocBlock while several items are represented.
+The ``@var`` tag MUST contain the name of the element it documents. An exception
+to this is when a declaration only refers to a single property or constant.
+In that case, the name of the property or constant MAY be omitted.
+
+The name is used when compound statements are used to define a series of constants
+or properties. Such a compound statement can only have one DocBlock while several
+items are represented.
+
+Effects in phpDocumentor
+------------------------
+
+Constants, properties and global variables, that are tagged with the
+``@var`` tag, will have their *Type* displayed in their signature.
+
+If the *Type* is a class that is documented by phpDocumentor,
+then a link to that class' documentation is provided.
+
 
 Examples
 --------
 
 .. code-block:: php
+   :linenos:
+
+    /** @var int $int This is a counter. */
+    $int = 0;
+
+    // There should be no docblock here.
+    $int++;
 
     class Foo
     {
-      /** @var string|null Should contain a description */
-      protected $description = null;
+        /**
+         * Full docblock with a summary.
+         *
+         * @var int
+         */
+        const INDENT = 4;
+
+        /** @var string|null Short docblock, should contain a description. */
+        protected $description = null;
+
+        public function setDescription($description)
+        {
+            // There should be no docblock here.
+            $this->description = $description;
+        }
     }
 
-Even compound statements may be documented:
+Another example is to document the variable in a foreach explicitly; many IDEs
+use this information to help you with auto-completion:
 
 .. code-block:: php
 
-    class Foo
-    {
-      /**
-       * @var string $name        Should contain a description
-       * @var string $description Should contain a description
-       */
-      protected $name, $description;
+   :linenos:
+    /** @var \Sqlite3 $sqlite */
+    foreach ($connections as $sqlite) {
+        // There should be no docblock here.
+        $sqlite->open('/my/database/path');
+        <...>
     }
 
+
+Even compound class constant and property statements may be documented:
+
+.. code-block:: php
+
+   :linenos:
+    class Foo
+    {
+        /**
+         * @var string $name        Should contain a description
+         * @var string $description Should contain a description
+         */
+        protected $name,
+            $description = 'Default description';
+    }
+
+.. _constant: https://www.php.net/language.constants
 .. _property: https://www.php.net/language.oop5.properties
+.. _variable: https://www.php.net/language.variables


### PR DESCRIPTION
Summary:
* Synced the text with the current text in PSR-19.

Syntax:
* Removed the `$` from the element_name to allow for it potentially being a constant name.

Description:
* Combined existing text with the current description in PSR-19 with minor adjustments for clarification.

Effects in phpDocumentor:
* Added the section and described the effects. (Hope I got it right)

Examples:
* Added in the global variable examples from PSR-19.
* Synced the existing property example with PSR-19.
* Added an example of a constant with a full docblock and no `@var` description.
* Added in the `foreach` example from PSR-19.
* Minor tweaks to the compound example.
    Note: in this case I have not taken over the example as used in PSR-19 as it conflicts with the text in the description.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Linked some text to related other documentation pages.
* Collected external links at the bottom of the document.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#517-var