### PR TITLE
Migrate Compiler\Pass test cases to PHPUnit built-in mocking library

### DIFF
--- a/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
@@ -13,10 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
-use Mockery as m;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\ProjectAnalyzer;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -25,7 +24,7 @@ use Psr\Log\NullLogger;
  * @covers ::__construct
  * @covers ::<private>
  */
-final class DebugTest extends MockeryTestCase
+final class DebugTest extends TestCase
 {
     /**
      * @covers ::execute
@@ -33,16 +32,20 @@ final class DebugTest extends MockeryTestCase
     public function testLogDebugAnalysis() : void
     {
         $testString = 'test';
-        $projectDescriptorMock = m::mock(ProjectDescriptor::class);
+        $projectDescriptorMock = $this->createMock(ProjectDescriptor::class);
 
-        $loggerMock = m::mock(LoggerInterface::class)
-            ->shouldReceive('debug')->with($testString)
-            ->getMock();
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->atLeastOnce())
+            ->method('debug')
+            ->with($testString);
 
-        $analyzerMock = m::mock(ProjectAnalyzer::class)
-            ->shouldReceive('analyze')->with($projectDescriptorMock)
-            ->shouldReceive('__toString')->andReturn($testString)
-            ->getMock();
+        $analyzerMock = $this->createMock(ProjectAnalyzer::class);
+        $analyzerMock->expects($this->atLeastOnce())
+            ->method('analyze')
+            ->with($projectDescriptorMock);
+        $analyzerMock->expects($this->atLeastOnce())
+            ->method('__toString')
+            ->willReturn($testString);
 
         $fixture = new Debug($loggerMock, $analyzerMock);
         $fixture->execute($projectDescriptorMock);
@@ -55,7 +58,7 @@ final class DebugTest extends MockeryTestCase
      */
     public function testGetDescription() : void
     {
-        $debug = new Debug(new NullLogger(), m::mock(ProjectAnalyzer::class));
+        $debug = new Debug(new NullLogger(), $this->createMock(ProjectAnalyzer::class));
 
         $this->assertSame('Analyze results and write report to log', $debug->getDescription());
     }

--- a/tests/unit/phpDocumentor/Compiler/Pass/ExampleTagsEnricherTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ExampleTagsEnricherTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
-use Mockery as m;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Mockery\MockInterface;
+use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\Example\Finder;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Reflection\DocBlock\ExampleFinder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the \phpDocumentor\Compiler\Pass\ExampleTagsEnricher class.
  */
-class ExampleTagsEnricherTest extends MockeryTestCase
+class ExampleTagsEnricherTest extends TestCase
 {
-    /** @var Finder|m\MockInterface */
+    /** @var Finder|MockObject */
     private $finderMock;
 
     /** @var ExampleTagsEnricher */
@@ -28,7 +28,7 @@ class ExampleTagsEnricherTest extends MockeryTestCase
      */
     protected function setUp() : void
     {
-        $this->finderMock = m::mock(ExampleFinder::class);
+        $this->finderMock = $this->createMock(ExampleFinder::class);
         $this->fixture    = new ExampleTagsEnricher($this->finderMock);
     }
 
@@ -128,10 +128,12 @@ class ExampleTagsEnricherTest extends MockeryTestCase
     /**
      * Returns a mocked Descriptor with its description set to the given value.
      */
-    private function givenAChildDescriptorWithDescription(string $description) : MockInterface
+    private function givenAChildDescriptorWithDescription(string $description) : MockObject
     {
-        $descriptor = m::mock(DescriptorAbstract::class);
-        $descriptor->shouldReceive('getDescription')->andReturn($description);
+        $descriptor = $this->createMock(DescriptorAbstract::class);
+        $descriptor->expects($this->atLeastOnce())
+            ->method('getDescription')
+            ->willReturn($description);
 
         return $descriptor;
     }
@@ -139,12 +141,17 @@ class ExampleTagsEnricherTest extends MockeryTestCase
     /**
      * Returns a mocked Project Descriptor.
      *
-     * @param m\MockInterface[] $descriptors
+     * @param MockObject[] $descriptors
      */
-    private function givenAProjectDescriptorWithChildDescriptors($descriptors) : MockInterface
+    private function givenAProjectDescriptorWithChildDescriptors($descriptors) : MockObject
     {
-        $projectDescriptor = m::mock(ProjectDescriptor::class);
-        $projectDescriptor->shouldReceive('getIndexes->get')->with('elements')->andReturn($descriptors);
+        $collection = $this->createMock(Collection::class);
+        $collection->method('get')->willReturn($descriptors);
+
+        $projectDescriptor = $this->createMock(ProjectDescriptor::class);
+        $projectDescriptor->expects($this->atLeastOnce())
+            ->method('getIndexes')
+            ->willReturn($collection);
 
         return $projectDescriptor;
     }
@@ -152,9 +159,9 @@ class ExampleTagsEnricherTest extends MockeryTestCase
     /**
      * Verifies if the given descriptor's setDescription method is called with the given value.
      */
-    public function thenDescriptionOfDescriptorIsChangedInto(m\MockInterface $descriptor, string $expected) : void
+    public function thenDescriptionOfDescriptorIsChangedInto(MockObject $descriptor, string $expected) : void
     {
-        $descriptor->shouldReceive('setDescription')->with($expected);
+        $descriptor->method('setDescription')->with($expected);
     }
 
     /**
@@ -162,7 +169,7 @@ class ExampleTagsEnricherTest extends MockeryTestCase
      */
     private function whenExampleTxtFileContains(string $exampleText) : void
     {
-        $this->finderMock->shouldReceive('find')->andReturn($exampleText);
+        $this->finderMock->expects($this->atLeastOnce())->method('find')->willReturn($exampleText);
     }
 
     /**
@@ -171,6 +178,6 @@ class ExampleTagsEnricherTest extends MockeryTestCase
      */
     private function whenExampleTxtFileContainsAndMustBeCalledOnlyOnce(string $exampleText) : void
     {
-        $this->finderMock->shouldReceive('find')->once()->andReturn($exampleText);
+        $this->finderMock->expects($this->once())->method('find')->willReturn($exampleText);;
     }
 }

--- a/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTagsTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineLinkAndSeeTagsTest.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
-use Mockery as m;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Mockery\MockInterface;
 use phpDocumentor\Compiler\Linker\DescriptorRepository;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
@@ -28,15 +25,17 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Transformer\Router\Router;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \phpDocumentor\Compiler\Pass\ResolveInlineLinkAndSeeTags
  * @covers ::__construct
  * @covers ::<private>
  */
-final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
+final class ResolveInlineLinkAndSeeTagsTest extends TestCase
 {
-    /** @var Router|MockInterface */
+    /** @var Router|MockObject */
     private $router;
 
     /** @var ResolveInlineLinkAndSeeTags */
@@ -47,7 +46,7 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
      */
     protected function setUp() : void
     {
-        $this->router = m::mock(Router::class);
+        $this->router = $this->createMock(Router::class);
 
         $fqsen = new Fqsen('\phpDocumentor\LinkDescriptor');
         $object = new ClassDescriptor();
@@ -220,12 +219,14 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
     /**
      * Returns a mocked Project Descriptor.
      *
-     * @param Collection|MockInterface $descriptors
+     * @param Collection|MockObject $descriptors
      */
-    private function givenAProjectDescriptorWithChildDescriptors($descriptors) : MockInterface
+    private function givenAProjectDescriptorWithChildDescriptors($descriptors) : MockObject
     {
-        $projectDescriptor = m::mock(ProjectDescriptor::class);
-        $projectDescriptor->shouldReceive('getIndexes')->andReturn($descriptors);
+        $projectDescriptor = $this->createMock(ProjectDescriptor::class);
+        $projectDescriptor->expects($this->atLeastOnce())
+            ->method('getIndexes')
+            ->willReturn($descriptors);
 
         return $projectDescriptor;
     }
@@ -244,17 +245,19 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
     /**
      * Returns a collection with descriptor. This collection will be scanned to see if a link can be made to a file.
      *
-     * @param DescriptorAbstract|MockInterface $descriptor
+     * @param DescriptorAbstract|MockObject $descriptor
      *
-     * @return Collection|MockInterface
+     * @return Collection|MockObject
      */
     private function givenACollection($descriptor)
     {
-        $collection = m::mock(Collection::class);
+        $collection = $this->createMock(Collection::class);
 
         $items = ['\phpDocumentor\LinkDescriptor' => $descriptor];
 
-        $collection->shouldReceive('get')->once()->andReturn($items);
+        $collection->expects($this->once())
+            ->method('get')
+            ->willReturn($items);
 
         return $collection;
     }
@@ -274,7 +277,8 @@ final class ResolveInlineLinkAndSeeTagsTest extends MockeryTestCase
         FileDescriptor $descriptor,
         FileDescriptor $elementToLinkTo
     ) : FileDescriptor {
-        $this->router->shouldReceive('generate')->andReturn('/classes/phpDocumentor.LinkDescriptor.html');
+        $this->router->method('generate')
+            ->willReturn('/classes/phpDocumentor.LinkDescriptor.html');
         $descriptor->setFile($elementToLinkTo);
 
         return $descriptor;


### PR DESCRIPTION
As mentioned in #2217: Prophecy integration has been deprecated in PHPUnit 9. This PR migrates Mockery to PHPUnit's built-in mocking library. If you feel like it still should be done with Prophecy feel free to close this.