### PR TITLE
Fix typo in document

### DIFF
--- a/docs/references/phpdoc/types.rst
+++ b/docs/references/phpdoc/types.rst
@@ -20,7 +20,7 @@ ABNF
     class-name               = 1*CHAR
     keyword                  = "string"|"integer"|"int"|"boolean"|"bool"|"float"
                                |"double"|"object"|"mixed"|"array"|"resource"|"scalar"
-                               |"void"|"null"|"callback"|"false"|"true"|"self"
+                               |"void"|"null"|"callable"|"false"|"true"|"self"
 
 When a Type is used the user will expect a value, or set of values, as
 detailed below.


### PR DESCRIPTION
Current version of the reference says that `callback` is a valid type in PHPDoc, which should be `callable`.
This PR fixes this issue.