### PR TITLE
changing templates for coherence

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,6 +24,9 @@ parameters:
     # PHPStan doesn't support @template D of T but will still complain if we put a D in a Collection of T !
     - '#Parameter \#2 \$value of method phpDocumentor\\Descriptor\\Collection<T>::offsetSet\(\) expects T, D given\.#'
 
+    # phpstan/phpstan/issues/3951
+    - '#Method phpDocumentor\\Descriptor\\ProjectDescriptorBuilder::filterDescriptor\(\) should return TDescriptor of phpDocumentor\\Descriptor\\Descriptor\|null but returns phpDocumentor\\Descriptor\\Filter\\Filterable\|null\.#'
+
     # PHPStan doesn't support inheritance of TDescriptor
     - '#Parameter \#2 \$assembler of method phpDocumentor\\Descriptor\\Builder\\AssemblerFactory<TInput of object,TDescriptor of phpDocumentor\\Descriptor\\Descriptor>::(register|registerFallback)\(\) expects phpDocumentor\\Descriptor\\Builder\\AssemblerInterface.* given\.#'
     -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,8 +25,7 @@ parameters:
     - '#Parameter \#2 \$value of method phpDocumentor\\Descriptor\\Collection<T>::offsetSet\(\) expects T, D given\.#'
 
     # PHPStan doesn't support inheritance of TDescriptor
-    - '#Parameter \#2 \$assembler of method phpDocumentor\\Descriptor\\Builder\\AssemblerFactory::(register|registerFallback)\(\) expects phpDocumentor\\Descriptor\\Builder\\AssemblerInterface.* given\.#'
-
+    - '#Parameter \#2 \$assembler of method phpDocumentor\\Descriptor\\Builder\\AssemblerFactory<TInput of object,TDescriptor of phpDocumentor\\Descriptor\\Descriptor>::(register|registerFallback)\(\) expects phpDocumentor\\Descriptor\\Builder\\AssemblerInterface.* given\.#'
     -
             message: "#^Parameter \\#1 \\$value of method phpDocumentor\\\\GraphViz\\\\Graph\\:\\:setCenter\\(\\) expects bool, string given\\.$#"
             count: 1

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
@@ -40,7 +40,6 @@ use phpDocumentor\Descriptor\Builder\Reflector\Tags\UsesAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\VarAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\VersionAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\TraitAssembler;
-use phpDocumentor\Descriptor\Descriptor;
 use phpDocumentor\Reflection\DocBlock\ExampleFinder;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\Tags;
@@ -72,7 +71,7 @@ use function array_merge;
  * Attempts to retrieve an Assembler for the provided criteria.
  *
  * @template TInput of object
- * @template TDescriptor of Descriptor
+ * @template TDescriptor of \phpDocumentor\Descriptor\Descriptor
  */
 class AssemblerFactory
 {
@@ -117,8 +116,8 @@ class AssemblerFactory
      *
      * @return AssemblerInterface<TParamDescriptor, TParamInput>|null
      *
-     * @template TParamInput of TInput
-     * @template TParamDescriptor of TDescriptor
+     * @psalm-template TParamInput of object
+     * @psalm-template TParamDescriptor of \phpDocumentor\Descriptor\Descriptor
      */
     public function get(object $criteria, string $type) : ?AssemblerInterface
     {
@@ -136,8 +135,12 @@ class AssemblerFactory
         return null;
     }
 
+    /**
+     * @return self<TInput, TDescriptor>
+     */
     public static function createDefault(ExampleFinder $exampleFinder) : self
     {
+        /** @var self<TInput, TDescriptor> $factory */
         $factory = new self();
         $argumentAssembler = new ArgumentAssembler();
 

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
@@ -70,13 +70,16 @@ use function array_merge;
 
 /**
  * Attempts to retrieve an Assembler for the provided criteria.
+ *
+ * @template TInput of object
+ * @template TDescriptor of Descriptor
  */
 class AssemblerFactory
 {
-    /** @var AssemblerMatcher<Descriptor, object>[] */
+    /** @var AssemblerMatcher<TDescriptor, TInput>[] */
     protected $assemblers = [];
 
-    /** @var AssemblerMatcher<Descriptor, object>[] */
+    /** @var AssemblerMatcher<TDescriptor, TInput>[] */
     protected $fallbackAssemblers = [];
 
     /**
@@ -84,7 +87,7 @@ class AssemblerFactory
      *
      * @param callable $matcher A callback function accepting the criteria as only parameter and which must
      *     return a boolean.
-     * @param AssemblerInterface<Descriptor, object> $assembler An instance of the Assembler that
+     * @param AssemblerInterface<TDescriptor, TInput> $assembler An instance of the Assembler that
      *     will be returned if the callback returns true with the provided criteria.
      */
     public function register(callable $matcher, AssemblerInterface $assembler) : void
@@ -98,7 +101,7 @@ class AssemblerFactory
      *
      * @param callable $matcher A callback function accepting the criteria as only parameter and which must
      *     return a boolean.
-     * @param AssemblerInterface<Descriptor, object> $assembler An instance of the Assembler that
+     * @param AssemblerInterface<TDescriptor, TInput> $assembler An instance of the Assembler that
      *     will be returned if the callback returns true with the provided criteria.
      */
     public function registerFallback(callable $matcher, AssemblerInterface $assembler) : void
@@ -109,17 +112,21 @@ class AssemblerFactory
     /**
      * Retrieves a matching Assembler based on the provided criteria or null if none was found.
      *
-     * @param TInput $criteria
-     * @param class-string<TDescriptor> $type
+     * @param TParamInput $criteria
+     * @param class-string<TParamDescriptor> $type
      *
-     * @return AssemblerInterface<TDescriptor, TInput>
+     * @return AssemblerInterface<TParamDescriptor, TParamInput>|null
      *
-     * @template TInput of object
-     * @template TDescriptor of Descriptor
+     * @template TParamInput of TInput
+     * @template TParamDescriptor of TDescriptor
      */
     public function get(object $criteria, string $type) : ?AssemblerInterface
     {
-        /** @var AssemblerMatcher<TDescriptor, TInput> $candidate */
+        /**
+         * @var AssemblerMatcher<TParamDescriptor, TParamInput> $candidate This is cheating, but there's no way to make
+         * psalm understand that TParamDescriptor & TParamInput given in param happen to be the same as the one in the
+         * factory. We know it is because they matched.
+         */
         foreach (array_merge($this->assemblers, $this->fallbackAssemblers) as $candidate) {
             if ($candidate->match($criteria)) {
                 return $candidate->getAssembler();

--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -77,14 +77,12 @@ class ProjectDescriptorBuilder
     /**
      * Takes the given data and attempts to build a Descriptor from it.
      *
-     * @param TInput $data
      * @param class-string<TDescriptor> $type
      *
      * @return TDescriptor|null
      *
      * @throws InvalidArgumentException If no Assembler could be found that matches the given data.
      *
-     * @template TInput of object
      * @template TDescriptor of Descriptor
      */
     public function buildDescriptor(object $data, string $type) : ?Descriptor
@@ -102,7 +100,6 @@ class ProjectDescriptorBuilder
         }
 
         // create Descriptor and populate with the provided data
-        /** @var TDescriptor|null $descriptor */
         $descriptor = $this->filterDescriptor($assembler->create($data));
 
         return $descriptor;
@@ -114,7 +111,7 @@ class ProjectDescriptorBuilder
      * @param TInput $data
      * @param class-string<TDescriptor> $type
      *
-     * @return AssemblerInterface<Descriptor, TInput>|null
+     * @return AssemblerInterface<TDescriptor, TInput>|null
      *
      * @template TInput as object
      * @template TDescriptor as Descriptor
@@ -155,7 +152,6 @@ class ProjectDescriptorBuilder
         }
 
         // filter the descriptor; this may result in the descriptor being removed!
-        /** @var TDescriptor|null $descriptor */
         $descriptor = $this->filter($descriptor);
 
         return $descriptor;

--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -33,7 +33,7 @@ class ProjectDescriptorBuilder
     /** @var string */
     public const DEFAULT_PROJECT_NAME = 'Untitled project';
 
-    /** @var AssemblerFactory $assemblerFactory */
+    /** @var AssemblerFactory<object, Descriptor> $assemblerFactory */
     protected $assemblerFactory;
 
     /** @var Filter $filter */
@@ -49,6 +49,7 @@ class ProjectDescriptorBuilder
     private $servicesWithCustomSettings;
 
     /**
+     * @param AssemblerFactory<object, Descriptor> $assemblerFactory
      * @param iterable<WithCustomSettings> $servicesWithCustomSettings
      */
     public function __construct(
@@ -100,9 +101,7 @@ class ProjectDescriptorBuilder
         }
 
         // create Descriptor and populate with the provided data
-        $descriptor = $this->filterDescriptor($assembler->create($data));
-
-        return $descriptor;
+        return $this->filterDescriptor($assembler->create($data));
     }
 
     /**


### PR DESCRIPTION
This PR propose changing some templates annotations for psalm.

Most of the time, it shouldn't be needed to add local @var with templates, it means there is something weird going on.

In the case of ProjectDescriptorBuilder.php, it was just an omission in getAssembler documentation.

The AssemblerFactory.php is more complex though. If I understand it fully, The class is a collection of AssemblerMatcher built in advance. When needed, we send a Descriptor, and it returns a matching AssemblerInterface.

That means the Descriptor given and the one retrieved is not actually the same and Psalm detects it. We know it's basically the same because it matched, so I had to cheat a little with an annotation saying that the returned element is the one given in parameter.