### PR TITLE
GH#2493 Search links do not resolve on the homepage

### DIFF
--- a/data/templates/default/components/header-title.html.twig
+++ b/data/templates/default/components/header-title.html.twig
@@ -1,1 +1,1 @@
-<h1 class="phpdocumentor-title"><a href="{{ path('/') }}">{{ project.name }}</a></h1>
+<h1 class="phpdocumentor-title"><a href="{{ link('.') }}">{{ project.name }}</a></h1>

--- a/data/templates/default/components/header-title.html.twig
+++ b/data/templates/default/components/header-title.html.twig
@@ -1,1 +1,1 @@
-<h1 class="phpdocumentor-title"><a href="{{ link('.') }}">{{ project.name }}</a></h1>
+<h1 class="phpdocumentor-title"><a href="{{ path('/') }}">{{ project.name }}</a></h1>

--- a/data/templates/default/components/sidebar.html.twig
+++ b/data/templates/default/components/sidebar.html.twig
@@ -44,15 +44,15 @@
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
         {% if project.settings.custom['graphs.enabled'] %}
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="{{ path('graphs/classes.html') }}">Class Diagram</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="graphs/classes.html">Class Diagram</a></h3>
         {% endif %}
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="{{ path('reports/deprecated.html') }}">Deprecated</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="{{ path('reports/errors.html') }}">Errors</a></h3>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="{{ path('reports/markers.html') }}">Markers</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/deprecated.html">Deprecated</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/errors.html">Errors</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
     <section class="phpdocumentor-sidebar__category">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
-        <h3 class="phpdocumentor-sidebar__root-package"><a href="{{ path('indices/files.html') }}">Files</a></h3>
+        <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>
 </aside>

--- a/data/templates/default/layout.html.twig
+++ b/data/templates/default/layout.html.twig
@@ -4,20 +4,21 @@
     <meta charset="utf-8">
     <title>{% block title %}{{ project.name }}{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="{{ path('images/favicon.ico') }}"/>
-    <link rel="stylesheet" href="{{ path('css/normalize.css') }}">
-    <link rel="stylesheet" href="{{ path('css/base.css') }}">
+    {{ renderBaseUrlHeader() }}
+    <link rel="icon" href="images/favicon.ico"/>
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/base.css">
     {% block stylesheets %}
         <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap" rel="stylesheet">
-        <link rel="stylesheet" href="{{ path('css/template.css') }}">
+        <link rel="stylesheet" href="css/template.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/css/all.min.css" integrity="sha256-ybRkN9dBjhcS2qrW1z+hfCxq+1aBdwyQM5wlQoQVt/0=" crossorigin="anonymous" />
     {% endblock %}
     {% block javascripts %}
         <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
-        <script src="{{ path('js/search.js') }}"></script>
-        <script defer src="{{ path('js/searchIndex.js') }}"></script>
+        <script src="js/search.js"></script>
+        <script defer src="js/searchIndex.js"></script>
     {% endblock %}
 </head>
 <body id="top">

--- a/data/templates/default/menu.html.twig
+++ b/data/templates/default/menu.html.twig
@@ -1,7 +1,7 @@
 {% if isChild|default(false) == false %}
 <h2 class="phpdocumentor-sidebar__root-package">
 {% endif %}
-    <a href="{{ path(menuItem.path) }}">{{ menuItem.label }}</a>
+    <a href="{{ menuItem.path }}">{{ menuItem.label }}</a>
 {% if isChild|default(false) == false %}
 </h2>
 {% endif %}

--- a/data/templates/default/reports/deprecated.html.twig
+++ b/data/templates/default/reports/deprecated.html.twig
@@ -13,7 +13,7 @@
 
 {% block content %}
     <ul class="phpdocumentor-breadcrumbs">
-        <li><a href="{{ path("/index.html") }}">Home</a></li>
+        <li><a href="{{ path("/") }}">Home</a></li>
     </ul>
 
     <div class="phpdocumentor-row">

--- a/data/templates/default/reports/errors.html.twig
+++ b/data/templates/default/reports/errors.html.twig
@@ -8,7 +8,7 @@
 
 {% block content %}
 <ul class="phpdocumentor-breadcrumbs">
-    <li><a href="{{ path("/index.html") }}">Home</a></li>
+    <li><a href="{{ path("/") }}">Home</a></li>
 </ul>
 
 <div class="phpdocumentor-row">

--- a/data/templates/default/reports/markers.html.twig
+++ b/data/templates/default/reports/markers.html.twig
@@ -8,7 +8,7 @@
 
 {% block content %}
     <ul class="phpdocumentor-breadcrumbs">
-        <li><a href="{{ path("/index.html") }}">Home</a></li>
+        <li><a href="{{ path("/") }}">Home</a></li>
     </ul>
 
     <div class="phpdocumentor-row">

--- a/data/templates/default/search.js.twig
+++ b/data/templates/default/search.js.twig
@@ -97,7 +97,7 @@ var Search = (function () {
         results.forEach(function (result) {
             var entry = document.createElement("li");
             entry.classList.add("phpdocumentor-search-results__entry");
-            entry.innerHTML += '<h3><a href="' + result.url + '">' + result.name + "</h3>\n";
+            entry.innerHTML += '<h3><a href="' + document.baseURI + result.url + '">' + result.name + "</h3>\n";
             entry.innerHTML += '<small>' + result.fqsen + "</small>\n";
             entry.innerHTML += '<div class="phpdocumentor-summary">' + result.summary + '</div>';
             searchResultEntries.appendChild(entry)

--- a/data/templates/default/searchIndex.js.twig
+++ b/data/templates/default/searchIndex.js.twig
@@ -1,3 +1,4 @@
+{% set baseUrl = renderBaseUrlHeader() %}
 Search.appendIndex(
     [
         {% for element in project.indexes.elements %}

--- a/src/Guides/Environment.php
+++ b/src/Guides/Environment.php
@@ -102,14 +102,15 @@ final class Environment
         Configuration $configuration,
         Renderer $renderer,
         LoggerInterface $logger,
-        FilesystemInterface $origin
+        FilesystemInterface $origin,
+        Metas $metas
     ) {
         $this->configuration = $configuration;
         $this->renderer = $renderer;
         $this->origin = $origin;
         $this->logger = $logger;
         $this->urlGenerator = new UrlGenerator();
-        $this->metas = new Metas();
+        $this->metas = $metas;
 
         $this->reset();
     }

--- a/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
+++ b/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
@@ -76,8 +76,13 @@ final class ParseFileHandler
         $directory = $command->getDirectory();
         $file = $command->getFile();
 
-        $environment = new Environment($configuration, $this->renderer, $this->logger, $command->getOrigin());
-        $environment->setMetas($this->metas);
+        $environment = new Environment(
+            $configuration,
+            $this->renderer,
+            $this->logger,
+            $command->getOrigin(),
+            $this->metas
+        );
         $environment->setCurrentFileName($file);
         $environment->setCurrentDirectory($directory);
 

--- a/src/Guides/UrlGenerator.php
+++ b/src/Guides/UrlGenerator.php
@@ -15,7 +15,6 @@ namespace phpDocumentor\Guides;
 
 use League\Uri\UriInfo;
 use phpDocumentor\UriFactory;
-use Symfony\Component\Routing\Generator\UrlGenerator as SymfonyUrlGenerator;
 use function array_pop;
 use function explode;
 use function implode;
@@ -50,11 +49,7 @@ final class UrlGenerator
     }
 
     /**
-     * Resolves a relative URL using directories.
-     *
-     * For instance, if the current directory is "path/to/something", and you want to get the relative URL to
-     * "path/to/something/else.html", the result will be else.html. Else, "../" will be added to go to the upper
-     * directory.
+     * Resolves a relative URL/
      */
     public function relativeUrl(string $basePath, string $url) : ?string
     {
@@ -68,7 +63,7 @@ final class UrlGenerator
             return $url;
         }
 
-        return SymfonyUrlGenerator::getRelativePath($basePath, ltrim($url, '/'));
+        return ltrim($url, '/');
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/VersionDescriptor.php
+++ b/src/phpDocumentor/Descriptor/VersionDescriptor.php
@@ -43,7 +43,10 @@ final class VersionDescriptor
         return $this->documentationSets;
     }
 
-    public static function fromConfiguration(array $config): self
+    /**
+     * @param array<mixed> $config
+     */
+    public static function fromConfiguration(array $config) : self
     {
         $documentationSets = Collection::fromClassString(DocumentationSetDescriptor::class);
 

--- a/src/phpDocumentor/Descriptor/VersionDescriptor.php
+++ b/src/phpDocumentor/Descriptor/VersionDescriptor.php
@@ -42,4 +42,19 @@ final class VersionDescriptor
     {
         return $this->documentationSets;
     }
+
+    public static function fromConfiguration(array $config): self
+    {
+        $documentationSets = Collection::fromClassString(DocumentationSetDescriptor::class);
+
+        foreach ($config['guides'] ?? [] as $guide) {
+            $documentationSets->add(new GuideSetDescriptor('', $guide['source'], $guide['output']));
+        }
+
+        foreach ($config['api'] ?? [] as $api) {
+            $documentationSets->add(new ApiSetDescriptor('', $api['source'], $api['output']));
+        }
+
+        return new self($config['number'], $documentationSets);
+    }
 }

--- a/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
+++ b/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
@@ -13,11 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage;
 
-use phpDocumentor\Descriptor\ApiSetDescriptor;
-use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\Collection as PartialsCollection;
-use phpDocumentor\Descriptor\DocumentationSetDescriptor;
-use phpDocumentor\Descriptor\GuideSetDescriptor;
 use phpDocumentor\Descriptor\VersionDescriptor;
 
 final class InitializeBuilderFromConfig

--- a/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
+++ b/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
@@ -44,18 +44,7 @@ final class InitializeBuilderFromConfig
         $builder->setCustomSettings($configuration['phpdocumentor']['settings'] ?? []);
 
         foreach (($configuration['phpdocumentor']['versions'] ?? []) as $version) {
-            $documentationSets = Collection::fromClassString(DocumentationSetDescriptor::class);
-
-            foreach ($version['guides'] ?? [] as $guide) {
-                $documentationSets->add(new GuideSetDescriptor('', $guide['source'], $guide['output']));
-            }
-
-            foreach ($version['api'] ?? [] as $api) {
-                $documentationSets->add(new ApiSetDescriptor('', $api['source'], $api['output']));
-            }
-
-            $version = new VersionDescriptor($version['number'], $documentationSets);
-            $builder->addVersion($version);
+            $builder->addVersion(VersionDescriptor::fromConfiguration($version));
         }
 
         return $payload;

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -145,19 +145,19 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
             ),
             new TwigFunction(
                 'path',
-                function(string $url): string {
+                function (string $url) : string {
                     return $this->routeRenderer->convertToRootPath($url);
                 }
             ),
             new TwigFunction(
                 'link',
-                function (object $element): string {
+                function (object $element) : string {
                     return $this->routeRenderer->link($element);
                 }
             ),
             new TwigFunction(
                 'breadcrumbs',
-                static function (DescriptorAbstract $baseNode) {
+                static function (DescriptorAbstract $baseNode) : array {
                     $results = [];
                     $namespace = $baseNode instanceof NamespaceDescriptor
                         ? $baseNode->getParent()
@@ -172,7 +172,7 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
             ),
             new TwigFunction(
                 'packages',
-                static function (DescriptorAbstract $baseNode) {
+                static function (DescriptorAbstract $baseNode) : array {
                     $results = [];
                     $package = $baseNode instanceof PackageDescriptor
                         ? $baseNode->getParent()
@@ -185,54 +185,63 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
                     return $results;
                 }
             ),
-            new TwigFunction('methods', static function (DescriptorAbstract $descriptor) : Collection {
-                $methods = new Collection();
-                if (method_exists($descriptor, 'getInheritedMethods')) {
-                    $methods = $methods->merge($descriptor->getInheritedMethods());
-                }
+            new TwigFunction(
+                'methods',
+                static function (DescriptorAbstract $descriptor) : Collection {
+                    $methods = new Collection();
+                    if (method_exists($descriptor, 'getInheritedMethods')) {
+                        $methods = $methods->merge($descriptor->getInheritedMethods());
+                    }
 
-                if (method_exists($descriptor, 'getMagicMethods')) {
-                    $methods = $methods->merge($descriptor->getMagicMethods());
-                }
+                    if (method_exists($descriptor, 'getMagicMethods')) {
+                        $methods = $methods->merge($descriptor->getMagicMethods());
+                    }
 
-                if (method_exists($descriptor, 'getMethods')) {
-                    $methods = $methods->merge($descriptor->getMethods());
-                }
+                    if (method_exists($descriptor, 'getMethods')) {
+                        $methods = $methods->merge($descriptor->getMethods());
+                    }
 
-                return $methods;
-            }),
-            new TwigFunction('properties', static function (DescriptorAbstract $descriptor) : Collection {
-                $properties = new Collection();
-                if (method_exists($descriptor, 'getInheritedProperties')) {
-                    $properties = $properties->merge($descriptor->getInheritedProperties());
+                    return $methods;
                 }
+            ),
+            new TwigFunction(
+                'properties',
+                static function (DescriptorAbstract $descriptor) : Collection {
+                    $properties = new Collection();
+                    if (method_exists($descriptor, 'getInheritedProperties')) {
+                        $properties = $properties->merge($descriptor->getInheritedProperties());
+                    }
 
-                if (method_exists($descriptor, 'getMagicProperties')) {
-                    $properties = $properties->merge($descriptor->getMagicProperties());
+                    if (method_exists($descriptor, 'getMagicProperties')) {
+                        $properties = $properties->merge($descriptor->getMagicProperties());
+                    }
+
+                    if (method_exists($descriptor, 'getProperties')) {
+                        $properties = $properties->merge($descriptor->getProperties());
+                    }
+
+                    return $properties;
                 }
+            ),
+            new TwigFunction(
+                'constants',
+                static function (DescriptorAbstract $descriptor) : Collection {
+                    $constants = new Collection();
+                    if (method_exists($descriptor, 'getInheritedConstants')) {
+                        $constants = $constants->merge($descriptor->getInheritedConstants());
+                    }
 
-                if (method_exists($descriptor, 'getProperties')) {
-                    $properties = $properties->merge($descriptor->getProperties());
+                    if (method_exists($descriptor, 'getMagicConstants')) {
+                        $constants = $constants->merge($descriptor->getMagicConstants());
+                    }
+
+                    if (method_exists($descriptor, 'getConstants')) {
+                        $constants = $constants->merge($descriptor->getConstants());
+                    }
+
+                    return $constants;
                 }
-
-                return $properties;
-            }),
-            new TwigFunction('constants', static function (DescriptorAbstract $descriptor) : Collection {
-                $constants = new Collection();
-                if (method_exists($descriptor, 'getInheritedConstants')) {
-                    $constants = $constants->merge($descriptor->getInheritedConstants());
-                }
-
-                if (method_exists($descriptor, 'getMagicConstants')) {
-                    $constants = $constants->merge($descriptor->getMagicConstants());
-                }
-
-                if (method_exists($descriptor, 'getConstants')) {
-                    $constants = $constants->merge($descriptor->getConstants());
-                }
-
-                return $constants;
-            }),
+            ),
         ];
     }
 

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -146,12 +146,12 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
             new TwigFunction(
                 'path',
                 function(string $url): string {
-                    return $this->routeRenderer->convertToRootPath($url, true);
+                    return $this->routeRenderer->convertToRootPath($url);
                 }
             ),
             new TwigFunction(
                 'link',
-                function ($element): string {
+                function (object $element): string {
                     return $this->routeRenderer->link($element);
                 }
             ),

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -64,6 +64,9 @@ final class LinkRenderer
     /** @var ProjectDescriptor|null */
     private $project;
 
+    /** @var bool */
+    private $convertToRootPath = true;
+
     public function __construct(Router $router)
     {
         $this->router = $router;
@@ -103,6 +106,14 @@ final class LinkRenderer
         return $result;
     }
 
+    public function doNotConvertUrlsToRootPath(): self
+    {
+        $result = clone $this;
+        $result->convertToRootPath = false;
+
+        return $result;
+    }
+
     /**
      * Returns the target directory relative to the Project's Root.
      */
@@ -121,7 +132,7 @@ final class LinkRenderer
             return $uri;
         }
 
-        return $this->convertToRootPath($uri);
+        return $this->convertToRootPath($this->withoutLeadingSlash($uri));
     }
 
     /**
@@ -178,7 +189,7 @@ final class LinkRenderer
      *       namespace reference. As such we assume a class as that is the
      *       most common occurrence.
      */
-    public function convertToRootPath(string $pathOrReference) : ?string
+    public function convertToRootPath(string $pathOrReference, bool $force = false) : ?string
     {
         if ($this->isReferenceToFqsen($pathOrReference)) {
             try {
@@ -192,7 +203,12 @@ final class LinkRenderer
             return null;
         }
 
-        return $this->getPathPrefixBasedOnDepth() . $this->withoutLeadingSlash($pathOrReference);
+        $withoutLeadingSlash = $this->withoutLeadingSlash($pathOrReference);
+        if ($this->convertToRootPath || $force) {
+            return $this->getPathPrefixBasedOnDepth() . $withoutLeadingSlash;
+        }
+
+        return $withoutLeadingSlash;
     }
 
     /**

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -106,7 +106,7 @@ final class LinkRenderer
         return $result;
     }
 
-    public function doNotConvertUrlsToRootPath(): self
+    public function doNotConvertUrlsToRootPath() : self
     {
         $result = clone $this;
         $result->convertToRootPath = false;


### PR DESCRIPTION
The URLs that are used in the search are pregenerated and attempt to
compensate for subdirectories but that does not work on the homepage.

By using the `<base>` HTML element, we can make it easier for ourselves
but now suddenly need to alter / revert the subdirectory determinations
and conversions.

## Todo

- [x] Guides do not know about this and need their behaviour stripped too
- [x] The logo's anchor somehow does not work; but my time is up to look at that now