### PR TITLE
use null coalesce operator when more logical

### DIFF
--- a/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
+++ b/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
@@ -44,7 +44,7 @@ final class ResolveInlineMarkers implements CompilerPassInterface
         /** @var FileDescriptor $file */
         foreach ($project->getFiles() as $file) {
             $matches     = [];
-            $source = $file->getSource() ?: '';
+            $source = $file->getSource() ?? '';
 
             preg_match_all(
                 '~//[\s]*(' . implode('|', $markerTerms) . ')\:?[\s]*(.*)~',

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/ClassAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/ClassAssembler.php
@@ -45,7 +45,7 @@ class ClassAssembler extends AssemblerAbstract
         $classDescriptor->setFullyQualifiedStructuralElementName($data->getFqsen());
         $classDescriptor->setName($data->getName());
         $classDescriptor->setPackage(
-            $this->extractPackageFromDocBlock($data->getDocBlock()) ?: $this->getBuilder()->getDefaultPackage()
+            $this->extractPackageFromDocBlock($data->getDocBlock()) ?? $this->getBuilder()->getDefaultPackage()
         );
         $classDescriptor->setLine($data->getLocation()->getLineNumber());
         if ((string) $data->getParent() !== (string) $data->getFqsen()) {

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
@@ -47,7 +47,7 @@ class FileAssembler extends AssemblerAbstract
     {
         $fileDescriptor = new FileDescriptor($data->getHash());
         $fileDescriptor->setPackage(
-            $this->extractPackageFromDocBlock($data->getDocBlock()) ?: $this->getBuilder()->getDefaultPackage()
+            $this->extractPackageFromDocBlock($data->getDocBlock()) ?? $this->getBuilder()->getDefaultPackage()
         );
 
         $fileDescriptor->setName($data->getName());

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/InterfaceAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/InterfaceAssembler.php
@@ -41,7 +41,7 @@ class InterfaceAssembler extends AssemblerAbstract
         $interfaceDescriptor->setFullyQualifiedStructuralElementName($data->getFqsen());
         $interfaceDescriptor->setName($data->getName());
         $interfaceDescriptor->setLine($data->getLocation()->getLineNumber());
-        $interfaceDescriptor->setPackage($this->extractPackageFromDocBlock($data->getDocBlock()) ?: '');
+        $interfaceDescriptor->setPackage($this->extractPackageFromDocBlock($data->getDocBlock()) ?? '');
 
         // Reflection library formulates namespace as global but this is not wanted for phpDocumentor itself
         $interfaceDescriptor->setNamespace(substr((string) $data->getFqsen(), 0, -strlen($data->getName()) - 1));

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/TraitAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/TraitAssembler.php
@@ -41,7 +41,7 @@ class TraitAssembler extends AssemblerAbstract
         $traitDescriptor->setFullyQualifiedStructuralElementName($data->getFqsen());
         $traitDescriptor->setName($data->getName());
         $traitDescriptor->setLine($data->getLocation()->getLineNumber());
-        $traitDescriptor->setPackage($this->extractPackageFromDocBlock($data->getDocBlock()) ?: '');
+        $traitDescriptor->setPackage($this->extractPackageFromDocBlock($data->getDocBlock()) ?? '');
 
         // Reflection library formulates namespace as global but this is not wanted for phpDocumentor itself
         $traitDescriptor->setNamespace(

--- a/src/phpDocumentor/Descriptor/ConstantDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ConstantDescriptor.php
@@ -133,7 +133,7 @@ class ConstantDescriptor extends DescriptorAbstract implements
      */
     public function getFile() : FileDescriptor
     {
-        return parent::getFile() ?: $this->getParent()->getFile();
+        return parent::getFile() ?? $this->getParent()->getFile();
     }
 
     /**

--- a/src/phpDocumentor/Dsn.php
+++ b/src/phpDocumentor/Dsn.php
@@ -116,7 +116,7 @@ final class Dsn
      */
     public function getHost() : string
     {
-        return $this->uri->getHost() ?: '';
+        return $this->uri->getHost() ?? '';
     }
 
     /**
@@ -146,7 +146,7 @@ final class Dsn
      */
     public function getUsername() : string
     {
-        return explode(':', $this->uri->getUserInfo() ?: '')[0];
+        return explode(':', $this->uri->getUserInfo() ?? '')[0];
     }
 
     /**
@@ -154,7 +154,7 @@ final class Dsn
      */
     public function getPassword() : string
     {
-        return explode(':', $this->uri->getUserInfo() ?: '')[1] ?? '';
+        return explode(':', $this->uri->getUserInfo() ?? '')[1] ?? '';
     }
 
     /**
@@ -184,7 +184,7 @@ final class Dsn
     public function getQuery() : array
     {
         $result = [];
-        parse_str($this->uri->getQuery() ?: '', $result);
+        parse_str($this->uri->getQuery() ?? '', $result);
 
         return $result;
     }

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -251,11 +251,11 @@ final class LinkRenderer
         }
 
         if ($node instanceof Object_) {
-            $node = $node->getFqsen() ?: $node;
+            $node = $node->getFqsen() ?? $node;
         }
 
         if ($node instanceof Fqsen) {
-            $node = $this->project->findElement($node) ?: $node;
+            $node = $this->project->findElement($node) ?? $node;
         }
 
         if ($node instanceof AbstractList) {

--- a/tests/unit/phpDocumentor/Faker/Provider.php
+++ b/tests/unit/phpDocumentor/Faker/Provider.php
@@ -36,7 +36,7 @@ final class Provider extends Base
 
     public function transformation(?Template $template = null) : Transformation
     {
-        return new Transformation($template ?: $this->template(), '', '', '', '');
+        return new Transformation($template ?? $this->template(), '', '', '', '');
     }
 
     public function transformer(?Template\Collection $templateCollection = null) : Transformer


### PR DESCRIPTION
This PR propose replacing some usage of elvis operator (?:) by the null coalesce operator (??)

The latter is less confusing and less error prone.

The former will make implicit cast under the hood when necessary and other weird behaviour.

For example, if used with a string:

```
$a = 'a';
var_dump($a ?: '');
```
This code will work fine, but if $a contains the string '0', it will actually be replaced by an empty string


I have a little doubt about two cases, in ClassAssembler.php and FileAssembler.php. If extractPackageFromDocBlock can return an empty string, it was replaced by default package before and now it will stay an empty string. Is this possible?