### PR TITLE
reintroduce unused code detection

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorLevel="6"
+    findUnusedVariablesAndParams="true"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/Guides/Metas.php
+++ b/src/Guides/Metas.php
@@ -119,7 +119,7 @@ final class Metas
      */
     private function doesLinkExist(array $links, string $link) : bool
     {
-        foreach ($links as $name => $url) {
+        foreach ($links as $name => $_url) {
             if ($name === strtolower($link)) {
                 return true;
             }

--- a/src/Guides/Nodes/TableNode.php
+++ b/src/Guides/Nodes/TableNode.php
@@ -168,7 +168,7 @@ class TableNode extends Node
             return;
         }
 
-        foreach ($this->data as $i => $row) {
+        foreach ($this->data as $row) {
             foreach ($row->getColumns() as $col) {
                 $lines = explode("\n", $col->getContent());
 
@@ -506,7 +506,7 @@ class TableNode extends Node
         }
 
         // one more loop to set headers
-        foreach ($rows as $rowIndex => $row) {
+        foreach ($rows as $rowIndex => $_row) {
             if ($rowIndex > $finalHeadersRow) {
                 continue;
             }

--- a/src/Guides/References/ResolvedReference.php
+++ b/src/Guides/References/ResolvedReference.php
@@ -86,7 +86,7 @@ class ResolvedReference
      */
     private function validateAttributes(array $attributes) : void
     {
-        foreach ($attributes as $attribute => $value) {
+        foreach ($attributes as $attribute => $_value) {
             if (!is_string($attribute)
                 || $attribute === 'href'
                 || !(bool) preg_match('/^[a-zA-Z\_][\w\.\-_]+$/', $attribute)

--- a/src/Guides/Renderers/Html/TocNodeRenderer.php
+++ b/src/Guides/Renderers/Html/TocNodeRenderer.php
@@ -74,7 +74,7 @@ class TocNodeRenderer implements NodeRenderer
         int $level,
         array &$tocItems
     ) : void {
-        foreach ($titles as $k => $entry) {
+        foreach ($titles as $entry) {
             [$title, $children] = $entry;
 
             [$title, $target] = $this->generateTarget($url, $title);

--- a/src/Guides/RestructuredText/Builder/Scanner.php
+++ b/src/Guides/RestructuredText/Builder/Scanner.php
@@ -58,7 +58,7 @@ class Scanner
         }
 
         $parseQueue = new Files();
-        foreach ($this->fileInfos as $filename => $fileInfo) {
+        foreach ($this->fileInfos as $filename => $_fileInfo) {
             if (!$this->doesFileRequireParsing($filename)) {
                 continue;
             }


### PR DESCRIPTION
This PR aims to reintroduce unused code detection that has been disabled earlier due to a bug in Psalm.

I believe this should now be fixed (at least in latest version) so I try to run it against the CI to check