### PR TITLE
Leverage newer API of PrettyVersion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ext-xml": "*",
         "doctrine/event-manager": "^1.1",
         "jawira/plantuml": "^1.27",
-        "jean85/pretty-package-versions": "^1.2",
+        "jean85/pretty-package-versions": "^1.5 || ^2.0.1",
         "league/commonmark": "^1.5",
         "league/flysystem": "^1.0",
         "league/pipeline": "^1.0",

--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -95,7 +95,7 @@ class Application extends BaseApplication
             $version = trim(file_get_contents(__DIR__ . '/../../../VERSION'));
             // @codeCoverageIgnoreStart
             try {
-                $version = PrettyVersions::getVersion(Versions::ROOT_PACKAGE_NAME)->getPrettyVersion();
+                $version = PrettyVersions::getRootPackageVersion()->getPrettyVersion();
                 $version = sprintf('v%s', ltrim($version, 'v'));
             } catch (OutOfBoundsException $e) {
             }


### PR DESCRIPTION
With those changes, you'll stop leveraging the transient dependency of `ocramius/package-version` and use the dedicated API of PrettyVersion. This also allows PrettyVersion 2.0 which drops the sub dependency alltogether, and hooks into the Composer 2 APIs directly.