### PR TITLE
Move init of twig to init step

### DIFF
--- a/src/Guides/Renderer.php
+++ b/src/Guides/Renderer.php
@@ -21,6 +21,7 @@ use phpDocumentor\Transformer\Writer\Graph\PlantumlRenderer;
 use phpDocumentor\Transformer\Writer\Twig\EnvironmentFactory;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use function count;
 
 class Renderer
 {
@@ -56,8 +57,13 @@ class Renderer
     ) : void {
         $targetDirectory = $documentationSet->getOutput();
 
-        $this->environment = $this->environmentFactory->create($project, $transformation, $targetDirectory);
+        $this->environment = $this->environmentFactory->create($project, $transformation->template());
         $this->environment->addExtension(new AssetsExtension($this->logger, $this->plantumlRenderer));
+        $this->environment->addGlobal('project', $project);
+        $this->environment->addGlobal('usesNamespaces', count($project->getNamespace()->getChildren()) > 0);
+        $this->environment->addGlobal('usesPackages', count($project->getPackage()->getChildren()) > 1);
+        $this->environment->addGlobal('documentationSet', $project);
+        $this->environment->addGlobal('destinationPath', $targetDirectory);
 
         // pre-set the global variable so that we can update it later
         $this->environment->addGlobal('env', null);

--- a/src/Guides/TemplateRenderer.php
+++ b/src/Guides/TemplateRenderer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides;
 
-use phpDocumentor\Transformer\Writer\Twig\Extension;
 use Twig\Environment;
 use function rtrim;
 
@@ -42,10 +41,8 @@ final class TemplateRenderer
 
     public function setDestination(string $filename) : void
     {
-        /** @var Extension $extension */
-        $extension = $this->getTemplateEngine()->getExtension(Extension::class);
         $destination = $this->subFolder . '/' . $filename;
-        $extension->setDestination($destination);
+        $this->getTemplateEngine()->addGlobal('destinationPath', $destination);
     }
 
     /**

--- a/src/phpDocumentor/Transformer/Transformer.php
+++ b/src/phpDocumentor/Transformer/Transformer.php
@@ -145,7 +145,7 @@ class Transformer
 
             $isInitialized[] = $writerName;
             $writer = $this->writers[$writerName];
-            $this->initializeWriter($writer, $project);
+            $this->initializeWriter($writer, $project, $transformation->template());
         }
     }
 
@@ -165,7 +165,7 @@ class Transformer
      *
      * @uses Dispatcher to emit the events surrounding an initialization.
      */
-    private function initializeWriter(WriterAbstract $writer, ProjectDescriptor $project) : void
+    private function initializeWriter(WriterAbstract $writer, ProjectDescriptor $project, Template $template) : void
     {
         /** @var WriterInitializationEvent $instance */
         $instance = WriterInitializationEvent::createInstance($this);
@@ -173,7 +173,7 @@ class Transformer
         Dispatcher::getInstance()->dispatch($event, self::EVENT_PRE_INITIALIZATION);
 
         if ($writer instanceof Initializable) {
-            $writer->initialize($project);
+            $writer->initialize($project, $template);
         }
 
         Dispatcher::getInstance()->dispatch($event, self::EVENT_POST_INITIALIZATION);

--- a/src/phpDocumentor/Transformer/Writer/Initializable.php
+++ b/src/phpDocumentor/Transformer/Writer/Initializable.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer\Writer;
 
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Transformer\Template;
 
 interface Initializable
 {
-    public function initialize(ProjectDescriptor $projectDescriptor) : void;
+    public function initialize(ProjectDescriptor $project, Template $template) : void;
 }

--- a/src/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactory.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactory.php
@@ -17,12 +17,11 @@ use League\CommonMark\MarkdownConverterInterface;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Guides\Twig\TocExtension;
 use phpDocumentor\Path;
-use phpDocumentor\Transformer\Transformation;
+use phpDocumentor\Transformer\Template;
 use Twig\Environment;
 use Twig\Extension\DebugExtension;
 use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
-use function ltrim;
 
 class EnvironmentFactory
 {
@@ -55,10 +54,9 @@ class EnvironmentFactory
 
     public function create(
         ProjectDescriptor $project,
-        Transformation $transformation,
-        string $destination
+        Template $template
     ) : Environment {
-        $mountManager = $transformation->template()->files();
+        $mountManager = $template->files();
 
         $loaders = [];
         if ($this->templateOverridesAt instanceof Path) {
@@ -70,7 +68,7 @@ class EnvironmentFactory
 
         $env = new Environment(new ChainLoader($loaders));
 
-        $this->addPhpDocumentorExtension($project, $destination, $env);
+        $this->addPhpDocumentorExtension($project, $env);
         $env->addExtension($this->tocExtension);
         $this->enableDebug($env);
 
@@ -82,11 +80,9 @@ class EnvironmentFactory
      */
     private function addPhpDocumentorExtension(
         ProjectDescriptor $project,
-        string $path,
         Environment $twigEnvironment
     ) : void {
         $extension = new Extension($project, $this->markDownConverter, $this->renderer);
-        $extension->setDestination(ltrim($path, '/\\'));
         $twigEnvironment->addExtension($extension);
     }
 

--- a/tests/unit/phpDocumentor/Transformer/Template/CollectionTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Template/CollectionTest.php
@@ -20,7 +20,6 @@ use phpDocumentor\Transformer\Transformation;
 
 /**
  * @coversDefaultClass \phpDocumentor\Transformer\Template\Collection
- * @covers ::__construct
  * @covers ::<private>
  */
 final class CollectionTest extends MockeryTestCase

--- a/tests/unit/phpDocumentor/Transformer/TransformerTest.php
+++ b/tests/unit/phpDocumentor/Transformer/TransformerTest.php
@@ -115,6 +115,7 @@ final class TransformerTest extends TestCase
 
         $transformation = $this->prophesize(Transformation::class);
         $transformation->getQuery()->shouldBeCalled()->willReturn('');
+        $transformation->template()->willReturn($this->faker()->template());
         $transformation->getWriter()->shouldBeCalled()->willReturn($myTestWriter);
         $transformation->getArtifact()->shouldBeCalled()->willReturn('');
         $transformation->setTransformer(Argument::exact($this->fixture))->shouldBeCalled();

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactoryTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactoryTest.php
@@ -61,9 +61,9 @@ final class EnvironmentFactoryTest extends TestCase
      */
     public function testItCreatesATwigEnvironmentWithThephpDocumentorExtension() : void
     {
-        $transformation = $this->faker()->transformation();
+        $template = $this->faker()->template();
 
-        $environment = $this->factory->create(new ProjectDescriptor('name'), $transformation, '/home');
+        $environment = $this->factory->create(new ProjectDescriptor('name'), $template);
 
         $this->assertInstanceOf(Environment::class, $environment);
         $this->assertCount(6, $environment->getExtensions());
@@ -78,11 +78,10 @@ final class EnvironmentFactoryTest extends TestCase
      */
     public function testItCreatesATwigEnvironmentWithTheCorrectTemplateLoaders() : void
     {
-        $transformation = $this->faker()->transformation();
+        $template = $this->faker()->template();
+        $mountManager = $template->files();
 
-        $mountManager = $transformation->template()->files();
-
-        $environment = $this->factory->create(new ProjectDescriptor('name'), $transformation, '/home');
+        $environment = $this->factory->create(new ProjectDescriptor('name'), $template);
 
         /** @var ChainLoader $loader */
         $loader = $environment->getLoader();
@@ -106,9 +105,9 @@ final class EnvironmentFactoryTest extends TestCase
      */
     public function testTheCreatedEnvironmentHasTheDebugExtension() : void
     {
-        $transformation = $this->faker()->transformation();
+        $template = $this->faker()->template();
 
-        $environment = $this->factory->create(new ProjectDescriptor('name'), $transformation, '/home');
+        $environment = $this->factory->create(new ProjectDescriptor('name'), $template);
 
         $this->assertFalse($environment->getCache());
         $this->assertTrue($environment->isDebug());

--- a/tests/unit/phpDocumentor/Transformer/Writer/TwigTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/TwigTest.php
@@ -121,7 +121,9 @@ final class TwigTest extends TestCase
         );
         $transformation->setTransformer($transformer->reveal());
 
-        $this->writer->transform(new ProjectDescriptor('project'), $transformation);
+        $project = new ProjectDescriptor('project');
+        $this->writer->initialize($project, $this->faker()->template());
+        $this->writer->transform($project, $transformation);
 
         $this->assertFileExists($targetDir . '/index.html');
         $this->assertStringEqualsFile($targetDir . '/index.html', 'This is a twig file');


### PR DESCRIPTION
By moving the init of twig to an init step we are clearing the road
to start processing documentation sets. The phpDoc twig extension uses the
context now to configure the router on render. Which removes direct calls to the
extension. And make it possible to switch context without touching the extension state.