### PR TITLE
remove Font Awesome all.min.js and leave only all.min.css

### DIFF
--- a/data/templates/default/layout.html.twig
+++ b/data/templates/default/layout.html.twig
@@ -16,7 +16,6 @@
     {% block javascripts %}
         <script src="https://cdn.jsdelivr.net/npm/fuse.js@3.4.6"></script>
         <script src="https://cdn.jsdelivr.net/npm/css-vars-ponyfill@2"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.0/js/all.min.js" integrity="sha256-0vuk8LXoyrmCjp1f0O300qo1M75ZQyhH9X3J6d+scmk=" crossorigin="anonymous"></script>
         <script src="js/search.js"></script>
         <script defer src="js/searchIndex.js"></script>
     {% endblock %}


### PR DESCRIPTION
Closes #2686 

- [x] remove all.min.js
- [x] audit uses of Font Awesome throughout to ensure there are no SVG/JS-specific uses
- [x] determine whether the presence of the "svg-inline--fa" classes in [`index.html.dist`](https://github.com/mlwilkerson/phpDocumentor/blob/2563c52743d553a8b814e2e73c54a3bc4849e827/data/demo/index.html.dist#L7) are accidental or essential