### PR TITLE
prevent PHP error.

### DIFF
--- a/src/phpDocumentor/Descriptor/PropertyDescriptor.php
+++ b/src/phpDocumentor/Descriptor/PropertyDescriptor.php
@@ -88,7 +88,7 @@ class PropertyDescriptor extends DescriptorAbstract implements
         return $this->static;
     }
 
-    public function setType(Type $type) : void
+    public function setType(?Type $type) : void
     {
         $this->type = $type;
     }


### PR DESCRIPTION
Reason: type parameter for magic property can be null

  [TypeError]
  Argument 1 passed to phpDocumentor\Descriptor\PropertyDescriptor::setType() must implement interface phpDocumentor\Reflection\Type, null given, called in /Users/akrys/phpDocumentor/src/phpDocumentor/Descriptor/ClassDescriptor.php on line 291