### PR TITLE
Enable github-actions updates via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
   - dependency-name: twig/twig
     versions:
     - ">= 3.a, < 4"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot recently gained the ability to check for GitHub action updates.

Merging this pull-request will:

- Enable checks for GitHub actions via Dependabot.

Documentation for configuration:
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot#enabling-github-dependabot-version-updates-for-actions

GitHub blog post announcing GitHub actions update support:
https://github.blog/2020-06-25-dependabot-now-updates-your-actions-workflows/

EDIT:
Add the open-pull-requests-limit to the GitHub Action too, force-pushed the branch.