### PR TITLE
replace callable by Matcher when applicable

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,6 +27,9 @@ parameters:
     # phpstan/phpstan/issues/3951
     - '#Method phpDocumentor\\Descriptor\\ProjectDescriptorBuilder::filterDescriptor\(\) should return TDescriptor of phpDocumentor\\Descriptor\\Descriptor\|null but returns phpDocumentor\\Descriptor\\Filter\\Filterable\|null\.#'
 
+    # PHPStan has issue when involving templates and parent types
+    - '#Parameter \#1 \$matcher of method phpDocumentor\\Descriptor\\Builder\\AssemblerFactory::(register|registerFallback)\(\) expects phpDocumentor\\Descriptor\\Builder\\Matcher<object>, phpDocumentor\\Descriptor\\Builder\\Matcher<.+> given\.#'
+
     # PHPStan doesn't support inheritance of TDescriptor
     - '#Parameter \#2 \$assembler of method phpDocumentor\\Descriptor\\Builder\\AssemblerFactory::(register|registerFallback)\(\) expects phpDocumentor\\Descriptor\\Builder\\AssemblerInterface.* given\.#'
     -

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
@@ -82,12 +82,12 @@ class AssemblerFactory
     /**
      * Registers an assembler instance to this factory.
      *
-     * @param callable $matcher A callback function accepting the criteria as only parameter and which must
+     * @param Matcher<object> $matcher A callback function accepting the criteria as only parameter and which must
      *     return a boolean.
      * @param AssemblerInterface<Descriptor, object> $assembler An instance of the Assembler that
      *     will be returned if the callback returns true with the provided criteria.
      */
-    public function register(callable $matcher, AssemblerInterface $assembler) : void
+    public function register(Matcher $matcher, AssemblerInterface $assembler) : void
     {
         $this->assemblers[] = new AssemblerMatcher($matcher, $assembler);
     }
@@ -96,12 +96,12 @@ class AssemblerFactory
      * Registers an assembler instance to this factory that is to be executed after all other assemblers have been
      * checked.
      *
-     * @param callable $matcher A callback function accepting the criteria as only parameter and which must
+     * @param Matcher<object> $matcher A callback function accepting the criteria as only parameter and which must
      *     return a boolean.
      * @param AssemblerInterface<Descriptor, object> $assembler An instance of the Assembler that
      *     will be returned if the callback returns true with the provided criteria.
      */
-    public function registerFallback(callable $matcher, AssemblerInterface $assembler) : void
+    public function registerFallback(Matcher $matcher, AssemblerInterface $assembler) : void
     {
         $this->fallbackAssemblers[] = new AssemblerMatcher($matcher, $assembler);
     }

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerMatcher.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerMatcher.php
@@ -17,16 +17,17 @@ use phpDocumentor\Descriptor\Descriptor;
 
 final class AssemblerMatcher
 {
-    /** @var callable */
+    /** @var Matcher<object> */
     private $matcher;
 
     /** @var AssemblerInterface<Descriptor, object> */
     private $assembler;
 
     /**
+     * @param Matcher<object> $matcher
      * @param AssemblerInterface<Descriptor, object> $assembler
      */
-    public function __construct(callable $matcher, AssemblerInterface $assembler)
+    public function __construct(Matcher $matcher, AssemblerInterface $assembler)
     {
         $this->matcher   = $matcher;
         $this->assembler = $assembler;


### PR DESCRIPTION
This PR propose narrowing down the callable type to Matcher when possible.