### PR TITLE
Split transformer from template creation

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,6 +34,9 @@ parameters:
     # PHPStan doesn't support inheritance of TDescriptor
     - '#Parameter \#2 \$assembler of method phpDocumentor\\Descriptor\\Builder\\AssemblerFactory::(register|registerFallback)\(\) expects phpDocumentor\\Descriptor\\Builder\\AssemblerInterface.* given\.#'
 
+    # Design improvement of configuration needed
+    - '#Parameter \#1 \$templates of method phpDocumentor\\Transformer\\Template\\Factory::getTemplates\(\) expects array<int, array\(.* => string\)>, array<int, string>&nonEmpty given\.#'
+
     # Advanced transformations of array. PHPStan doesn't seem to keep nonEmpty flag through some array functions
     - '#Method phpDocumentor\\Configuration\\Definition\\Version2::upgrade\(\) should return.+#'
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -46,6 +46,8 @@
                 <!-- psalm bug -->
                 <referencedFunction name="phpDocumentor\Descriptor\Builder\AssemblerFactory::register" />
                 <referencedFunction name="phpDocumentor\Descriptor\Builder\AssemblerFactory::registerFallback" />
+                <!-- requires config design improvements -->
+                <referencedFunction name="phpDocumentor\Transformer\Template\Factory::getTemplates" />
             </errorLevel>
         </InvalidArgument>
 

--- a/src/phpDocumentor/Console/Command/Project/RunCommand.php
+++ b/src/phpDocumentor/Console/Command/Project/RunCommand.php
@@ -328,7 +328,7 @@ HELP
                 $output->writeln('Applying transformations (can take a while)');
                 $this->transformerProgressBar = new ProgressBar(
                     $output,
-                    count($event->getSubject()->getTemplates()->getTransformations())
+                    count($event->getTransformations())
                 );
             }
         );

--- a/src/phpDocumentor/Pipeline/Stage/Transform.php
+++ b/src/phpDocumentor/Pipeline/Stage/Transform.php
@@ -44,7 +44,7 @@ class Transform
     private $logger;
 
     /** @var Factory */
-    private $factory;
+    private $templateFactory;
 
     /** @var FlySystemFactory */
     private $flySystemFactory;
@@ -56,11 +56,11 @@ class Transform
         Transformer $transformer,
         FlySystemFactory $flySystemFactory,
         LoggerInterface $logger,
-        Factory $factory
+        Factory $templateFactory
     ) {
         $this->transformer   = $transformer;
         $this->logger        = $logger;
-        $this->factory       = $factory;
+        $this->templateFactory  = $templateFactory;
         $this->flySystemFactory = $flySystemFactory;
 
         $this->connectOutputToEvents();
@@ -75,7 +75,7 @@ class Transform
     {
         $configuration = $payload->getConfig();
 
-        $templates = $this->factory->getTemplates(
+        $templates = $this->templateFactory->getTemplates(
             $configuration['phpdocumentor']['templates'],
             $this->createFileSystem($configuration['phpdocumentor']['paths']['output'])
         );

--- a/src/phpDocumentor/Transformer/Event/PostTransformEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PostTransformEvent.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Transformer\Event;
 
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Event\EventAbstract;
+use phpDocumentor\Transformer\Transformation;
 
 /**
  * Event happen right after all transformations have completed.
@@ -23,6 +24,9 @@ final class PostTransformEvent extends EventAbstract
 {
     /** @var ProjectDescriptor|null */
     private $project;
+
+    /** @var Transformation[] */
+    private $tranformations;
 
     /**
      * Creates a new instance of a derived object and return that.
@@ -52,5 +56,17 @@ final class PostTransformEvent extends EventAbstract
         $this->project = $project;
 
         return $this;
+    }
+
+    /** @param Transformation[] $transformations */
+    public function setTransformations(array $transformations) : void
+    {
+        $this->tranformations = $transformations;
+    }
+
+    /** @return Transformation[] */
+    public function getTransformations() : array
+    {
+        return $this->tranformations;
     }
 }

--- a/src/phpDocumentor/Transformer/Event/PostTransformEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PostTransformEvent.php
@@ -26,7 +26,7 @@ final class PostTransformEvent extends EventAbstract
     private $project;
 
     /** @var Transformation[] */
-    private $tranformations;
+    private $transformations;
 
     /**
      * Creates a new instance of a derived object and return that.
@@ -61,12 +61,12 @@ final class PostTransformEvent extends EventAbstract
     /** @param Transformation[] $transformations */
     public function setTransformations(array $transformations) : void
     {
-        $this->tranformations = $transformations;
+        $this->transformations = $transformations;
     }
 
     /** @return Transformation[] */
     public function getTransformations() : array
     {
-        return $this->tranformations;
+        return $this->transformations;
     }
 }

--- a/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Transformer\Event;
 
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Event\EventAbstract;
+use phpDocumentor\Transformer\Transformation;
 
 /**
  * Event that happens prior to the execution of all transformations.
@@ -23,6 +24,9 @@ final class PreTransformEvent extends EventAbstract
 {
     /** @var ProjectDescriptor|null */
     private $project;
+
+    /** @var Transformation[] */
+    private $tranformations;
 
     /**
      * Creates a new instance of a derived object and return that.
@@ -52,5 +56,17 @@ final class PreTransformEvent extends EventAbstract
         $this->project = $project;
 
         return $this;
+    }
+
+    /** @param Transformation[] $transformations */
+    public function setTransformations(array $transformations) : void
+    {
+        $this->tranformations = $transformations;
+    }
+
+    /** @return Transformation[] */
+    public function getTransformations() : array
+    {
+        return $this->tranformations;
     }
 }

--- a/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
+++ b/src/phpDocumentor/Transformer/Event/PreTransformEvent.php
@@ -26,7 +26,7 @@ final class PreTransformEvent extends EventAbstract
     private $project;
 
     /** @var Transformation[] */
-    private $tranformations;
+    private $transformations;
 
     /**
      * Creates a new instance of a derived object and return that.
@@ -61,12 +61,12 @@ final class PreTransformEvent extends EventAbstract
     /** @param Transformation[] $transformations */
     public function setTransformations(array $transformations) : void
     {
-        $this->tranformations = $transformations;
+        $this->transformations = $transformations;
     }
 
     /** @return Transformation[] */
     public function getTransformations() : array
     {
-        return $this->tranformations;
+        return $this->transformations;
     }
 }

--- a/src/phpDocumentor/Transformer/Template/Collection.php
+++ b/src/phpDocumentor/Transformer/Template/Collection.php
@@ -17,48 +17,14 @@ use ArrayObject;
 //phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use phpDocumentor\Transformer\Template;
 use phpDocumentor\Transformer\Transformation;
-use phpDocumentor\Transformer\Transformer;
-use phpDocumentor\Transformer\Writer\Collection as WriterCollection;
 
 /**
  * Contains a collection of Templates that may be queried.
  *
  * @template-extends ArrayObject<string, Template>
  */
-class Collection extends ArrayObject
+final class Collection extends ArrayObject
 {
-    /** @var Factory */
-    private $factory;
-
-    /** @var WriterCollection */
-    private $writerCollection;
-
-    /**
-     * Constructs this collection and requires a factory to load templates.
-     */
-    public function __construct(Factory $factory, WriterCollection $writerCollection)
-    {
-        parent::__construct([]);
-        $this->factory = $factory;
-        $this->writerCollection = $writerCollection;
-    }
-
-    /**
-     * Loads a template with the given name or file path.
-     */
-    public function load(Transformer $transformer, string $nameOrPath) : void
-    {
-        $template = $this->factory->get($transformer, $nameOrPath);
-
-        /** @var Transformation $transformation */
-        foreach ($template as $transformation) {
-            $writer = $this->writerCollection[$transformation->getWriter()];
-            $writer->checkRequirements();
-        }
-
-        $this[$template->getName()] = $template;
-    }
-
     /**
      * Returns a list of all transformations contained in the templates of this collection.
      *
@@ -74,13 +40,5 @@ class Collection extends ArrayObject
         }
 
         return $result;
-    }
-
-    /**
-     * Returns the path where all templates are stored.
-     */
-    public function getTemplatesPath() : string
-    {
-        return $this->factory->getTemplatesPath();
     }
 }

--- a/tests/unit/phpDocumentor/Pipeline/Stage/TransformTest.php
+++ b/tests/unit/phpDocumentor/Pipeline/Stage/TransformTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage;
 
+use League\Flysystem\FilesystemInterface;
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 use phpDocumentor\Dsn;
-use phpDocumentor\Reflection\DocBlock\ExampleFinder;
+use phpDocumentor\Faker\Faker;
+use phpDocumentor\Parser\FlySystemFactory;
 use phpDocumentor\Transformer\Template\Collection;
+use phpDocumentor\Transformer\Template\Factory;
 use phpDocumentor\Transformer\Transformer;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -25,6 +30,7 @@ use const DIRECTORY_SEPARATOR;
 final class TransformTest extends TestCase
 {
     use ProphecyTrait;
+    use Faker;
 
     /** @var ProjectDescriptorBuilder|ProphecyMock */
     private $projectDescriptorBuilder;
@@ -35,32 +41,35 @@ final class TransformTest extends TestCase
     /** @var LoggerInterface|ProphecyMock */
     private $logger;
 
-    /** @var ExampleFinder|ProphecyMock */
-    private $exampleFinder;
-
     /** @var Compile */
     private $transform;
+
+    /** @var LegacyMockInterface|MockInterface|FlySystemFactory */
+    private $flySystemFactory;
 
     public function setUp() : void
     {
         $projectDescriptor = new ProjectDescriptor('test');
+        $this->flySystemFactory         = $this->faker()->flySystemFactory();
         $this->projectDescriptorBuilder = $this->prophesize(ProjectDescriptorBuilder::class);
         $this->projectDescriptorBuilder->getProjectDescriptor()->willReturn($projectDescriptor);
         $this->transformer              = $this->prophesize(Transformer::class);
         $this->logger                   = $this->prophesize(LoggerInterface::class);
-        $this->exampleFinder            = $this->prophesize(ExampleFinder::class);
-        $this->transformer->execute($projectDescriptor)->shouldBeCalled();
+        $this->transformer->execute($projectDescriptor, [])->shouldBeCalled();
+        $templateFactory = $this->prophesize(Factory::class);
+        $templateFactory->getTemplates(Argument::any(), Argument::any())->willReturn(new Collection());
 
         $this->transform = new Transform(
             $this->transformer->reveal(),
+            $this->flySystemFactory,
             $this->logger->reveal(),
-            $this->exampleFinder->reveal()
+            $templateFactory->reveal()
         );
     }
 
     /**
      * @covers ::__invoke
-     * @covers ::setTargetLocationBasedOnDsn
+     * @covers ::createFileSystem
      */
     public function test_if_target_location_for_output_is_set_with_a_relative_path() : void
     {
@@ -69,13 +78,14 @@ final class TransformTest extends TestCase
         $payload = new Payload($config, $this->projectDescriptorBuilder->reveal());
 
         $this->transformer->setTarget(getcwd() . DIRECTORY_SEPARATOR . '.')->shouldBeCalled();
+        $this->transformer->setDestination(Argument::type(FilesystemInterface::class))->shouldBeCalled();
 
         ($this->transform)($payload);
     }
 
     /**
      * @covers ::__invoke
-     * @covers ::setTargetLocationBasedOnDsn
+     * @covers ::createFileSystem
      */
     public function test_if_target_location_for_output_is_set_with_an_absolute_path() : void
     {
@@ -84,33 +94,7 @@ final class TransformTest extends TestCase
         $payload = new Payload($config, $this->projectDescriptorBuilder->reveal());
 
         $this->transformer->setTarget('/my/absolute/folder')->shouldBeCalled();
-
-        ($this->transform)($payload);
-    }
-
-    /**
-     * @covers ::__invoke
-     * @covers ::loadTemplatesBasedOnNames
-     */
-    public function test_loading_templates_with_a_given_set_of_template_names() : void
-    {
-        $config = $this->givenAnExampleConfigWithDsnAndTemplates(
-            'file://.',
-            [
-                ['name' => 'template1'],
-                ['name' => 'template2'],
-            ]
-        );
-
-        $payload = new Payload($config, $this->projectDescriptorBuilder->reveal());
-
-        $this->transformer->setTarget(Argument::any());
-
-        $templateCollection = $this->prophesize(Collection::class);
-        $templateCollection->load($this->transformer, 'template1')->shouldBeCalled();
-        $templateCollection->load($this->transformer, 'template2')->shouldBeCalled();
-
-        $this->transformer->getTemplates()->willReturn($templateCollection->reveal());
+        $this->transformer->setDestination(Argument::type(FilesystemInterface::class))->shouldBeCalled();
 
         ($this->transform)($payload);
     }
@@ -124,6 +108,7 @@ final class TransformTest extends TestCase
         $payload           = new Payload($config, $this->projectDescriptorBuilder->reveal());
 
         $this->transformer->setTarget(Argument::any());
+        $this->transformer->setDestination(Argument::type(FilesystemInterface::class));
 
         ($this->transform)($payload);
     }

--- a/tests/unit/phpDocumentor/Pipeline/Stage/TransformTest.php
+++ b/tests/unit/phpDocumentor/Pipeline/Stage/TransformTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage;
 
+use League\Flysystem\Adapter\NullAdapter;
+use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemInterface;
 use Mockery\LegacyMockInterface;
 use Mockery\MockInterface;
@@ -50,7 +52,8 @@ final class TransformTest extends TestCase
     public function setUp() : void
     {
         $projectDescriptor = new ProjectDescriptor('test');
-        $this->flySystemFactory         = $this->faker()->flySystemFactory();
+        $this->flySystemFactory         = $this->prophesize(FlySystemFactory::class);
+        $this->flySystemFactory->create(Argument::type(Dsn::class))->willReturn(new Filesystem(new NullAdapter()));
         $this->projectDescriptorBuilder = $this->prophesize(ProjectDescriptorBuilder::class);
         $this->projectDescriptorBuilder->getProjectDescriptor()->willReturn($projectDescriptor);
         $this->transformer              = $this->prophesize(Transformer::class);
@@ -61,7 +64,7 @@ final class TransformTest extends TestCase
 
         $this->transform = new Transform(
             $this->transformer->reveal(),
-            $this->flySystemFactory,
+            $this->flySystemFactory->reveal(),
             $this->logger->reveal(),
             $templateFactory->reveal()
         );

--- a/tests/unit/phpDocumentor/Transformer/Template/CollectionTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Template/CollectionTest.php
@@ -17,10 +17,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use phpDocumentor\Faker\Faker;
 use phpDocumentor\Transformer\Template;
 use phpDocumentor\Transformer\Transformation;
-use phpDocumentor\Transformer\Writer\Collection as WriterCollection;
-use phpDocumentor\Transformer\Writer\WriterAbstract;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 
 /**
  * @coversDefaultClass \phpDocumentor\Transformer\Template\Collection
@@ -29,14 +25,7 @@ use Prophecy\Prophecy\ObjectProphecy;
  */
 final class CollectionTest extends MockeryTestCase
 {
-    use ProphecyTrait;
     use Faker;
-
-    /** @var ObjectProphecy|WriterCollection */
-    private $writerCollectionMock;
-
-    /** @var ObjectProphecy|Factory */
-    private $factoryMock;
 
     /** @var Collection */
     private $fixture;
@@ -46,46 +35,7 @@ final class CollectionTest extends MockeryTestCase
      */
     protected function setUp() : void
     {
-        $this->factoryMock = $this->prophesize(Factory::class);
-        $this->writerCollectionMock = $this->prophesize(WriterCollection::class);
-        $this->fixture = new Collection($this->factoryMock->reveal(), $this->writerCollectionMock->reveal());
-    }
-
-    /**
-     * @covers ::load
-     */
-    public function testIfLoadRetrievesTemplateFromFactoryAndRegistersIt() : void
-    {
-        $templateName = 'default';
-        $template = $this->faker()->template($templateName);
-        $template['a'] = $this->givenAnEmptyTransformation($template);
-
-        $transformer = $this->faker()->transformer();
-        $this->factoryMock->get($transformer, $templateName)->shouldBeCalled()->willReturn($template);
-
-        $writer = $this->prophesize(WriterAbstract::class);
-        $writer->checkRequirements()->shouldBeCalled();
-
-        $this->writerCollectionMock->offsetGet('')->shouldBeCalled()->willReturn($writer->reveal());
-
-        $this->fixture->load($transformer, $templateName);
-
-        $this->assertCount(1, $this->fixture);
-        $this->assertArrayHasKey($templateName, $this->fixture);
-        $this->assertSame($template, $this->fixture[$templateName]);
-    }
-
-    /**
-     * @covers ::getTemplatesPath
-     */
-    public function testCollectionProvidesTemplatesPath() : void
-    {
-        $path = '/tmp';
-        $this->factoryMock->getTemplatesPath()->shouldBeCalled()->willReturn($path);
-
-        $result = $this->fixture->getTemplatesPath();
-
-        $this->assertSame($path, $result);
+        $this->fixture = new Collection([]);
     }
 
     /**


### PR DESCRIPTION
To be able to add more transformers in an upcoming pr which will
allow us to support multiple versions, documentation sets etc. I removed
all template-related code from the transformer.

The Template Factory will now provide a collection of templates to render
equal to the existing template collection this is able to provide the required
transformations. The Transformer will only instruct the writers to execute transformations.

This commit contains a number of shortcuts to finish this faster. The configuration type
hints could be improved, and the destination should be removed from the transformer. Although
both are not really required at the moment. Things will work as before now.