### PR TITLE
Migrate phpDocumentor\Transformer from Mockery to Prophecy

### DIFF
--- a/tests/unit/phpDocumentor/Transformer/Event/PostTransformEventTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Event/PostTransformEventTest.php
@@ -13,16 +13,15 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Event;
 
-use Mockery as m;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @coversDefaultClass \phpDocumentor\Transformer\Event\PostTransformEvent
  * @covers ::__construct
  */
-final class PostTransformEventTest extends MockeryTestCase
+final class PostTransformEventTest extends TestCase
 {
     /** @var PostTransformEvent $fixture */
     private $fixture;
@@ -52,11 +51,11 @@ final class PostTransformEventTest extends MockeryTestCase
      */
     public function testSetAndGetProject() : void
     {
-        $project = m::mock(ProjectDescriptor::class);
+        $project = $this->prophesize(ProjectDescriptor::class);
         $this->assertNull($this->fixture->getProject());
 
-        $this->fixture->setProject($project);
+        $this->fixture->setProject($project->reveal());
 
-        $this->assertSame($project, $this->fixture->getProject());
+        $this->assertSame($project->reveal(), $this->fixture->getProject());
     }
 }

--- a/tests/unit/phpDocumentor/Transformer/Event/PreTransformEventTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Event/PreTransformEventTest.php
@@ -13,16 +13,15 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Event;
 
-use Mockery as m;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * @coversDefaultClass \phpDocumentor\Transformer\Event\PreTransformEvent
  * @covers ::__construct
  */
-final class PreTransformEventTest extends MockeryTestCase
+final class PreTransformEventTest extends TestCase
 {
     /** @var PreTransformEvent $fixture */
     private $fixture;
@@ -52,11 +51,11 @@ final class PreTransformEventTest extends MockeryTestCase
      */
     public function testSetAndGetProject() : void
     {
-        $project = m::mock(ProjectDescriptor::class);
+        $project = $this->prophesize(ProjectDescriptor::class);
         $this->assertNull($this->fixture->getProject());
 
-        $this->fixture->setProject($project);
+        $this->fixture->setProject($project->reveal());
 
-        $this->assertSame($project, $this->fixture->getProject());
+        $this->assertSame($project->reveal(), $this->fixture->getProject());
     }
 }

--- a/tests/unit/phpDocumentor/Transformer/Router/ClassBasedFqsenUrlGeneratorTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Router/ClassBasedFqsenUrlGeneratorTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Router;
 
-use Mockery as m;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
@@ -26,7 +26,7 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
  * @covers ::__construct
  * @covers ::<private>
  */
-class ClassBasedFqsenUrlGeneratorTest extends MockeryTestCase
+class ClassBasedFqsenUrlGeneratorTest extends TestCase
 {
     /**
      * @covers ::__invoke
@@ -34,16 +34,14 @@ class ClassBasedFqsenUrlGeneratorTest extends MockeryTestCase
      */
     public function testGenerateUrlForFqsenDescriptor(string $fromFqsen, string $toPath) : void
     {
-        // Arrange
-        $urlGenerator = m::mock(UrlGeneratorInterface::class);
-        $urlGenerator->shouldReceive('generate')->andReturn($toPath);
-        $fqsen = new Fqsen($fromFqsen);
-        $fixture = new ClassBasedFqsenUrlGenerator($urlGenerator, new AsciiSlugger());
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGenerator->generate(Argument::any(), Argument::any())->shouldBeCalled()->willReturn($toPath);
 
-        // Act
+        $fqsen = new Fqsen($fromFqsen);
+        $fixture = new ClassBasedFqsenUrlGenerator($urlGenerator->reveal(), new AsciiSlugger());
+
         $result = $fixture($fqsen);
 
-        // Assert
         $this->assertSame($toPath, $result);
     }
 

--- a/tests/unit/phpDocumentor/Transformer/Template/FactoryTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Template/FactoryTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Template;
 
-use Mockery as m;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use phpDocumentor\Faker\Faker;
 use phpDocumentor\Parser\FlySystemFactory;
 use phpDocumentor\Transformer\Transformer;
 use phpDocumentor\Transformer\Writer\Collection as WriterCollection;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\NullLogger;
 
 /**
@@ -28,14 +28,16 @@ use Psr\Log\NullLogger;
  * @covers ::__construct
  * @covers ::<private>
  */
-final class FactoryTest extends MockeryTestCase
+final class FactoryTest extends TestCase
 {
     use Faker;
 
     /** @var Factory */
     private $fixture;
-    /** @var m\LegacyMockInterface|m\MockInterface|FlySystemFactory */
+
+    /** @var ObjectProphecy|FlySystemFactory */
     private $flySystemFactory;
+
     /** @var vfsStreamDirectory */
     private $globalTemplates;
 
@@ -61,12 +63,12 @@ final class FactoryTest extends MockeryTestCase
         $templateDirectory = $this->givenAnExampleTemplateInDirectoryCalled($templateName);
         $this->globalTemplates->addChild($templateDirectory);
 
-        $templateCollection = m::mock(Collection::class);
-        $templateCollection->shouldReceive('getTemplatesPath')->andReturn($this->globalTemplates->url());
+        $templateCollection = $this->prophesize(Collection::class);
+        $templateCollection->getTemplatesPath()->shouldBeCalled()->willReturn($this->globalTemplates->url());
 
         $transformer = new Transformer(
-            $templateCollection,
-            m::mock(WriterCollection::class),
+            $templateCollection->reveal(),
+            $this->prophesize(WriterCollection::class)->reveal(),
             new NullLogger(),
             $this->flySystemFactory
         );
@@ -102,12 +104,12 @@ final class FactoryTest extends MockeryTestCase
 
         // Arrange
         $templateName = 'does-not-exist';
-        $templateCollection = m::mock(Collection::class);
-        $templateCollection->shouldReceive('getTemplatesPath')->andReturn($this->globalTemplates->url());
+        $templateCollection = $this->prophesize(Collection::class);
+        $templateCollection->getTemplatesPath()->willReturn($this->globalTemplates->url());
 
         $transformer = new Transformer(
-            $templateCollection,
-            m::mock(WriterCollection::class),
+            $templateCollection->reveal(),
+            $this->prophesize(WriterCollection::class)->reveal(),
             new NullLogger(),
             $this->flySystemFactory
         );

--- a/tests/unit/phpDocumentor/Transformer/Writer/CollectionTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/CollectionTest.php
@@ -13,21 +13,20 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer;
 
-use Mockery as m;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Mockery\MockInterface;
 use phpDocumentor\Transformer\Router\Router;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use stdClass;
 
 /**
  * Test class for phpDocumentor\Transformer\Writer\Collection
  */
-final class CollectionTest extends MockeryTestCase
+final class CollectionTest extends TestCase
 {
-    /** @var MockInterface|Router */
+    /** @var ObjectProphecy|Router */
     private $routers;
 
-    /** @var MockInterface|WriterAbstract */
+    /** @var ObjectProphecy|WriterAbstract */
     private $writer;
 
     /** @var Collection */
@@ -38,9 +37,9 @@ final class CollectionTest extends MockeryTestCase
      */
     protected function setUp() : void
     {
-        $this->routers = m::mock(Router::class);
-        $this->writer = m::mock(WriterAbstract::class);
-        $this->fixture = new Collection($this->routers);
+        $this->routers = $this->prophesize(Router::class);
+        $this->writer = $this->prophesize(WriterAbstract::class);
+        $this->fixture = new Collection($this->routers->reveal());
     }
 
     /**
@@ -58,7 +57,7 @@ final class CollectionTest extends MockeryTestCase
     public function testOffsetSetWithInvalidIndexName() : void
     {
         $this->expectException('InvalidArgumentException');
-        $this->fixture->offsetSet('i', $this->writer);
+        $this->fixture->offsetSet('i', $this->writer->reveal());
     }
 
     /**
@@ -77,7 +76,7 @@ final class CollectionTest extends MockeryTestCase
     {
         $this->registerWriter();
 
-        $this->assertSame($this->writer, $this->fixture->offsetGet('index'));
+        $this->assertSame($this->writer->reveal(), $this->fixture->offsetGet('index'));
     }
 
     /**
@@ -87,7 +86,7 @@ final class CollectionTest extends MockeryTestCase
     {
         $this->registerWriter();
 
-        $this->writer->shouldReceive('checkRequirements')->once();
+        $this->writer->checkRequirements()->shouldBeCalledOnce();
         $this->fixture->checkRequirements();
 
         $this->assertTrue(true);
@@ -98,6 +97,6 @@ final class CollectionTest extends MockeryTestCase
      */
     private function registerWriter() : void
     {
-        $this->fixture->offsetSet('index', $this->writer);
+        $this->fixture->offsetSet('index', $this->writer->reveal());
     }
 }


### PR DESCRIPTION
#2217

`Transformer/Template/CollectionTest.php` was left as child of `MockeryTestCase` instead of PHPUnit's `TestCase` as it uses `phpDocumentor\Faker\Provider` class which is as well dependent on Mockery. 

To keep this PR simple `Provider` **must** be migrated (refactored) later and all child classes must be changed to `TestCase`.