### PR TITLE
replace static in final class by the class name

### DIFF
--- a/src/Guides/Nodes/Node.php
+++ b/src/Guides/Nodes/Node.php
@@ -132,7 +132,7 @@ abstract class Node
             return '';
         }
 
-        if ($this->value instanceof Node) {
+        if ($this->value instanceof self) {
             return $this->value->getValueString();
         }
 

--- a/src/Guides/Nodes/SpanNode.php
+++ b/src/Guides/Nodes/SpanNode.php
@@ -44,7 +44,7 @@ class SpanNode extends Node
             $span = implode("\n", $span);
         }
 
-        if ($span instanceof SpanNode) {
+        if ($span instanceof self) {
             $span = $span->render();
         }
 

--- a/src/phpDocumentor/AutoloaderLocator.php
+++ b/src/phpDocumentor/AutoloaderLocator.php
@@ -24,7 +24,7 @@ final class AutoloaderLocator
 {
     public static function autoload() : ClassLoader
     {
-        return require static::findVendorPath() . '/autoload.php';
+        return require self::findVendorPath() . '/autoload.php';
     }
 
     /**
@@ -64,8 +64,8 @@ final class AutoloaderLocator
             $vendorDir = $vendorFolderWhenInstalledWithComposer;
         } else {
             // Repository cloned via git
-            $vendorDir = $baseDir . '/../../' . static::getCustomVendorPathFromComposer(
-                $baseDir . '/../../' . static::findComposerConfigurationPath()
+            $vendorDir = $baseDir . '/../../' . self::getCustomVendorPathFromComposer(
+                $baseDir . '/../../' . self::findComposerConfigurationPath()
             );
         }
 

--- a/src/phpDocumentor/Descriptor/Builder/Matcher.php
+++ b/src/phpDocumentor/Descriptor/Builder/Matcher.php
@@ -15,15 +15,15 @@ final class Matcher
     private $type;
 
     /**
-     * @param class-string<StaticT> $type
+     * @param class-string<SelfT> $type
      *
-     * @return static<StaticT>
+     * @return self<SelfT>
      *
-     * @template StaticT
+     * @template SelfT
      */
     public static function forType(string $type) : self
     {
-        return new static($type);
+        return new self($type);
     }
 
     /**

--- a/src/phpDocumentor/Parser/Event/PreParsingEvent.php
+++ b/src/phpDocumentor/Parser/Event/PreParsingEvent.php
@@ -30,7 +30,7 @@ final class PreParsingEvent extends EventAbstract
      */
     public static function createInstance(object $subject) : EventAbstract
     {
-        return new static($subject);
+        return new self($subject);
     }
 
     public function setFileCount(int $fileCount) : self

--- a/src/phpDocumentor/Transformer/Event/PostTransformEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PostTransformEvent.php
@@ -31,7 +31,7 @@ final class PostTransformEvent extends EventAbstract
      */
     public static function createInstance(object $subject) : EventAbstract
     {
-        return new static($subject);
+        return new self($subject);
     }
 
     /**

--- a/src/phpDocumentor/Transformer/Event/PostTransformationEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PostTransformationEvent.php
@@ -27,6 +27,6 @@ final class PostTransformationEvent extends EventAbstract
      */
     public static function createInstance(object $subject) : EventAbstract
     {
-        return new static($subject);
+        return new self($subject);
     }
 }

--- a/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
@@ -31,7 +31,7 @@ final class PreTransformEvent extends EventAbstract
      */
     public static function createInstance(object $subject) : EventAbstract
     {
-        return new static($subject);
+        return new self($subject);
     }
 
     /**

--- a/src/phpDocumentor/Transformer/Event/PreTransformationEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PreTransformationEvent.php
@@ -35,7 +35,7 @@ final class PreTransformationEvent extends Event
 
     public static function create(object $subject, Transformation $transformation) : self
     {
-        return new static($subject, $transformation);
+        return new self($subject, $transformation);
     }
 
     public function getTransformation() : Transformation

--- a/src/phpDocumentor/Transformer/Event/WriterInitializationEvent.php
+++ b/src/phpDocumentor/Transformer/Event/WriterInitializationEvent.php
@@ -28,7 +28,7 @@ final class WriterInitializationEvent extends EventAbstract
      */
     public static function createInstance(object $subject) : EventAbstract
     {
-        return new static($subject);
+        return new self($subject);
     }
 
     /**


### PR DESCRIPTION
The static keyword is redundant in final classes, it create unnecessary confusion. I replaced static by the class name.

Aso, would you be open to mark as final every class in the library that is not inherited? You told me once that this library is not supposed to be extended. This would warrant that and allow more simplifications like this PR