### PR TITLE
Fix #2832: Determine plantuml location using project dir

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -271,6 +271,10 @@ services:
             - { method: offsetSet, arguments: ['twig', '@phpDocumentor\Transformer\Writer\Twig']}
             - { method: offsetSet, arguments: ['RenderGuide', '@phpDocumentor\Transformer\Writer\RenderGuide']}
 
+    phpDocumentor\Transformer\Writer\Graph\PlantumlClassDiagram:
+      arguments:
+        $plantUmlBinaryPath: '%kernel.project_dir%/bin/plantuml'
+
     ###################################################################################
     ## Guides - EXPERIMENTAL ##########################################################
     ###################################################################################

--- a/src/phpDocumentor/Transformer/Writer/Graph/PlantumlClassDiagram.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph/PlantumlClassDiagram.php
@@ -32,9 +32,13 @@ final class PlantumlClassDiagram implements Generator
     /** @var LoggerInterface */
     private $logger;
 
-    public function __construct(LoggerInterface $logger)
+    /** @var string */
+    private $plantUmlBinaryPath;
+
+    public function __construct(LoggerInterface $logger, string $plantUmlBinaryPath)
     {
         $this->logger = $logger;
+        $this->plantUmlBinaryPath = $plantUmlBinaryPath;
     }
 
     public function create(ProjectDescriptor $project, string $filename) : void
@@ -58,7 +62,7 @@ $namespace
 PUML;
         file_put_contents($pumlFileLocation, $output);
 
-        $process = new Process(['../../../../../bin/plantuml', '-tsvg', $pumlFileLocation], __DIR__, null, null, 600.0);
+        $process = new Process([$this->plantUmlBinaryPath, '-tsvg', $pumlFileLocation], __DIR__, null, null, 600.0);
         $process->run();
 
         if ($process->isSuccessful()) {

--- a/tests/unit/phpDocumentor/Transformer/Writer/GraphTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/GraphTest.php
@@ -30,7 +30,7 @@ final class GraphTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->graph = new Graph(new GraphVizClassDiagram(), new PlantumlClassDiagram(new NullLogger()));
+        $this->graph = new Graph(new GraphVizClassDiagram(), new PlantumlClassDiagram(new NullLogger(), ''));
     }
 
     /**


### PR DESCRIPTION
In issue #2832, @FrankMarwort reported that the directory determination
for the plantuml binary was based on a fixed path. Although we can make
some assumptions in the code base, it is superior to use symfony's
project_dir internal variable to determine this location.