### PR TITLE
introduce VersionObject

### DIFF
--- a/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
+++ b/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
@@ -63,12 +63,12 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
         $configuration = $this->overwriteSettings($configuration);
 
         if (!isset($configuration['phpdocumentor']['versions'])) {
-            $configuration['phpdocumentor']['versions'][] = $this->createDefaultVersionSettings();
+            $configuration['phpdocumentor']['versions']['1.0.0'] = $this->createDefaultVersionSettings();
         }
 
         if ($this->shouldReduceNumberOfVersionsToOne($configuration)) {
             $configuration['phpdocumentor']['versions'] = [
-                end($configuration['phpdocumentor']['versions']),
+                '1.0.0' => end($configuration['phpdocumentor']['versions']),
             ];
         }
 

--- a/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
+++ b/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
@@ -48,9 +48,9 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     public function __invoke(array $configuration, ?UriInterface $uri = null) : array
@@ -91,9 +91,9 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function overwriteDestinationFolder(array $configuration) : array
@@ -110,9 +110,9 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
     /**
      * Changes the given configuration array so that the cache handling is disabled.
      *
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function disableCache(array $configuration) : array
@@ -126,9 +126,9 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function overwriteCacheFolder(array $configuration) : array
@@ -142,9 +142,9 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function overwriteTitle(array $configuration) : array
@@ -160,9 +160,9 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
     /**
      * Changes the given configuration array to feature the templates from the options.
      *
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function overwriteTemplates(array $configuration) : array
@@ -179,14 +179,7 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
         return $configuration;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function setFilesInPath(array $version) : array
+    private function setFilesInPath(VersionSpecification $version) : VersionSpecification
     {
         $filename = $this->options['filename'] ?? null;
         if (!$filename) {
@@ -195,12 +188,12 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
 
         $filename = explode(',', implode(',', $filename));
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
-        $version['api'][0]['source']['paths'] = array_map(
-            static function ($path) {
+        $version->api[0]['source']['paths'] = array_map(
+            static function ($path) : Path {
                 return new Path($path);
             },
             $filename
@@ -209,14 +202,7 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function setDirectoriesInPath(array $version) : array
+    private function setDirectoriesInPath(VersionSpecification $version) : VersionSpecification
     {
         /** @var string|string[]|null $directory */
         $directory = $this->options['directory'] ?? '';
@@ -228,7 +214,7 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
         // all values split
         $directory = explode(',', implode(',', $directory));
 
-        $currentApiConfig = current($version['api'] ?? []);
+        $currentApiConfig = current($version->getApi() ?? []);
         if (!$currentApiConfig) {
             $currentApiConfig = current($this->createDefaultApiSettings());
         }
@@ -236,7 +222,7 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
         // Reset the current config, because directory is overwriting the config.
         $currentApiConfig['source']['paths'] = [];
 
-        $version['api'] = [];
+        $version->setApi([]);
         foreach ($directory as $path) {
             // If the passed directory is an absolute path this should be handled as a new Api
             // A version may contain multiple APIs.
@@ -245,62 +231,48 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
                 $apiConfig['source']['dsn'] = Dsn::createFromString($path);
                 $apiConfig['source']['paths'] = [new Path('./')];
 
-                $version['api'][] = $apiConfig;
+                $version->addApi($apiConfig);
             } else {
                 $currentApiConfig['source']['paths'][] = new Path($path);
             }
         }
 
         if (count($currentApiConfig['source']['paths']) > 0) {
-            $version['api'][] = $currentApiConfig;
+            $version->addApi($currentApiConfig);
         }
 
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function registerExtensions(array $version) : array
+    private function registerExtensions(VersionSpecification $version) : VersionSpecification
     {
         if (!isset($this->options['extensions']) || !$this->options['extensions']) {
             return $version;
         }
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
         Assert::isArray($this->options['extensions']);
 
-        $version['api'][0]['extensions'] = $this->options['extensions'];
+        $version->api[0]['extensions'] = $this->options['extensions'];
 
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function overwriteIgnoredPaths(array $version) : array
+    private function overwriteIgnoredPaths(VersionSpecification $version) : VersionSpecification
     {
         if (!isset($this->options['ignore']) || !$this->options['ignore']) {
             return $version;
         }
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
-        $version['api'][0]['ignore']['paths'] = array_map(
-            static function ($path) {
+        $version->api[0]['ignore']['paths'] = array_map(
+            static function ($path) : Path {
                 return new Path($path);
             },
             $this->options['ignore']
@@ -309,84 +281,56 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function overwriteIgnoredTags(array $version) : array
+    private function overwriteIgnoredTags(VersionSpecification $version) : VersionSpecification
     {
         if (!isset($this->options['ignore-tags']) || !$this->options['ignore-tags']) {
             return $version;
         }
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
         Assert::isArray($this->options['ignore-tags']);
 
-        $version['api'][0]['ignore-tags'] = $this->options['ignore-tags'];
+        $version->api[0]['ignore-tags'] = $this->options['ignore-tags'];
 
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function overwriteMarkers(array $version) : array
+    private function overwriteMarkers(VersionSpecification $version) : VersionSpecification
     {
         if (!isset($this->options['markers']) || !$this->options['markers']) {
             return $version;
         }
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
         Assert::isArray($this->options['markers']);
 
-        $version['api'][0]['markers'] = $this->options['markers'];
+        $version->api[0]['markers'] = $this->options['markers'];
 
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function overwriteIncludeSource(array $version) : array
+    private function overwriteIncludeSource(VersionSpecification $version) : VersionSpecification
     {
         if (!isset($this->options['sourcecode'])) {
             return $version;
         }
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
-        $version['api'][0]['include-source'] = $this->options['sourcecode'];
+        $version->api[0]['include-source'] = $this->options['sourcecode'];
 
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function overwriteVisibility(array $version) : array
+    private function overwriteVisibility(VersionSpecification $version) : VersionSpecification
     {
         /** @var string[]|string|null $visibilityFlags */
         $visibilityFlags = $this->options['visibility'] ?? null;
@@ -394,46 +338,32 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
             return $version;
         }
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
         $visibilities = array_unique(explode(',', implode(',', $visibilityFlags)));
-        $version['api'][0]['visibility'] = $visibilities;
+        $version->api[0]['visibility'] = $visibilities;
 
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function overwriteDefaultPackageName(array $version) : array
+    private function overwriteDefaultPackageName(VersionSpecification $version) : VersionSpecification
     {
         if (!isset($this->options['defaultpackagename']) || !$this->options['defaultpackagename']) {
             return $version;
         }
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
-        $version['api'][0]['default-package-name'] = $this->options['defaultpackagename'];
+        $version->api[0]['default-package-name'] = $this->options['defaultpackagename'];
 
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function overwriteExamples(array $version) : array
+    private function overwriteExamples(VersionSpecification $version) : VersionSpecification
     {
         /** @var string|null $examples */
         $examples = $this->options['examples-dir'] ?? null;
@@ -441,11 +371,11 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
             return $version;
         }
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
-        $version['api'][0]['examples'] = [
+        $version->api[0]['examples'] = [
             'dsn' => Dsn::createFromString($examples),
             'paths' => ['./'],
         ];
@@ -453,24 +383,19 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
         return $version;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function createDefaultVersionSettings() : array
+    private function createDefaultVersionSettings() : VersionSpecification
     {
         return current($this->configFactory->createDefault()['phpdocumentor']['versions']);
     }
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @return array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>
+     * @return array<int, array{source: array{dsn: Dsn, paths: array<Path>}, output?: string, ignore?: array{paths: non-empty-array<Path>}, extensions?: non-empty-list<string>, visibility?: array<string>, default-package-name?: string, include-source?: bool, markers?: non-empty-list<string>, ignore-tags?: non-empty-list<string>, examples?: array{dsn: Dsn, paths: list<string>}}>
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function createDefaultApiSettings() : array
     {
-        return $this->createDefaultVersionSettings()['api'];
+        return $this->createDefaultVersionSettings()->getApi();
     }
 
     //phpcs:disable Generic.Files.LineLength.TooLong
@@ -478,7 +403,7 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
      * If the source path was influenced; we can no longer reliable render multiple versions as such we reduce
      * the list of versions to the last one; assuming that is the most recent / desirable one.
      *
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function shouldReduceNumberOfVersionsToOne(array $configuration) : bool
@@ -489,9 +414,9 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function overwriteSettings(array $configuration) : array
@@ -521,14 +446,7 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
         return $configuration;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
-    /**
-     * @param array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array} $version
-     *
-     * @return array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}
-     */
-    //phpcs:enable Generic.Files.LineLength.TooLong
-    private function overwriteEncoding(array $version) : array
+    private function overwriteEncoding(VersionSpecification $version) : VersionSpecification
     {
         /** @var string|null $encoding */
         $encoding = $this->options['encoding'] ?? null;
@@ -536,11 +454,11 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
             return $version;
         }
 
-        if (!isset($version['api'])) {
-            $version['api'] = $this->createDefaultApiSettings();
+        if (($version->getApi() ?? []) === []) {
+            $version->setApi($this->createDefaultApiSettings());
         }
 
-        $version['api'][0]['encoding'] = $encoding;
+        $version->api[0]['encoding'] = $encoding;
 
         return $version;
     }

--- a/src/phpDocumentor/Configuration/ConfigurationFactory.php
+++ b/src/phpDocumentor/Configuration/ConfigurationFactory.php
@@ -15,7 +15,6 @@ namespace phpDocumentor\Configuration;
 
 use League\Uri\Contracts\UriInterface;
 use phpDocumentor\Configuration\Exception\InvalidConfigPathException;
-use phpDocumentor\Dsn;
 use phpDocumentor\UriFactory;
 use function file_exists;
 use function sprintf;
@@ -108,9 +107,9 @@ use function sprintf;
     /**
      * Applies all middleware callbacks onto the configuration.
      *
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function applyMiddleware(array $configuration, ?UriInterface $uri) : array

--- a/src/phpDocumentor/Configuration/Definition/Normalizable.php
+++ b/src/phpDocumentor/Configuration/Definition/Normalizable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration\Definition;
 
+use phpDocumentor\Configuration\VersionSpecification;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
 
@@ -11,9 +12,9 @@ interface Normalizable
 {
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>} $configuration
+     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, mixed>, settings?: array<mixed>, templates?: non-empty-list<string>} $configuration
      *
-     * @return array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}
+     * @return array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     public function normalize(array $configuration) : array;

--- a/src/phpDocumentor/Configuration/Definition/Upgradable.php
+++ b/src/phpDocumentor/Configuration/Definition/Upgradable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration\Definition;
 
-use phpDocumentor\Dsn;
+use phpDocumentor\Configuration\VersionSpecification;
 
 interface Upgradable
 {
@@ -23,7 +23,7 @@ interface Upgradable
      * The 'configVersion' field in the result will inform the ConfigurationFactory what the next Configuration
      * definition should be used to parse this result.
      *
-     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>, transformer: array{target: string}, parser: array{target: string, default-package-name: string, extensions: array{extensions: array}, visibility: string, markers: array{items: array}}, files: array{files: array, directories: array, ignores: array}, transformations: array{templates: array<string>}} $values
+     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>, transformer: array{target: string}, parser: array{target: string, default-package-name: string, extensions: array{extensions: array}, visibility: string, markers: array{items: array}}, files: array{files: array, directories: array, ignores: array}, transformations: array{templates: array<string>}} $values
      *
      * @return array{configVersion: string, paths: array{cache: string, output: string}, templates: non-empty-list<string>, title: string, version: array{array{api: array{array{default-package-name: mixed, extensions: array{extensions: mixed}, ignore: array{paths: array<string>}, markers: array{markers: mixed}, source: array{paths: array<string>}, visibilities: non-empty-list<string>|null}}, number: string}}}
      */

--- a/src/phpDocumentor/Configuration/Definition/Version2.php
+++ b/src/phpDocumentor/Configuration/Definition/Version2.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Configuration\Definition;
 
 use phpDocumentor\Configuration\SymfonyConfigFactory;
-use phpDocumentor\Dsn;
+use phpDocumentor\Configuration\VersionSpecification;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use function array_map;
@@ -152,7 +152,7 @@ final class Version2 implements ConfigurationInterface, Upgradable
     /**
      * Upgrades the version 2 configuration to the version 3 configuration.
      *
-     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>, transformer: array{target: string}, parser: array{target: string, default-package-name: string, extensions: array{extensions: array}, visibility: string, markers: array{items: array}}, files: array{files: array, directories: array, ignores: array}, transformations: array{templates: array<string>}} $values
+     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>, transformer: array{target: string}, parser: array{target: string, default-package-name: string, extensions: array{extensions: array}, visibility: string, markers: array{items: array}}, files: array{files: array, directories: array, ignores: array}, transformations: array{templates: array<string>}} $values
      *
      * @return array{configVersion: string, title: string, paths: array{cache: string, output: string}, templates: non-empty-list<string>, version: array{array{api: array{array{default-package-name: string, extensions: array{extensions: array}, ignore: array{paths: array<string>}, markers: array{markers: array}, source: array{paths: array<string>}, visibilities: non-empty-list<string>|null}}, number: string}}}
      *

--- a/src/phpDocumentor/Configuration/MiddlewareInterface.php
+++ b/src/phpDocumentor/Configuration/MiddlewareInterface.php
@@ -21,9 +21,9 @@ interface MiddlewareInterface
 {
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string|Dsn, cache: string|Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     public function __invoke(array $configuration, ?UriInterface $uri = null) : array;

--- a/src/phpDocumentor/Configuration/ProvideTemplateOverridePathMiddleware.php
+++ b/src/phpDocumentor/Configuration/ProvideTemplateOverridePathMiddleware.php
@@ -44,9 +44,9 @@ final class ProvideTemplateOverridePathMiddleware implements MiddlewareInterface
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     public function __invoke(array $configuration, ?UriInterface $pathOfConfigFile = null) : array

--- a/src/phpDocumentor/Configuration/SymfonyConfigFactory.php
+++ b/src/phpDocumentor/Configuration/SymfonyConfigFactory.php
@@ -17,7 +17,6 @@ use phpDocumentor\Configuration\Definition\Normalizable;
 use phpDocumentor\Configuration\Definition\Upgradable;
 use phpDocumentor\Configuration\Exception\UnSupportedConfigVersionException;
 use phpDocumentor\Configuration\Exception\UpgradeFailedException;
-use phpDocumentor\Dsn;
 use RuntimeException;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Processor;
@@ -43,7 +42,7 @@ class SymfonyConfigFactory
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     public function createFromFile(string $filename) : array
@@ -56,7 +55,7 @@ class SymfonyConfigFactory
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     public function createDefault() : array
@@ -68,9 +67,9 @@ class SymfonyConfigFactory
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>} $values
+     * @param array<mixed> $values
      *
-     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}}
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function generateConfiguration(array $values) : array
@@ -96,9 +95,9 @@ class SymfonyConfigFactory
      * Configuration definition) then it will do so and re-run this method with the upgraded values. The 'configVersion'
      * field will tell which definition should be used; when none is provided then a version 2 configuration is assumed.
      *
-     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>} $values
+     * @param array{configVersion?: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, mixed>, settings?: array<mixed>, templates?: non-empty-list<string>} $values
      *
-     * @return array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}
+     * @return array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function processConfiguration(array $values) : array
@@ -137,9 +136,9 @@ class SymfonyConfigFactory
 
     //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>, transformer: array{target: string}, parser: array{target: string, default-package-name: string, extensions: array{extensions: array}, visibility: string, markers: array{items: array}}, files: array{files: array, directories: array, ignores: array}, transformations: array{templates: array}} $configuration
+     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>, transformer: array{target: string}, parser: array{target: string, default-package-name: string, extensions: array{extensions: array}, visibility: string, markers: array{items: array}}, files: array{files: array, directories: array, ignores: array}, transformations: array{templates: array}} $configuration
      *
-     * @return array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, apis: array, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}
+     * @return array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}
      */
     //phpcs:enable Generic.Files.LineLength.TooLong
     private function upgradeConfiguration(Upgradable $definition, array $configuration) : array

--- a/src/phpDocumentor/Configuration/VersionSpecification.php
+++ b/src/phpDocumentor/Configuration/VersionSpecification.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Configuration;
+
+use phpDocumentor\Dsn;
+use phpDocumentor\Path;
+
+class VersionSpecification
+{
+    /** @var string */
+    private $number;
+
+    /**
+     * @var array<
+     *     int,
+     *     array{
+     *         source: array{dsn: Dsn, paths: array<Path>},
+     *         output?: string,
+     *         ignore?: array{paths: non-empty-array<Path>},
+     *         extensions?: non-empty-list<string>,
+     *         visibility?: array<string>,
+     *         default-package-name?: string,
+     *         include-source?: bool,
+     *         markers?: non-empty-list<string>,
+     *         ignore-tags?: non-empty-list<string>,
+     *         examples?: array{dsn: Dsn, paths: list<string>},
+     *         encoding?: string,
+     *         validate?: bool
+     *     }>
+     */
+    public $api;
+
+    /** @var array<mixed>|null */
+    public $guides;
+
+    //phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName squizlabs/PHP_CodeSniffer/issues/2591
+    /**
+     * @param array<
+     *     int,
+     *     array{
+     *         source: array{dsn: Dsn, paths: array<Path>},
+     *         output?: string,
+     *         ignore?: array{paths: non-empty-array<Path>},
+     *         extensions?: non-empty-list<string>,
+     *         visibility?: array<string>,
+     *         default-package-name?: string,
+     *         include-source?: bool,
+     *         markers?: non-empty-list<string>,
+     *         ignore-tags?: non-empty-list<string>,
+     *         examples?: array{dsn: Dsn, paths: list<string>}
+     *     }> $api
+     * @param array<mixed>|null $guides
+     */
+    //phpcs:enable Squiz.Commenting.FunctionComment.MissingParamName
+    public function __construct(string $number, array $api, ?array $guides)
+    {
+        $this->number = $number;
+        $this->api = $api;
+        $this->guides = $guides;
+    }
+
+    public function getNumber() : string
+    {
+        return $this->number;
+    }
+
+    /**
+     * @return array<
+     *     int,
+     *     array{
+     *         source: array{dsn: Dsn, paths: array<Path>},
+     *         output?: string,
+     *         ignore?: array{paths: non-empty-array<Path>},
+     *         extensions?: non-empty-list<string>,
+     *         visibility?: array<string>,
+     *         default-package-name?: string,
+     *         include-source?: bool,
+     *         markers?: non-empty-list<string>,
+     *         ignore-tags?: non-empty-list<string>,
+     *         examples?: array{dsn: Dsn, paths: list<string>}
+     *     }>
+     */
+    public function getApi() : array
+    {
+        return $this->api;
+    }
+
+    //phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName squizlabs/PHP_CodeSniffer/issues/2591
+    /**
+     * @param array<
+     *     int,
+     *     array{
+     *         source: array{dsn: Dsn, paths: array<Path>},
+     *         output?: string,
+     *         ignore?: array{paths: non-empty-array<Path>},
+     *         extensions?: non-empty-list<string>,
+     *         visibility?: array<string>,
+     *         default-package-name?: string,
+     *         include-source?: bool,
+     *         markers?: non-empty-list<string>,
+     *         ignore-tags?: non-empty-list<string>,
+     *         examples?: array{dsn: Dsn, paths: list<string>}
+     *     }> $api
+     */
+    //phpcs:enable Squiz.Commenting.FunctionComment.MissingParamName
+    public function setApi(array $api) : void
+    {
+        $this->api = $api;
+    }
+
+    //phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName squizlabs/PHP_CodeSniffer/issues/2591
+    /**
+     * @param array{
+     *         source: array{dsn: Dsn, paths: array<Path>},
+     *         output?: string,
+     *         ignore?: array{paths: non-empty-array<Path>},
+     *         extensions?: non-empty-list<string>,
+     *         visibility?: array<string>,
+     *         default-package-name?: string,
+     *         include-source?: bool,
+     *         markers?: non-empty-list<string>,
+     *         ignore-tags?: non-empty-list<string>,
+     *         examples?: array{dsn: Dsn, paths: list<string>}
+     *     } $api
+     */
+    //phpcs:enable Squiz.Commenting.FunctionComment.MissingParamName
+    public function addApi(array $api) : void
+    {
+        $this->api[] = $api;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getGuides() : ?array
+    {
+        return $this->guides;
+    }
+}

--- a/src/phpDocumentor/Descriptor/ApiSetDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ApiSetDescriptor.php
@@ -14,13 +14,12 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use phpDocumentor\Dsn;
+use phpDocumentor\Path;
 
 final class ApiSetDescriptor extends DocumentationSetDescriptor
 {
     /**
-     * @param array<Dsn|list<string>> $source
-     *
-     * @phpstan-param array{dsn: Dsn, paths: list<string>} $source
+     * @param array{dsn: Dsn, paths: array<Path>} $source
      */
     public function __construct(string $name, array $source, string $output)
     {

--- a/src/phpDocumentor/Descriptor/DocumentationSetDescriptor.php
+++ b/src/phpDocumentor/Descriptor/DocumentationSetDescriptor.php
@@ -14,17 +14,15 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use phpDocumentor\Dsn;
+use phpDocumentor\Path;
 
 abstract class DocumentationSetDescriptor
 {
     /** @var string */
     protected $name = '';
 
-    /**
-     * @phpstan-var array{dsn?: Dsn, paths?: list<string>}
-     * @var array<Dsn|list<string>>
-     */
-    protected $source = [];
+    /** @var array{dsn: Dsn, paths: array<Path|string>} */
+    protected $source;
 
     /** @var string */
     protected $output = '.';
@@ -40,13 +38,11 @@ abstract class DocumentationSetDescriptor
      * The returned array contains an element 'dsn' (of type DSN) and 'paths'; where each path represents one part
      * of the documentation set relative to the DSN.
      *
-     * @return array<Dsn|list<string>>
+     * @return array{dsn: Dsn, paths: array<Path|string>}
      *
      * @todo: should the source location be included in a Descriptor? This couples it to the file system upon which
      *   it was ran and makes it uncacheable. But should this be cached? In any case, I need it for the RenderGuide
      *   writer at the moment; so refactor this once that becomes clearer.
-     *
-     * @phpstan-return array{dsn?: Dsn, paths?: list<string>}
      */
     public function getSource() : array
     {

--- a/src/phpDocumentor/Descriptor/GuideSetDescriptor.php
+++ b/src/phpDocumentor/Descriptor/GuideSetDescriptor.php
@@ -18,9 +18,7 @@ use phpDocumentor\Dsn;
 final class GuideSetDescriptor extends DocumentationSetDescriptor
 {
     /**
-     * @param array<Dsn|list<string>> $source
-     *
-     * @phpstan-param array{dsn: Dsn, paths: list<string>} $source
+     * @param array{dsn: Dsn, paths: array<string>} $source
      */
     public function __construct(string $name, array $source, string $output)
     {

--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -198,11 +198,10 @@ class ProjectDescriptorBuilder
     }
 
     /**
-     * @param array<string, array<string>> $apiConfig
+     * @param array<string> $visibilities
      */
-    public function setVisibility(array $apiConfig) : void
+    public function setVisibility(array $visibilities) : void
     {
-        $visibilities = $apiConfig['visibility'];
         $visibility = 0;
 
         foreach ($visibilities as $item) {

--- a/src/phpDocumentor/Descriptor/VersionDescriptor.php
+++ b/src/phpDocumentor/Descriptor/VersionDescriptor.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor;
 
+use phpDocumentor\Configuration\VersionSpecification;
+
 final class VersionDescriptor
 {
     /** @var string */
@@ -43,21 +45,18 @@ final class VersionDescriptor
         return $this->documentationSets;
     }
 
-    /**
-     * @param array<mixed> $config
-     */
-    public static function fromConfiguration(array $config) : self
+    public static function fromConfiguration(VersionSpecification $config) : self
     {
         $documentationSets = Collection::fromClassString(DocumentationSetDescriptor::class);
 
-        foreach ($config['guides'] ?? [] as $guide) {
+        foreach ($config->getGuides() ?? [] as $guide) {
             $documentationSets->add(new GuideSetDescriptor('', $guide['source'], $guide['output']));
         }
 
-        foreach ($config['api'] ?? [] as $api) {
+        foreach ($config->getApi() ?? [] as $api) {
             $documentationSets->add(new ApiSetDescriptor('', $api['source'], $api['output']));
         }
 
-        return new self($config['number'], $documentationSets);
+        return new self($config->getNumber(), $documentationSets);
     }
 }

--- a/src/phpDocumentor/Parser/FileCollector.php
+++ b/src/phpDocumentor/Parser/FileCollector.php
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace phpDocumentor\Parser;
 
 use phpDocumentor\Dsn;
+use phpDocumentor\Path;
 use phpDocumentor\Reflection\File;
 
 interface FileCollector
 {
     /**
      * @param Dsn                  $dsn        dsn of source.
-     * @param list<string>         $paths
+     * @param list<string|Path>    $paths
      * @param array<string, mixed> $ignore     array containing keys 'paths' and 'hidden'
      * @param list<string>         $extensions
      *

--- a/src/phpDocumentor/Parser/FlySystemCollector.php
+++ b/src/phpDocumentor/Parser/FlySystemCollector.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Parser;
 
 use phpDocumentor\Dsn;
+use phpDocumentor\Path;
 
 final class FlySystemCollector implements FileCollector
 {
@@ -30,7 +31,7 @@ final class FlySystemCollector implements FileCollector
     }
 
     /**
-     * @param list<string>         $paths
+     * @param list<string|Path>    $paths
      * @param array<string, mixed> $ignore
      * @param list<string>         $extensions
      *

--- a/src/phpDocumentor/Parser/SpecificationFactory.php
+++ b/src/phpDocumentor/Parser/SpecificationFactory.php
@@ -19,6 +19,7 @@ use Flyfinder\Specification\IsHidden;
 use Flyfinder\Specification\NotSpecification;
 use Flyfinder\Specification\SpecificationInterface;
 use phpDocumentor\Parser\SpecificationFactoryInterface as FactoryInterface;
+use phpDocumentor\Path;
 
 /**
  * Factory class to build Specification used by FlyFinder when reading files to process.
@@ -28,7 +29,7 @@ final class SpecificationFactory implements FactoryInterface
     /**
      * Creates a SpecificationInterface object based on the ignore and extension parameters.
      *
-     * @param list<string> $paths
+     * @param list<string|Path> $paths
      * @param array<string, bool|array<string>|null> $ignore
      * @param list<string> $extensions
      */

--- a/src/phpDocumentor/Parser/SpecificationFactoryInterface.php
+++ b/src/phpDocumentor/Parser/SpecificationFactoryInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Parser;
 
 use Flyfinder\Specification\SpecificationInterface;
+use phpDocumentor\Path;
 
 /**
  * Interface for Specifications used to filter the FileSystem.
@@ -23,7 +24,7 @@ interface SpecificationFactoryInterface
     /**
      * Creates a SpecificationInterface object based on the ignore and extension parameters.
      *
-     * @param list<string> $paths
+     * @param list<string|Path> $paths
      * @param array<string, bool|array<string>|null> $ignore
      * @param list<string> $extensions
      */

--- a/src/phpDocumentor/Pipeline/Stage/Parser/ParseFiles.php
+++ b/src/phpDocumentor/Pipeline/Stage/Parser/ParseFiles.php
@@ -49,7 +49,7 @@ final class ParseFiles
         $apiConfig = current($payload->getApiConfigs());
 
         $builder = $payload->getBuilder();
-        $builder->setVisibility($apiConfig);
+        $builder->setVisibility($apiConfig['visibility']);
         $builder->setMarkers($apiConfig['markers']);
         $builder->setIncludeSource($apiConfig['include-source']);
         $builder->setIgnoredTags($apiConfig['ignore-tags']);

--- a/src/phpDocumentor/Pipeline/Stage/Parser/ParseGuides.php
+++ b/src/phpDocumentor/Pipeline/Stage/Parser/ParseGuides.php
@@ -58,7 +58,7 @@ final class ParseGuides
              * For now settings of the first guides are used.
              * We need to change this later, when we accept more different things
              */
-            $config = current(current($payload->getConfig()['phpdocumentor']['versions'])['guides']);
+            $config = current(current($payload->getConfig()['phpdocumentor']['versions'])->guides);
             $dsn = $config['source']['dsn'];
             $inputFormat = $config['format'];
 

--- a/src/phpDocumentor/Pipeline/Stage/Parser/Payload.php
+++ b/src/phpDocumentor/Pipeline/Stage/Parser/Payload.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage\Parser;
 
+use phpDocumentor\Configuration\VersionSpecification;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
+use phpDocumentor\Dsn;
+use phpDocumentor\Path;
 use phpDocumentor\Pipeline\Stage\Payload as ApplicationPayload;
 use phpDocumentor\Reflection\File;
 use function array_merge;
@@ -24,25 +27,29 @@ final class Payload extends ApplicationPayload
     /** @var File[] */
     private $files;
 
+    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array<string, string|array<mixed>> $config
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $config
      * @param File[] $files
      */
+    //phpcs:enable Generic.Files.LineLength.TooLong
     public function __construct(array $config, ProjectDescriptorBuilder $builder, array $files = [])
     {
         parent::__construct($config, $builder);
         $this->files = $files;
     }
 
+    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @return list<array<array<mixed>|bool|string>>
+     * @return array<int, array{source: array{dsn: Dsn, paths: array<Path>}, output?: string, ignore?: array{paths: non-empty-array<Path>}, extensions?: non-empty-list<string>, visibility?: array<string>, default-package-name?: string, include-source?: bool, markers?: non-empty-list<string>, ignore-tags?: non-empty-list<string>, examples?: array{dsn: Dsn, paths: list<string>}, encoding?: string, validate?: bool}>
      */
+    //phpcs:enable Generic.Files.LineLength.TooLong
     public function getApiConfigs() : array
     {
         // Grep only the first version for now. Multi version support will be added later
         $version = current($this->getConfig()['phpdocumentor']['versions']);
 
-        return $version['api'];
+        return $version->getApi();
     }
 
     /**

--- a/src/phpDocumentor/Pipeline/Stage/Payload.php
+++ b/src/phpDocumentor/Pipeline/Stage/Payload.php
@@ -13,28 +13,37 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage;
 
+use phpDocumentor\Configuration\VersionSpecification;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
+use phpDocumentor\Dsn;
+use phpDocumentor\Path;
 
 class Payload
 {
-    /** @var array<string, string|array<mixed>> */
+    //phpcs:disable Generic.Files.LineLength.TooLong
+    /** @var array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} */
+    //phpcs:enable Generic.Files.LineLength.TooLong
     private $config;
 
     /** @var ProjectDescriptorBuilder */
     private $builder;
 
+    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array<string, string|array<mixed>> $config
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $config
      */
+    //phpcs:enable Generic.Files.LineLength.TooLong
     public function __construct(array $config, ProjectDescriptorBuilder $builder)
     {
         $this->config = $config;
         $this->builder = $builder;
     }
 
+    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @return array<string, string|array<mixed>>
+     * @return array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}}
      */
+    //phpcs:enable Generic.Files.LineLength.TooLong
     public function getConfig() : array
     {
         return $this->config;

--- a/src/phpDocumentor/Pipeline/Stage/Transform.php
+++ b/src/phpDocumentor/Pipeline/Stage/Transform.php
@@ -132,7 +132,7 @@ final class Transform
     }
 
     /**
-     * @param array<string, string> $templateNames
+     * @param array<int, string> $templateNames
      */
     private function loadTemplatesBasedOnNames(array $templateNames) : void
     {

--- a/src/phpDocumentor/Pipeline/Stage/TransformToPayload.php
+++ b/src/phpDocumentor/Pipeline/Stage/TransformToPayload.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage;
 
+use phpDocumentor\Configuration\VersionSpecification;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
+use phpDocumentor\Dsn;
+use phpDocumentor\Path;
 
 final class TransformToPayload
 {
@@ -25,9 +28,11 @@ final class TransformToPayload
         $this->descriptorBuilder = $descriptorBuilder;
     }
 
+    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array<string, string> $configuration
+     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
      */
+    //phpcs:enable Generic.Files.LineLength.TooLong
     public function __invoke(array $configuration) : Payload
     {
         return new Payload($configuration, $this->descriptorBuilder);

--- a/tests/unit/phpDocumentor/Configuration/CommandlineOptionsMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Configuration/CommandlineOptionsMiddlewareTest.php
@@ -120,7 +120,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
                 'dsn' => Dsn::createFromString('.'),
                 'paths' => [new Path('./src/index.php')],
             ],
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['source']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['source']
         );
     }
 
@@ -139,7 +139,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
                 'dsn' => Dsn::createFromString('.'),
                 'paths' => [new Path('./src')],
             ],
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['source']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['source']
         );
     }
 
@@ -158,7 +158,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
                 'dsn' => Dsn::createFromString('.'),
                 'paths' => ['/**/*'],
             ],
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['source']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['source']
         );
     }
 
@@ -174,7 +174,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
                 'dsn' => Dsn::createFromString('/src'),
                 'paths' => [new Path('./')],
             ],
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['source']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['source']
         );
     }
 
@@ -190,14 +190,14 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
                 'dsn' => Dsn::createFromString('/src'),
                 'paths' => [new Path('./')],
             ],
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['source']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['source']
         );
         $this->assertEquals(
             [
                 'dsn' => Dsn::createFromString('.'),
                 'paths' => [new Path('./localSrc')],
             ],
-            current($newConfiguration['phpdocumentor']['versions'])['api'][1]['source']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[1]['source']
         );
     }
 
@@ -214,7 +214,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
 
         $this->assertEquals(
             $extensions,
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['extensions']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['extensions']
         );
     }
 
@@ -234,7 +234,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
                 'hidden' => true,
                 'symlinks' => true,
             ],
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['ignore']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['ignore']
         );
     }
 
@@ -251,7 +251,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
 
         $this->assertEquals(
             $markers,
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['markers']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['markers']
         );
     }
 
@@ -268,7 +268,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
 
         $this->assertEquals(
             $visibility,
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['visibility']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['visibility']
         );
     }
 
@@ -285,7 +285,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
 
         $this->assertEquals(
             $encoding,
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['encoding']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['encoding']
         );
     }
 
@@ -302,7 +302,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
 
         $this->assertEquals(
             $defaultPackageName,
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['default-package-name']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['default-package-name']
         );
     }
 
@@ -318,7 +318,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
 
         $this->assertEquals(
             true,
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['include-source']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['include-source']
         );
 
         $middleware = $this->createCommandlineOptionsMiddleware(['sourcecode' => false]);
@@ -326,7 +326,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
 
         $this->assertEquals(
             false,
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['include-source']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['include-source']
         );
     }
 
@@ -336,7 +336,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
 
         // wipe version so that middleware needs to re-add the api key
         unset($configuration['phpdocumentor']['versions']);
-        $configuration['phpdocumentor']['versions'] = ['1.0.0' => []];
+        $configuration['phpdocumentor']['versions'] = ['1.0.0' => new VersionSpecification('1.0.0', [], null)];
 
         return $configuration;
     }
@@ -382,7 +382,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
                 'dsn' => Dsn::createFromString('/src'),
                 'paths' => [new Path('./')],
             ],
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['examples']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['examples']
         );
     }
 
@@ -398,7 +398,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
                 'dsn' => Dsn::createFromString('/src'),
                 'paths' => [new Path('./')],
             ],
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['examples']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['examples']
         );
     }
 
@@ -415,7 +415,7 @@ final class CommandlineOptionsMiddlewareTest extends TestCase
 
         $this->assertEquals(
             $tags,
-            current($newConfiguration['phpdocumentor']['versions'])['api'][0]['ignore-tags']
+            current($newConfiguration['phpdocumentor']['versions'])->getApi()[0]['ignore-tags']
         );
     }
 

--- a/tests/unit/phpDocumentor/Configuration/Definition/Version3Test.php
+++ b/tests/unit/phpDocumentor/Configuration/Definition/Version3Test.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Configuration\Definition;
 
 use phpDocumentor\Configuration\SymfonyConfigFactory;
+use phpDocumentor\Configuration\VersionSpecification;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
 use PHPUnit\Framework\TestCase;
@@ -53,17 +54,21 @@ final class Version3Test extends TestCase
         $expected = $this->defaultConfigurationOutput();
         $expected['paths']['output'] = Dsn::createFromString($expected['paths']['output']);
         $expected['paths']['cache'] = new Path($expected['paths']['cache']);
-        $expected['versions']['1.0.0']['api'] = $expected['versions']['1.0.0']['apis'];
-        unset($expected['versions']['1.0.0']['apis']);
-        $expected['versions']['1.0.0']['api'][0]['ignore-tags']
-            = $expected['versions']['1.0.0']['api'][0]['ignore-tags']['ignore_tags'];
-        $expected['versions']['1.0.0']['api'][0]['extensions']
-            = $expected['versions']['1.0.0']['api'][0]['extensions']['extensions'];
-        $expected['versions']['1.0.0']['api'][0]['markers']
-            = $expected['versions']['1.0.0']['api'][0]['markers']['markers'];
-        $expected['versions']['1.0.0']['api'][0]['visibility']
-            = $expected['versions']['1.0.0']['api'][0]['visibilities'];
-        unset($expected['versions']['1.0.0']['api'][0]['visibilities']);
+        $expected['versions']['1.0.0']
+            = new VersionSpecification(
+                '1.0.0',
+                $expected['versions']['1.0.0']['apis'],
+                $expected['versions']['1.0.0']['guides']
+            );
+        $expected['versions']['1.0.0']->api[0]['ignore-tags']
+            = $expected['versions']['1.0.0']->getApi()[0]['ignore-tags']['ignore_tags'];
+        $expected['versions']['1.0.0']->api[0]['extensions']
+            = $expected['versions']['1.0.0']->getApi()[0]['extensions']['extensions'];
+        $expected['versions']['1.0.0']->api[0]['markers']
+            = $expected['versions']['1.0.0']->getApi()[0]['markers']['markers'];
+        $expected['versions']['1.0.0']->api[0]['visibility']
+            = $expected['versions']['1.0.0']->getApi()[0]['visibilities'];
+        unset($expected['versions']['1.0.0']->api[0]['visibilities']);
         $configuration = $definition->normalize($configuration);
 
         $this->assertEquals($expected, $configuration);

--- a/tests/unit/phpDocumentor/Configuration/PathNormalizingMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Configuration/PathNormalizingMiddlewareTest.php
@@ -48,14 +48,14 @@ final class PathNormalizingMiddlewareTest extends TestCase
     public function testNormalizedPathsToGlob(string $input, string $output) : void
     {
         $configuration = $this->givenAConfiguration();
-        $configuration['phpdocumentor']['versions']['1.0.0']['api'][0]['source']['paths'] = [$input];
+        $configuration['phpdocumentor']['versions']['1.0.0']->api[0]['source']['paths'] = [$input];
 
         $middleware = new PathNormalizingMiddleware();
         $outputConfig = $middleware($configuration, Uri::createFromString('./config.xml'));
 
         self::assertEquals(
             [$output],
-            $outputConfig['phpdocumentor']['versions']['1.0.0']['api'][0]['source']['paths']
+            $outputConfig['phpdocumentor']['versions']['1.0.0']->getApi()[0]['source']['paths']
         );
     }
 
@@ -65,14 +65,14 @@ final class PathNormalizingMiddlewareTest extends TestCase
     public function testNormalizedIgnoreToGlob(string $input, string $output) : void
     {
         $configuration = $this->givenAConfiguration();
-        $configuration['phpdocumentor']['versions']['1.0.0']['api'][0]['ignore']['paths'] = [$input];
+        $configuration['phpdocumentor']['versions']['1.0.0']->api[0]['ignore']['paths'] = [$input];
 
         $middleware = new PathNormalizingMiddleware();
         $outputConfig = $middleware($configuration, Uri::createFromString('./config.xml'));
 
         self::assertEquals(
             [$output],
-            $outputConfig['phpdocumentor']['versions']['1.0.0']['api'][0]['ignore']['paths']
+            $outputConfig['phpdocumentor']['versions']['1.0.0']->getApi()[0]['ignore']['paths']
         );
     }
 

--- a/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorBuilderTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorBuilderTest.php
@@ -108,7 +108,7 @@ class ProjectDescriptorBuilderTest extends MockeryTestCase
         int $expectedValue
     ) : void {
         $this->fixture->createProjectDescriptor();
-        $this->fixture->setVisibility(['visibility' => $setting]);
+        $this->fixture->setVisibility($setting);
         $projectSettings = $this->fixture->getProjectDescriptor()->getSettings();
 
         self::assertEquals($expectedValue, $projectSettings->getVisibility());

--- a/tests/unit/phpDocumentor/Pipeline/Stage/Parser/CollectFilesTest.php
+++ b/tests/unit/phpDocumentor/Pipeline/Stage/Parser/CollectFilesTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage\Parser;
 
+use phpDocumentor\Configuration\VersionSpecification;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 use phpDocumentor\Dsn;
 use phpDocumentor\Parser\FileCollector;
@@ -46,28 +47,26 @@ final class CollectFilesTest extends TestCase
 
         $fixture = new CollectFiles($fileCollector->reveal(), new NullLogger());
 
-        $payload = new Payload(
+        $version = new VersionSpecification(
+            '1.0.0',
             [
-                'phpdocumentor' => [
-                    'versions' => [
-                        '1.0.0' => [
-                            'api' => [
-                                [
-                                    'source' => [
-                                        'dsn' => $dns,
-                                        'paths' => [0 => 'src'],
-                                    ],
-                                    'ignore' => [
-                                        'paths' => [],
-                                        'hidden' => null,
-                                    ],
-                                    'extensions' => ['php'],
-                                ],
-                            ],
-                        ],
+                [
+                    'source' => [
+                        'dsn' => $dns,
+                        'paths' => [0 => 'src'],
                     ],
+                    'ignore' => [
+                        'paths' => [],
+                        'hidden' => null,
+                    ],
+                    'extensions' => ['php'],
                 ],
             ],
+            null
+        );
+
+        $payload = new Payload(
+            ['phpdocumentor' => ['versions' => ['1.0.0' => $version]]],
             $this->prophesize(ProjectDescriptorBuilder::class)->reveal()
         );
 


### PR DESCRIPTION
This PR propose introducing a VersionObject to replace a big Version array in configuration.

I wasn't very inspired for the name so it can be changed if needed (just not in "Version" to avoid confusion with Version2 and Version3)