### PR TITLE
Admonition contents are not rendered

### DIFF
--- a/data/templates/default/components/admonition.css.twig
+++ b/data/templates/default/components/admonition.css.twig
@@ -3,19 +3,24 @@
     border-radius: var(--border-radius-base-size);
     border-color: var(--primary-color-lighten);
     background-color: var(--primary-color-lighter);
-    font-size: 85%;
-    padding: .5rem;
-    margin: 2rem 0;
+    padding: var(--spacing-lg);
+    margin: var(--spacing-lg) 0;
     display: flex;
     flex-direction: row;
+    align-items: flex-start;
 }
 
-.phpdocumentor-admonition--success {
+.phpdocumentor-admonition p:last-of-type {
+    margin-bottom: 0;
+}
+
+.phpdocumentor-admonition--success,
+.phpdocumentor-admonition.-success {
     border-color: var(--admonition-success-color);
 }
 
 .phpdocumentor-admonition__icon {
-    font-size: 2rem;
-    margin: .75rem 0.75rem 1.25rem 0.5rem;
+    margin-right: var(--spacing-md);
     color: var(--primary-color);
+    max-width: 3rem;
 }

--- a/data/templates/default/css/variables.css.twig
+++ b/data/templates/default/css/variables.css.twig
@@ -23,7 +23,7 @@
     --primary-color-darken: hsl(96, 57%, 40%);
     --primary-color-darker: hsl(96, 57%, 20%);
     --primary-color-lighten: hsl(96, 57%, 80%);
-    --primary-color-lighter: hsl(96, 57%, 97%);
+    --primary-color-lighter: hsl(96, 57%, 99%);
     --dark-gray: #d1d1d1;
     --light-gray: #f0f0f0;
 

--- a/data/templates/default/guides/code.html.twig
+++ b/data/templates/default/guides/code.html.twig
@@ -1,1 +1,1 @@
-<pre{% if codeNode.classes %} class="{{ codeNode.classesString }}"{% endif %}><code class="{{ codeNode.language }}">{{ codeNode.value }}</code></pre>
+<pre class="{% if codeNode.classes %}{{ codeNode.classesString }}{% endif %} phpdocumentor-code -dark"><code class="{{ codeNode.language }}">{{ codeNode.value }}</code></pre>

--- a/data/templates/default/guides/directives/admonition.html.twig
+++ b/data/templates/default/guides/directives/admonition.html.twig
@@ -1,5 +1,2 @@
-<div class="admonition-wrapper{{ class ? (' '~class) : '' }}">
-    <div class="admonition admonition-{{ name }}">
-        <p class="admonition-title">{{ text }}</p>
-    </div>
-</div>
+<div class="phpdocumentor-admonition phpdocumentor-admonition--{{ name }} {{ class ? (' '~class) : '' }}">
+{#</div> <-- closing div is in de WrapperNode / AbstractAdmonitionDirective#}

--- a/data/templates/default/guides/directives/admonition.html.twig
+++ b/data/templates/default/guides/directives/admonition.html.twig
@@ -1,2 +1,18 @@
-<div class="phpdocumentor-admonition phpdocumentor-admonition--{{ name }} {{ class ? (' '~class) : '' }}">
-{#</div> <-- closing div is in de WrapperNode / AbstractAdmonitionDirective#}
+<div class="phpdocumentor-admonition -{{ name }} {{ class ? (' '~class) : '' }}">
+    {% if name == 'important' %}
+    <svg class="phpdocumentor-admonition__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+    {% endif %}
+    {% if name == 'note' %}
+    <svg class="phpdocumentor-admonition__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"></path></svg>
+    {% endif %}
+    {% if name == 'warning' or name == 'caution' %}
+    <svg class="phpdocumentor-admonition__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
+    {% endif %}
+    {% if name == 'tip' or name == 'hint' %}
+    <svg class="phpdocumentor-admonition__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
+    {% endif %}
+    {% if name == 'seealso' %}
+    <svg class="phpdocumentor-admonition__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
+    {% endif %}
+    <article>
+{#</article></div> <-- closing article and div is in de WrapperNode / AbstractAdmonitionDirective#}

--- a/data/templates/default/objects/blockquote.css.twig
+++ b/data/templates/default/objects/blockquote.css.twig
@@ -1,8 +1,11 @@
 .phpdocumentor blockquote {
-    border-left: 4px solid var(--primary-color);
+    border-left: 4px solid var(--primary-color-darken);
     margin: var(--spacing-md) 0;
     padding: var(--spacing-xs) var(--spacing-sm);
     color: var(--primary-color-darker);
     font-style: italic;
-    font-size: var(--text-sm);
+}
+
+.phpdocumentor blockquote p:last-of-type {
+    margin-bottom: 0;
 }

--- a/data/templates/default/objects/code.css.twig
+++ b/data/templates/default/objects/code.css.twig
@@ -12,6 +12,15 @@
     box-sizing: border-box;
 }
 
+.phpdocumentor-code.-dark {
+    background: var(--text-color);
+    color: var(--primary-color-lighter);
+    padding: .5rem 1rem;
+    border-radius: .25rem;
+    box-shadow: 0 2px 3px var(--dark-gray);
+    font-size: 0.8rem;
+}
+
 pre > .phpdocumentor-code {
     display: block;
     white-space: pre;

--- a/docs/getting-started/configuration.rst
+++ b/docs/getting-started/configuration.rst
@@ -7,7 +7,7 @@ documentation easier.
 phpDocumentor uses an XML-based configuration file with quite a few options; in this document we will go into a few
 common uses and how to set this up.
 
-::
+.. code-block:: xml
 
     <?xml version="1.0" encoding="UTF-8" ?>
     <phpdocumentor

--- a/docs/getting-started/installing.rst
+++ b/docs/getting-started/installing.rst
@@ -17,6 +17,8 @@ Installing phpDocumentor
 Using Phive
 ~~~~~~~~~~~
 
+If phive is globally installed, you can run the following command::
+
    $ phive install phpDocumentor
 
 Once you run the command, phpDocumentor will be installed and it can be executed directly.

--- a/docs/getting-started/your-first-set-of-documentation.rst
+++ b/docs/getting-started/your-first-set-of-documentation.rst
@@ -96,22 +96,22 @@ DocBlocks are divided into the following three parts. Each of these parts is opt
 may not exist without a Summary.
 
 Summary
-  The Summary, sometimes called a short description, provides a brief introduction into the function
-  of the associated element. A Summary ends when it encounters either of the below situations::
+    The Summary, sometimes called a short description, provides a brief introduction into the function
+    of the associated element. A Summary ends when it encounters either of the below situations:
 
-    * a period ``.``, followed by a line break
-    * or a blank (comment) line.
+    - a period ``.``, followed by a line break
+    - or a blank (comment) line.
 
 Description
-  The Description, sometimes called the long description, can provide more information. Examples of additional
-  information are: a description of a function's algorithm, a usage example or a description of how a class
-  fits in the whole of the application's architecture. The description ends when the first tag is encountered
-  on a new line or when the DocBlock is closed.
+    The Description, sometimes called the long description, can provide more information. Examples of additional
+    information are: a description of a function's algorithm, a usage example or a description of how a class
+    fits in the whole of the application's architecture. The description ends when the first tag is encountered
+    on a new line or when the DocBlock is closed.
 
 Tags and Annotations
-  These provide a way to succinctly and uniformly provide meta-information about the associated element.
-  Tags can, for example, describe the type of information that is returned by a method or function.
-  Each tag is preceded by an at-sign (``@``) and starts on a new line.
+    These provide a way to succinctly and uniformly provide meta-information about the associated element.
+    Tags can, for example, describe the type of information that is returned by a method or function.
+    Each tag is preceded by an at-sign (``@``) and starts on a new line.
 
 Example
 ~~~~~~~

--- a/docs/internals/guides.rst
+++ b/docs/internals/guides.rst
@@ -49,4 +49,9 @@ Directives
 Renderers
 ~~~~~~~~~
 
+Read More
+---------
+
+- `Writing Directives <./guides/writing-directives>`_
+
 .. _docs-builder: https://github.com/ryanweaver/docs-builder

--- a/docs/internals/guides/writing-directives.rst
+++ b/docs/internals/guides/writing-directives.rst
@@ -1,0 +1,95 @@
+Writing Directives
+==================
+
+What is a Directive
+-------------------
+
+A directive is a Component that can be used in RestructuredText. Directives offer the possibility to describe a special
+Block element; such as an image, admonition, UML graph, etc. Directives can also have options, with which you can
+influence their rendering.
+
+For more information, check the specification at https://docutils.sourceforge.io/docs/ref/rst/directives.html.
+
+In the context of this implementation, a Directive is responsible for converting the given type, options and block's
+contents into a ``Node``. This node is subsequently responsible for rendering the given properties using an associated
+``NodeRenderer``.
+
+The Directive itself should not have to deal with the rendering process; it returns either a node, or performs an
+action.
+
+.. note::
+   The term _should_ already gives it away a little. The initial parser did not properly distinguish between parsing and
+   rendering. This means that some Directives, especially SubDirectives, _do_ produce rendered output. We hope to
+   refactor this away.
+
+Examples
+--------
+
+.. code::
+    .. DANGER::
+       Beware killer rabbits!
+
+.. code::
+    .. image:: picture.jpeg
+       :height: 100px
+       :width: 200 px
+       :scale: 50 %
+       :alt: alternate text
+       :align: right
+
+Writing a Directive
+-------------------
+
+The first step, is to create a class in ``src/Guides/RestructuredText/HTML/Directives`` that extends either
+``phpDocumentor\Guides\RestructuredText\Directives\Directive`` or
+``phpDocumentor\Guides\RestructuredText\Directives\SubDirective``.
+
+The difference between these two is whether you want the contents of the Directive to be parsed, similar to a paragraph
+or a whole Document, in which case you use a SubDirective; or a simpler Directive such as image or figure, in which
+case you use the Directive class.
+
+A Simple Directive
+~~~~~~~~~~~~~~~~~~
+
+Having a class that extends ``phpDocumentor\Guides\RestructuredText\Directives\Directive``, you need to implement the
+following two methods:
+
+1. ``getName()``, that should return the directive name or keyword; such as ``image``.
+2. ``processNode()``, that should return an instance of a Node using the given Parser, based on the variable name
+   (keyword) data in the Directive block and options set in the Directive block (if any).
+
+One of the clearest examples is the ``Image`` directive that uses the given data to construct an ImageNode and
+return that.
+
+Actions
+~~~~~~~
+
+As was hinted before, a Directive need not return a ``Node``. These can also influence the current document, which is
+called an 'Action'.
+
+Examples of these are:
+
+- Bibliographic fields
+- HTML Meta fields
+- The ``URL`` Directive (seen in the ``phpDocumentor\Guides\RestructuredText\HTML\Directives\Url`` class)
+
+This last directive if a straight forward example of how to create a simple Action.
+
+Complex Directives
+~~~~~~~~~~~~~~~~~~
+
+At time of writing, not much is known on what this exactly is or does. I infer it has to do with re-parsing the block
+(like you'd do with a paragraph) since Directives such as admonitions can be nested. But so far it is not clear yet.
+
+When I find out, I will write it down.
+
+.. code::
+
+   A directive that parses the sub block and call the processSub that can
+   be overloaded, like :
+
+   .. sub-directive::
+      Some block of code
+
+      You can imagine anything here, like adding *emphasis*, lists or
+      titles

--- a/src/Guides/RestructuredText/HTML/Directives/AbstractAdmonitionDirective.php
+++ b/src/Guides/RestructuredText/HTML/Directives/AbstractAdmonitionDirective.php
@@ -39,29 +39,23 @@ abstract class AbstractAdmonitionDirective extends SubDirective
         array $options
     ) : ?Node {
         $environment = $document->getEnvironment();
-        $wrapperDiv = function () use ($environment, $options) {
-            return $environment->getRenderer()->render(
-                'directives/admonition.html.twig',
-                [
-                    'name' => $this->name,
-                    'text' => $this->text,
-                    'class' => $options['class'] ?? null,
-                ]
+
+        return $parser
+            ->getNodeFactory()
+            ->createWrapperNode(
+                $document,
+                function () use ($environment, $options) {
+                    return $environment->getRenderer()->render(
+                        'directives/admonition.html.twig',
+                        [
+                            'name' => $this->name,
+                            'text' => $this->text,
+                            'class' => $options['class'] ?? null,
+                        ]
+                    );
+                },
+                '</article></div>'
             );
-        };
-
-//        $divOpen = $environment->getRenderer()->render(
-//            'directives/admonition.html.twig',
-//            [
-//                'name' => $this->name,
-//                'text' => $this->text,
-//                'class' => $options['class'] ?? null,
-//            ]
-//        );
-//
-        return $parser->getNodeFactory()->createWrapperNode($document, $wrapperDiv, '</div>');
-
-        return $parser->getNodeFactory()->createRawNode($wrapperDiv);
     }
 
     final public function getName() : string

--- a/src/Guides/RestructuredText/HTML/Directives/AbstractAdmonitionDirective.php
+++ b/src/Guides/RestructuredText/HTML/Directives/AbstractAdmonitionDirective.php
@@ -50,6 +50,17 @@ abstract class AbstractAdmonitionDirective extends SubDirective
             );
         };
 
+//        $divOpen = $environment->getRenderer()->render(
+//            'directives/admonition.html.twig',
+//            [
+//                'name' => $this->name,
+//                'text' => $this->text,
+//                'class' => $options['class'] ?? null,
+//            ]
+//        );
+//
+        return $parser->getNodeFactory()->createWrapperNode($document, $wrapperDiv, '</div>');
+
         return $parser->getNodeFactory()->createRawNode($wrapperDiv);
     }
 


### PR DESCRIPTION
In this change, I have made a start with rendering admonitions. The
prior method did not include the body of the admonition and as such
didn't really show anything.

This can still be improved, both the docs and the rendering style; and I
will do so in a subsequent commit