### PR TITLE
Migrate test cases that don't use Mockery to PHPUnit's TestCase

### DIFF
--- a/tests/unit/phpDocumentor/Compiler/CompilerTest.php
+++ b/tests/unit/phpDocumentor/Compiler/CompilerTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the Compiler.
  */
-class CompilerTest extends MockeryTestCase
+class CompilerTest extends TestCase
 {
     /** @var Compiler $fixture */
     protected $fixture;

--- a/tests/unit/phpDocumentor/Compiler/Linker/DescriptorRepositoryTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Linker/DescriptorRepositoryTest.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Linker;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\NamespaceDescriptor;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \phpDocumentor\Compiler\Linker\DescriptorRepository
  * @covers ::<private>
  */
-final class DescriptorRepositoryTest extends MockeryTestCase
+final class DescriptorRepositoryTest extends TestCase
 {
     /**
      * @covers ::setObjectAliasesList

--- a/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Linker;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use function get_class;
@@ -30,7 +30,7 @@ use function get_class;
  * @covers ::__construct
  * @covers ::<private>
  */
-final class LinkerTest extends MockeryTestCase
+final class LinkerTest extends TestCase
 {
     /** @var ObjectProphecy|DescriptorRepository */
     private $descriptorRepository;

--- a/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\ConstantDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
@@ -24,6 +23,7 @@ use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\PropertyDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 use function array_keys;
 use function array_values;
 
@@ -32,7 +32,7 @@ use function array_values;
  *
  * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder
  */
-class ElementsIndexBuilderTest extends MockeryTestCase
+class ElementsIndexBuilderTest extends TestCase
 {
     /** @var ElementsIndexBuilder $fixture */
     protected $fixture;

--- a/tests/unit/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractorTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractorTest.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TagDescriptor;
+use PHPUnit\Framework\TestCase;
 
-final class MarkerFromTagsExtractorTest extends MockeryTestCase
+final class MarkerFromTagsExtractorTest extends TestCase
 {
     /** @var MarkerFromTagsExtractor */
     private $fixture;

--- a/tests/unit/phpDocumentor/Compiler/Pass/NamespaceTreeBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/NamespaceTreeBuilderTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\ConstantDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
@@ -23,6 +22,7 @@ use phpDocumentor\Descriptor\NamespaceDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 use function array_keys;
 use function sort;
 
@@ -31,7 +31,7 @@ use function sort;
  * @covers ::<private>
  * @covers ::<protected>
  */
-class NamespaceTreeBuilderTest extends MockeryTestCase
+class NamespaceTreeBuilderTest extends TestCase
 {
     /** @var NamespaceTreeBuilder $fixture */
     protected $fixture;

--- a/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTagsTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTagsTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
-use Mockery as m;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Mockery\MockInterface;
 use phpDocumentor\Compiler\Linker\DescriptorRepository;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
@@ -28,15 +25,18 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Transformer\Router\Router;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \phpDocumentor\Compiler\Pass\ResolveInlineLinkAndSeeTags
  * @covers ::__construct
  * @covers ::<private>
  */
-final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
+final class ResolveInlineLinkAndSeeTagsTest extends TestCase
 {
-    /** @var Router|MockInterface */
+    /** @var Router|ObjectProphecy */
     private $router;
 
     /** @var ResolveInlineLinkAndSeeTags */
@@ -47,7 +47,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
      */
     protected function setUp() : void
     {
-        $this->router = m::mock(Router::class);
+        $this->router = $this->prophesize(Router::class);
 
         $fqsen = new Fqsen('\phpDocumentor\LinkDescriptor');
         $object = new ClassDescriptor();
@@ -62,7 +62,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
         $tagFactory->addService(new DescriptionFactory($tagFactory));
 
         $this->fixture = new ResolveInlineLinkAndSeeTags(
-            $this->router,
+            $this->router->reveal(),
             $repository,
             $tagFactory
         );
@@ -87,7 +87,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
         $collection = $this->givenACollection($descriptor);
         $project = $this->givenAProjectDescriptorWithChildDescriptors($collection);
 
-        $this->fixture->execute($project);
+        $this->fixture->execute($project->reveal());
 
         $this->thenDescriptionOfDescriptorIsChangedInto($descriptor, $description);
     }
@@ -104,7 +104,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
         $collection = $this->givenACollection($descriptor);
         $project = $this->givenAProjectDescriptorWithChildDescriptors($collection);
 
-        $this->fixture->execute($project);
+        $this->fixture->execute($project->reveal());
 
         $this->thenDescriptionOfDescriptorIsChangedInto($descriptor, $expected);
     }
@@ -121,7 +121,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
         $collection = $this->givenACollection($descriptor);
         $project = $this->givenAProjectDescriptorWithChildDescriptors($collection);
 
-        $this->fixture->execute($project);
+        $this->fixture->execute($project->reveal());
 
         $this->thenDescriptionOfDescriptorIsChangedInto($descriptor, $expected);
     }
@@ -139,7 +139,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
 
         $project = $this->givenAProjectDescriptorWithChildDescriptors($collection);
 
-        $this->fixture->execute($project);
+        $this->fixture->execute($project->reveal());
 
         $this->thenDescriptionOfDescriptorIsChangedInto($descriptor, $expected);
     }
@@ -154,13 +154,10 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
 
         $descriptor = $this->givenAChildDescriptorWithDescription($description);
         $collection = $this->givenACollection($descriptor);
-        $elementToLinkTo = $this->givenAnElementToLinkTo();
-
-        $this->whenDescriptionContainsSeeOrLinkWithElement($descriptor, $elementToLinkTo);
 
         $project = $this->givenAProjectDescriptorWithChildDescriptors($collection);
 
-        $this->fixture->execute($project);
+        $this->fixture->execute($project->reveal());
 
         $this->thenDescriptionOfDescriptorIsChangedInto($descriptor, $expected);
     }
@@ -180,7 +177,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
         $collection = $this->givenACollection($descriptor);
         $project = $this->givenAProjectDescriptorWithChildDescriptors($collection);
 
-        $this->fixture->execute($project);
+        $this->fixture->execute($project->reveal());
 
         $this->thenDescriptionOfDescriptorIsChangedInto($descriptor, $expected);
     }
@@ -200,7 +197,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
         $collection = $this->givenACollection($descriptor);
         $project = $this->givenAProjectDescriptorWithChildDescriptors($collection);
 
-        $this->fixture->execute($project);
+        $this->fixture->execute($project->reveal());
 
         $this->thenDescriptionOfDescriptorIsChangedInto($descriptor, $expected);
     }
@@ -220,12 +217,12 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
     /**
      * Returns a mocked Project Descriptor.
      *
-     * @param Collection|MockInterface $descriptors
+     * @param Collection|ObjectProphecy $descriptors
      */
-    private function givenAProjectDescriptorWithChildDescriptors($descriptors) : MockInterface
+    private function givenAProjectDescriptorWithChildDescriptors($descriptors) : ObjectProphecy
     {
-        $projectDescriptor = m::mock(ProjectDescriptor::class);
-        $projectDescriptor->shouldReceive('getIndexes')->andReturn($descriptors);
+        $projectDescriptor = $this->prophesize(ProjectDescriptor::class);
+        $projectDescriptor->getIndexes()->shouldBeCalled()->willReturn($descriptors);
 
         return $projectDescriptor;
     }
@@ -244,17 +241,17 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
     /**
      * Returns a collection with descriptor. This collection will be scanned to see if a link can be made to a file.
      *
-     * @param DescriptorAbstract|MockInterface $descriptor
+     * @param DescriptorAbstract|ObjectProphecy $descriptor
      *
-     * @return Collection|MockInterface
+     * @return Collection|ObjectProphecy
      */
     private function givenACollection($descriptor)
     {
-        $collection = m::mock(Collection::class);
+        $collection = $this->prophesize(Collection::class);
 
         $items = ['\phpDocumentor\LinkDescriptor' => $descriptor];
 
-        $collection->shouldReceive('get')->once()->andReturn($items);
+        $collection->get(Argument::any())->shouldBeCalledOnce()->willReturn($items);
 
         return $collection;
     }
@@ -274,7 +271,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
         FileDescriptor $descriptor,
         FileDescriptor $elementToLinkTo
     ) : FileDescriptor {
-        $this->router->shouldReceive('generate')->andReturn('/classes/phpDocumentor.LinkDescriptor.html');
+        $this->router->generate(Argument::any())->shouldBeCalled()->willReturn('/classes/phpDocumentor.LinkDescriptor.html');
         $descriptor->setFile($elementToLinkTo);
 
         return $descriptor;

--- a/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use PHPUnit\Framework\TestCase;
 
-final class ResolveInlineMarkersTest extends MockeryTestCase
+final class ResolveInlineMarkersTest extends TestCase
 {
     public function testExecuteSetsMarkers() : void
     {

--- a/tests/unit/phpDocumentor/Configuration/CommandlineOptionsMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Configuration/CommandlineOptionsMiddlewareTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
+use PHPUnit\Framework\TestCase;
 use function current;
 
 /**
@@ -23,7 +23,7 @@ use function current;
  * @covers ::__construct
  * @covers ::<private>
  */
-final class CommandlineOptionsMiddlewareTest extends MockeryTestCase
+final class CommandlineOptionsMiddlewareTest extends TestCase
 {
     /** @var ConfigurationFactory */
     private $configurationFactory;

--- a/tests/unit/phpDocumentor/Descriptor/ArgumentDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ArgumentDescriptorTest.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\String_;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \phpDocumentor\Descriptor\ArgumentDescriptor
  */
-final class ArgumentDescriptorTest extends MockeryTestCase
+final class ArgumentDescriptorTest extends TestCase
 {
     /**
      * @covers ::getType

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/ConstantAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/ConstantAssemblerTest.php
@@ -13,17 +13,17 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Builder\Reflector;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Constant;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test class for \phpDocumentor\Descriptor\Builder
  *
  * @coversDefaultClass  \phpDocumentor\Descriptor\Builder\Reflector\ConstantAssembler
  */
-class ConstantAssemblerTest extends MockeryTestCase
+class ConstantAssemblerTest extends TestCase
 {
     /** @var ConstantAssembler $fixture */
     protected $fixture;

--- a/tests/unit/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapperTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapperTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Cache;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 /**
@@ -29,7 +29,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  * @coversDefaultClass \phpDocumentor\Descriptor\Cache\ProjectDescriptorMapper
  * @covers ::__construct
  */
-final class ProjectDescriptorMapperTest extends MockeryTestCase
+final class ProjectDescriptorMapperTest extends TestCase
 {
     /** @var ProjectDescriptorMapper */
     private $mapper;

--- a/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
@@ -21,7 +21,7 @@ use stdClass;
  *
  * @coversDefaultClass \phpDocumentor\Descriptor\Collection
  */
-final class CollectionTest extends MockeryTestCase
+final class CollectionTest extends TestCase
 {
     /** @var Collection $fixture */
     private $fixture;

--- a/tests/unit/phpDocumentor/Descriptor/Example/FinderTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Example/FinderTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Example;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use org\bovigo\vfs\vfsStream;
 use phpDocumentor\Descriptor\Tag\ExampleDescriptor;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use function chdir;
 use function sys_get_temp_dir;
@@ -23,7 +23,7 @@ use function sys_get_temp_dir;
 /**
  * Tests for the \phpDocumentor\Descriptor\Example\Finder class.
  */
-final class FinderTest extends MockeryTestCase
+final class FinderTest extends TestCase
 {
     public const EXAMPLE_TEXT = 'This is an example';
 

--- a/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\ProjectDescriptor\Settings;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the ProjectDescriptor class.
  *
  * @coversDefaultClass \phpDocumentor\Descriptor\ProjectDescriptor
  */
-final class ProjectDescriptorTest extends MockeryTestCase
+final class ProjectDescriptorTest extends TestCase
 {
     public const EXAMPLE_NAME = 'Initial name';
 

--- a/tests/unit/phpDocumentor/Descriptor/Tag/DeprecatedDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/DeprecatedDescriptorTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Tag;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the DeprecatedDescriptor class.
  *
  * @coversDefaultClass \phpDocumentor\Descriptor\Tag\DeprecatedDescriptor
  */
-final class DeprecatedDescriptorTest extends MockeryTestCase
+final class DeprecatedDescriptorTest extends TestCase
 {
     public const EXAMPLE_VERSION = '2.0';
 

--- a/tests/unit/phpDocumentor/Descriptor/Tag/LinkDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/LinkDescriptorTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Tag;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the LinkDescriptor class.
  */
-final class LinkDescriptorTest extends MockeryTestCase
+final class LinkDescriptorTest extends TestCase
 {
     public const EXAMPLE_LINK = 'https://phpdoc.org';
 

--- a/tests/unit/phpDocumentor/Descriptor/Tag/MethodDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/MethodDescriptorTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Tag;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\Collection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the MethodDescriptor class.
  */
-class MethodDescriptorTest extends MockeryTestCase
+class MethodDescriptorTest extends TestCase
 {
     public const EXAMPLE_NAME = 'methodname';
 

--- a/tests/unit/phpDocumentor/Descriptor/Tag/PropertyDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/PropertyDescriptorTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Tag;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the PropertyDescriptor class.
  */
-class PropertyDescriptorTest extends MockeryTestCase
+class PropertyDescriptorTest extends TestCase
 {
     public const EXAMPLE_NAME = 'variableName';
 

--- a/tests/unit/phpDocumentor/Descriptor/Tag/ReturnDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/ReturnDescriptorTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Tag;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Reflection\Types\Array_;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the ReturnDescriptor class.
  */
-class ReturnDescriptorTest extends MockeryTestCase
+class ReturnDescriptorTest extends TestCase
 {
     /** @var ReturnDescriptor $fixture */
     protected $fixture;

--- a/tests/unit/phpDocumentor/Descriptor/Tag/SeeDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/SeeDescriptorTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Tag;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen as FqsenReference;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the SeeDescriptor class.
  */
-class SeeDescriptorTest extends MockeryTestCase
+class SeeDescriptorTest extends TestCase
 {
     /** @var SeeDescriptor $fixture */
     protected $fixture;

--- a/tests/unit/phpDocumentor/Descriptor/Tag/SinceDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/SinceDescriptorTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Tag;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the SinceDescriptor class.
  */
-class SinceDescriptorTest extends MockeryTestCase
+class SinceDescriptorTest extends TestCase
 {
     public const EXAMPLE_VERSION = 'version';
 

--- a/tests/unit/phpDocumentor/Descriptor/Tag/UsesDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/UsesDescriptorTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Tag;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the UsesDescriptor class.
  */
-class UsesDescriptorTest extends MockeryTestCase
+class UsesDescriptorTest extends TestCase
 {
     public const EXAMPLE_REFERENCE = '\Reference';
 

--- a/tests/unit/phpDocumentor/Descriptor/Tag/VersionDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Tag/VersionDescriptorTest.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Tag;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the functionality for the VersionDescriptor class.
  */
-class VersionDescriptorTest extends MockeryTestCase
+class VersionDescriptorTest extends TestCase
 {
     public const EXAMPLE_VERSION = '2.0';
 

--- a/tests/unit/phpDocumentor/Descriptor/TagDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/TagDescriptorTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 
-class TagDescriptorTest extends MockeryTestCase
+class TagDescriptorTest extends TestCase
 {
     public const TAG_NAME = 'test';
 

--- a/tests/unit/phpDocumentor/Event/EventAbstractTest.php
+++ b/tests/unit/phpDocumentor/Event/EventAbstractTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Event;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Event\Mock\EventAbstract as EventAbstractMock;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * Test for the EventAbstract class.
  */
-class EventAbstractTest extends MockeryTestCase
+class EventAbstractTest extends TestCase
 {
     /**
      * @covers \phpDocumentor\Event\EventAbstract::__construct

--- a/tests/unit/phpDocumentor/Parser/Event/PreFileEventTest.php
+++ b/tests/unit/phpDocumentor/Parser/Event/PreFileEventTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Parser\Event;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
@@ -21,7 +21,7 @@ use stdClass;
  * @covers ::__construct
  * @covers ::<private>
  */
-class PreFileEventTest extends MockeryTestCase
+class PreFileEventTest extends TestCase
 {
     /** @var PreFileEvent $fixture */
     protected $fixture;

--- a/tests/unit/phpDocumentor/Transformer/Event/PostTransformationEventTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Event/PostTransformationEventTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Event;
 
-use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @coversDefaultClass \phpDocumentor\Transformer\Event\PostTransformationEvent
  * @covers ::__construct
  */
-final class PostTransformationEventTest extends MockeryTestCase
+final class PostTransformationEventTest extends TestCase
 {
     /** @var PostTransformationEvent $fixture */
     private $fixture;


### PR DESCRIPTION
As the first step with #2217, I have decided to migrate all test classes that don't use any `Mockery` methods from `MockeryTestCase` to the original `TestCase` from PHPUnit. Thanks to that we will easily know which of the classes still needs some work. 