### PR TITLE
Docs: improvements for "references - phpdoc - tags - version"

### DIFF
--- a/docs/references/phpdoc/tags/version.rst
+++ b/docs/references/phpdoc/tags/version.rst
@@ -1,25 +1,26 @@
 @version
 ========
 
-The @version tag indicates the current version of Structural Elements.
+The ``@version`` tag is used to denote the current version of *Structural Elements*.
 
 Syntax
 ------
 
-    @version [<vector>] [<description>]
+.. code-block::
+
+    @version [<Semantic Version>] [<description>]
 
 Description
 -----------
 
-The @version tag can be used to indicate the current version of
-Structural Elements.
+The ``@version`` tag can be used to indicate the current "version" of
+*Structural Elements*.
 
 This information can be used to generate a set of API Documentation where the
 consumer is informed about elements at a particular version.
 
 It is RECOMMENDED that the version number matches a semantic version number as
-described in the Semantic Versioning Standard version 2.0 at
-https://semver.org/.
+described in the `Semantic Versioning Standard version 2.0`_.
 
 Version vectors from Version Control Systems are also supported, though they
 MUST follow the form:
@@ -28,6 +29,10 @@ MUST follow the form:
 
 A description MAY be provided, for the purpose of communicating any additional
 version-specific information.
+
+The ``@version`` tag MAY NOT be used to show the last modified or introduction
+version of an element, the :doc:`since` tag SHOULD be used for that purpose.
+
 
 Effects in phpDocumentor
 ------------------------
@@ -50,8 +55,16 @@ Examples
 
     /**
      * @version GIT: $Id$ In development. Very unstable.
+     *          (custom Git-based replacement keyword)
+     * @version @package_version@
+     *          (this PEAR replacement keyword expands upon package installation)
+     * @version $Id$
+     *          (this CVS keyword expands to show the CVS file revision number)
      */
     class NeoCounter
     {
         <...>
     }
+
+
+.. _Semantic Versioning Standard version 2.0  https://semver.org/


### PR DESCRIPTION
Summary:
* Made a hybrid of the current text in PSR-19 and the original text.

Syntax:
* Replaced "vector" with "Semantic Version" as per PSR 19.

Description:
* Combined existing text with the current description in PSR-19.

Examples:
* Added more VCS examples, as per PSR 19.

Other:
* Minor inline markup and grammar fixes.
* Made the syntax outline a code block.
* Collected external links at the bottom of the document.

Ref: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#518-version