### PR TITLE
Fix #2466 - XML template - description of property empty

### DIFF
--- a/data/templates/xml/property.xml.twig
+++ b/data/templates/xml/property.xml.twig
@@ -2,7 +2,7 @@
 <property namespace="{{ property.namespace }}" line="{{ property.line }}" visibility="{{ property.visibility }}">
     <name>{{ property.name }}</name>
     <full_name>{{ property.fullyQualifiedStructuralElementName }}</full_name>
-    <default>{{ property.value }}</default>
+    <default>{{ property.default }}</default>
     {% if inherited_from %}<inherited_from>{{ inherited_from }}</inherited_from>{% endif %}
-    {{ include('docblock.xml.twig', {descriptor: c}) }}
+    {{ include('docblock.xml.twig', {descriptor: property}) }}
 </property>

--- a/tests/functional/assets/core/issues/issue-2466/issue-2466.php
+++ b/tests/functional/assets/core/issues/issue-2466/issue-2466.php
@@ -1,0 +1,17 @@
+<?php
+    
+    /**
+     * Class Issue2466
+     *
+     */
+    class Issue2466
+    {
+        /**
+         * This is a description of the property
+         *
+         * Here is more detailed explanation of what this property is for.
+         *
+         * @var string
+         */
+        public $testProperty = 'default';
+    }

--- a/tests/functional/phpDocumentor/FunctionalTestCase.php
+++ b/tests/functional/phpDocumentor/FunctionalTestCase.php
@@ -59,5 +59,10 @@ class FunctionalTestCase extends TestCase
     {
         return unserialize(file_get_contents($this->workingDir . '/ast.dump'));
     }
+    
+    protected function loadContents($filename) : string
+    {
+        return file_get_contents($this->workingDir . '/' . $filename);
+    }
 
 }

--- a/tests/functional/phpDocumentor/issues/Issue2466FunctionalTest.php
+++ b/tests/functional/phpDocumentor/issues/Issue2466FunctionalTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace functional\phpDocumentor\issues;
+
+use phpDocumentor\Descriptor\ClassDescriptor;
+use phpDocumentor\Descriptor\ConstantDescriptor;
+use phpDocumentor\Descriptor\MethodDescriptor;
+use phpDocumentor\Descriptor\PropertyDescriptor;
+use phpDocumentor\FunctionalTestCase;
+
+final class Issue2466FunctionalTest extends FunctionalTestCase
+{
+    public function testConstantEscapedValueIsProcessedCorrectly() : void
+    {
+        $this->runPHPDocWithFile(__DIR__ . '/../../assets/core/issues/issue-2466/issue-2466.php', ['--template=xml', '-tout', ]);
+        $xml = $this->loadContents('out/structure.xml');
+
+        $this->assertStringContainsString('<default>&#039;default&#039;</default>', $xml);;
+        $this->assertStringContainsString('<description>This is a description of the property</description>', $xml);;
+        $this->assertStringContainsString('<long-description>Here is more detailed explanation of what this property is for.</long-description>', $xml);;
+    }
+}

--- a/tests/functional/phpDocumentor/issues/Issue2466FunctionalTest.php
+++ b/tests/functional/phpDocumentor/issues/Issue2466FunctionalTest.php
@@ -12,7 +12,7 @@ use phpDocumentor\FunctionalTestCase;
 
 final class Issue2466FunctionalTest extends FunctionalTestCase
 {
-    public function testConstantEscapedValueIsProcessedCorrectly() : void
+    public function testPropertyXmlContainsExpectedValues() : void
     {
         $this->runPHPDocWithFile(__DIR__ . '/../../assets/core/issues/issue-2466/issue-2466.php', ['--template=xml', '-tout', ]);
         $xml = $this->loadContents('out/structure.xml');


### PR DESCRIPTION
Fixes #2466 
- replace twig variables with the updated names
- add a functional test for the xml output containing the expected outputs