### PR TITLE
fix build

### DIFF
--- a/src/phpDocumentor/Compiler/Compiler.php
+++ b/src/phpDocumentor/Compiler/Compiler.php
@@ -19,7 +19,8 @@ use Webmozart\Assert\Assert;
 /**
  * Contains a series of compiler steps in a specific order; ready to be executed during transformation.
  *
- * @template-extends SplPriorityQueue<CompilerPassInterface, int>
+ * @psalm-template-extends SplPriorityQueue<CompilerPassInterface, int>
+ * @template-extends SplPriorityQueue<int, CompilerPassInterface>
  */
 class Compiler extends SplPriorityQueue
 {


### PR DESCRIPTION
This PR should fix the build.

The issue happened because in Psalm's last release, a stub SplPriorityQueue for was added in https://github.com/vimeo/psalm/pull/4255.

Unfortunately, the order of the templates don't match with the existing one in PhpStan:
https://github.com/phpstan/phpstan-src/blob/6a38951c5cf040db5cae0e8e229064320a751413/stubs/spl.stub#L69
https://github.com/vimeo/psalm/blob/446a833d18419a5876ce5784ebe4309e33b89c64/stubs/CoreGenericClasses.phpstub#L1677

Furthermore, it seems phpstan doesn't read @phpstan-template-extends so I had to define the phpstan version as @template-extends and use @psalm-template-extends for the psalm version

@muglug @ondrejmirtes Maybe static analysis tools should have stubs in common, similar to the functions map to avoid this kind of issues?
@muglug For this case, the Psalm order seems more logical to me but the PhpStan one is older, meaning changing Psalm's one will break less things. Would you agree on a PR for this?