### PR TITLE
Add php 8 syntax support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "league/uri-interfaces": "^2.0",
         "phpdocumentor/flyfinder": "^1.0",
         "phpdocumentor/graphviz": "^2.0",
-        "phpdocumentor/reflection": "^4.0",
+        "phpdocumentor/reflection": "5.x-dev",
         "phpdocumentor/reflection-common": "^2.0",
         "phpdocumentor/reflection-docblock": "^5.0",
         "phpdocumentor/type-resolver": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfa643ca88ba1d5b73777b6482fdbd05",
+    "content-hash": "993654322dbf599f3960cc5deabf4f83",
     "packages": [
         {
             "name": "doctrine/event-manager",
@@ -1120,16 +1120,16 @@
         },
         {
             "name": "phpdocumentor/reflection",
-            "version": "4.0.1",
+            "version": "5.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/Reflection.git",
-                "reference": "447928a45710d6313e68774cf12b5f730b909baa"
+                "reference": "c32a142d0f6ccb498a02d47f8338ef7c91d50311"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/447928a45710d6313e68774cf12b5f730b909baa",
-                "reference": "447928a45710d6313e68774cf12b5f730b909baa",
+                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/c32a142d0f6ccb498a02d47f8338ef7c91d50311",
+                "reference": "c32a142d0f6ccb498a02d47f8338ef7c91d50311",
                 "shasum": ""
             },
             "require": {
@@ -1143,12 +1143,13 @@
             },
             "require-dev": {
                 "mikey179/vfsstream": "~1.2",
-                "mockery/mockery": "~1.0"
+                "mockery/mockery": "~1.3.2"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-4.x": "4.1.x-dev"
+                    "dev-4.x": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1168,7 +1169,11 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2020-06-19T18:26:14+00:00"
+            "support": {
+                "issues": "https://github.com/phpDocumentor/Reflection/issues",
+                "source": "https://github.com/phpDocumentor/Reflection/tree/5.x"
+            },
+            "time": "2021-02-25T18:42:22+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -4454,7 +4459,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "phpdocumentor/reflection": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/config/reflection.yaml
+++ b/config/reflection.yaml
@@ -1,0 +1,58 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+  _instanceof:
+    phpDocumentor\Reflection\Php\ProjectFactoryStrategy:
+      tags: ['phpdoc.reflection.strategy']
+
+  phpDocumentor\Reflection\Php\:
+    resource: '../vendor/phpdocumentor/reflection/src/phpDocumentor/Reflection/Php'
+
+  phpDocumentor\Reflection\Php\NodesFactory:
+    class: phpDocumentor\Reflection\Php\NodesFactory
+    factory: [ phpDocumentor\Reflection\Php\NodesFactory, 'createInstance' ]
+
+  phpDocumentor\Reflection\FqsenResolver: ~
+  phpDocumentor\Reflection\DocBlock\TagFactory: '@phpDocumentor\Reflection\DocBlock\StandardTagFactory'
+  phpDocumentor\Reflection\DocBlock\StandardTagFactory:
+    calls:
+      - [ 'addService', [ '@phpDocumentor\Reflection\DocBlock\DescriptionFactory' ] ]
+      - [ 'addService', [ '@phpDocumentor\Reflection\TypeResolver' ] ]
+  phpDocumentor\Reflection\TypeResolver: ~
+  phpDocumentor\Reflection\DocBlock\DescriptionFactory: ~
+  phpDocumentor\Reflection\DocBlockFactoryInterface:
+    class: phpDocumentor\Reflection\DocBlockFactory
+    factory: [ \phpDocumentor\Reflection\DocBlockFactory, 'createInstance' ]
+
+  phpDocumentor\Reflection\Php\Factory\ConstructorPromotion:
+    arguments:
+      $methodStrategy: '@phpDocumentor\Reflection\Php\Factory\Method'
+    tags:
+      - name: 'phpdoc.reflection.strategy'
+        priority: 1100
+
+  phpDocumentor\Reflection\Php\Factory\Noop:
+    tags:
+      - name: 'phpdoc.reflection.strategy'
+        priority: -10000
+
+  phpDocumentor\Reflection\Php\Factory\File:
+    factory: [ phpDocumentor\Parser\FileFactory, 'createInstance' ]
+    arguments:
+      $middlewares: !tagged phpdoc.parser.middleware
+
+  phpDocumentor\Reflection\ProjectFactory:
+    class: phpDocumentor\Reflection\Php\ProjectFactory
+    arguments:
+      $strategies: '@phpDocumentor\Reflection\Php\ProjectFactoryStrategies'
+
+  phpDocumentor\Reflection\Php\ProjectFactoryStrategies:
+    arguments:
+      $strategies: []
+
+
+  ###################################################################################
+  ## Autoloading definitions for external services ##################################
+  ###################################################################################
+  PhpParser\PrettyPrinter\Standard: ~

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,5 +1,6 @@
 imports:
   - { resource: 'pipelines.yaml' }
+  - { resource: 'reflection.yaml' }
   - { resource: 'stages.yaml' }
 
 parameters:
@@ -158,57 +159,6 @@ services:
             - [insert, ['@phpDocumentor\Compiler\Pass\ResolveInlineMarkers', !php/const \phpDocumentor\Compiler\Pass\ResolveInlineMarkers::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Compiler\Pass\Debug', !php/const \phpDocumentor\Compiler\Pass\Debug::COMPILER_PRIORITY]]
             - [insert, ['@phpDocumentor\Compiler\Linker\Linker', !php/const \phpDocumentor\Compiler\Linker\Linker::COMPILER_PRIORITY]]
-
-    phpDocumentor\Reflection\Php\NodesFactory:
-        class: phpDocumentor\Reflection\Php\NodesFactory
-        factory: [phpDocumentor\Reflection\Php\NodesFactory, 'createInstance']
-
-    PhpParser\PrettyPrinter\Standard: ~
-    phpDocumentor\Reflection\FqsenResolver: ~
-    phpDocumentor\Reflection\DocBlock\TagFactory: '@phpDocumentor\Reflection\DocBlock\StandardTagFactory'
-    phpDocumentor\Reflection\DocBlock\StandardTagFactory:
-      calls:
-        - [ 'addService', ['@phpDocumentor\Reflection\DocBlock\DescriptionFactory']]
-        - [ 'addService', ['@phpDocumentor\Reflection\TypeResolver']]
-    phpDocumentor\Reflection\TypeResolver: ~
-    phpDocumentor\Reflection\DocBlock\DescriptionFactory: ~
-    phpDocumentor\Reflection\DocBlockFactoryInterface:
-        class: phpDocumentor\Reflection\DocBlockFactory
-        factory: [\phpDocumentor\Reflection\DocBlockFactory, 'createInstance']
-    phpDocumentor\Reflection\Php\Factory\Argument: ~
-    phpDocumentor\Reflection\Php\Factory\Class_: ~
-    phpDocumentor\Reflection\Php\Factory\Define: ~
-    phpDocumentor\Reflection\Php\Factory\ClassConstant: ~
-    phpDocumentor\Reflection\Php\Factory\GlobalConstant: ~
-    phpDocumentor\Reflection\Php\Factory\DocBlock: ~
-    phpDocumentor\Reflection\Php\Factory\Function_: ~
-    phpDocumentor\Reflection\Php\Factory\Interface_: ~
-    phpDocumentor\Reflection\Php\Factory\Method: ~
-    phpDocumentor\Reflection\Php\Factory\Property: ~
-    phpDocumentor\Reflection\Php\Factory\Trait_: ~
-
-    phpDocumentor\Reflection\Php\Factory\File:
-        factory: [phpDocumentor\Parser\FileFactory, 'createInstance']
-        arguments:
-            - '@phpDocumentor\Reflection\Php\NodesFactory'
-            - !tagged phpdoc.parser.middleware
-
-    phpDocumentor\Reflection\ProjectFactory:
-        class: phpDocumentor\Reflection\Php\ProjectFactory
-        arguments:
-            -
-                - '@phpDocumentor\Reflection\Php\Factory\Argument'
-                - '@phpDocumentor\Reflection\Php\Factory\Class_'
-                - '@phpDocumentor\Reflection\Php\Factory\Define'
-                - '@phpDocumentor\Reflection\Php\Factory\ClassConstant'
-                - '@phpDocumentor\Reflection\Php\Factory\GlobalConstant'
-                - '@phpDocumentor\Reflection\Php\Factory\DocBlock'
-                - '@phpDocumentor\Reflection\Php\Factory\Function_'
-                - '@phpDocumentor\Reflection\Php\Factory\Interface_'
-                - '@phpDocumentor\Reflection\Php\Factory\Method'
-                - '@phpDocumentor\Reflection\Php\Factory\Property'
-                - '@phpDocumentor\Reflection\Php\Factory\Trait_'
-                - '@phpDocumentor\Reflection\Php\Factory\File'
 
     phpDocumentor\Parser\Parser: ~
 

--- a/src/phpDocumentor/DependencyInjection/ReflectionProjectFactoryStrategyPass.php
+++ b/src/phpDocumentor/DependencyInjection/ReflectionProjectFactoryStrategyPass.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\DependencyInjection;
+
+use phpDocumentor\Reflection\Php\ProjectFactoryStrategies;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use function array_column;
+
+/**
+ * Custom Compiler pass to help symfony to construct the ProjectFactoryStrategies
+ *
+ * All strategies defined in {@see \phpDocumentor\Reflection\Php\Factory} are injected automatically by our service
+ * configuration with a default priority. In some situations this needs to be overwritten. This compiler pass helps us
+ * with that part. It will find the tagged services and add them to the {@see ProjectFactoryStrategies}, if multiple
+ * `phpdoc.reflection.strategy` tags are defined it will inject them multiple times with different priority.
+ * If no priority is defined the default will be used.
+ */
+final class ReflectionProjectFactoryStrategyPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container) : void
+    {
+        $strategies = $container->getDefinition(ProjectFactoryStrategies::class);
+        foreach ($container->findTaggedServiceIds('phpdoc.reflection.strategy') as $id => $tags) {
+            $priotities = array_column($tags, 'priority');
+            if (empty($priotities)) {
+                $strategies->addMethodCall(
+                    'addStrategy',
+                    [
+                        new Reference($id),
+                        ProjectFactoryStrategies::DEFAULT_PRIORITY,
+                    ]
+                );
+
+                continue;
+            }
+
+            foreach ($priotities as $priotity) {
+                $strategies->addMethodCall(
+                    'addStrategy',
+                    [
+                        new Reference($id),
+                        $priotity ?? ProjectFactoryStrategies::DEFAULT_PRIORITY,
+                    ]
+                );
+            }
+        }
+    }
+}

--- a/src/phpDocumentor/Kernel.php
+++ b/src/phpDocumentor/Kernel.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor;
 
 use Phar;
+use phpDocumentor\DependencyInjection\ReflectionProjectFactoryStrategyPass;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -91,6 +92,11 @@ class Kernel extends BaseKernel
                 yield new $class();
             }
         }
+    }
+
+    public function build(ContainerBuilder $container) : void
+    {
+        $container->addCompilerPass(new ReflectionProjectFactoryStrategyPass());
     }
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader) : void

--- a/src/phpDocumentor/Parser/FileFactory.php
+++ b/src/phpDocumentor/Parser/FileFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Parser;
 
 use IteratorAggregate;
+use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Middleware\Middleware;
 use phpDocumentor\Reflection\Php\Factory;
 use phpDocumentor\Reflection\Php\NodesFactory;
@@ -27,8 +28,11 @@ final class FileFactory
      *
      * @param IteratorAggregate<Middleware> $middlewares
      */
-    public static function createInstance(NodesFactory $nodesFactory, IteratorAggregate $middlewares) : Factory\File
-    {
-        return new Factory\File($nodesFactory, iterator_to_array($middlewares));
+    public static function createInstance(
+        DocBlockFactoryInterface $blockFactory,
+        NodesFactory $nodesFactory,
+        IteratorAggregate $middlewares
+    ) : Factory\File {
+        return new Factory\File($blockFactory, $nodesFactory, iterator_to_array($middlewares));
     }
 }

--- a/src/phpDocumentor/Parser/Middleware/ReEncodingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/ReEncodingMiddleware.php
@@ -43,6 +43,6 @@ final class ReEncodingMiddleware implements Middleware
             (new ByteString($command->getFile()->getContents()))->toUnicodeString($this->encoding)
         );
 
-        return $next(new CreateCommand($file, $command->getStrategies()));
+        return $next(new CreateCommand($command->getContext(), $file, $command->getStrategies()));
     }
 }

--- a/tests/unit/phpDocumentor/DependencyInjection/ReflectionProjectFactoryStrategyPassTest.php
+++ b/tests/unit/phpDocumentor/DependencyInjection/ReflectionProjectFactoryStrategyPassTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\DependencyInjection;
+
+use phpDocumentor\Reflection\Php\ProjectFactoryStrategies;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @coversDefaultClass \phpDocumentor\DependencyInjection\ReflectionProjectFactoryStrategyPass
+ */
+final class ReflectionProjectFactoryStrategyPassTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @covers ::process */
+    public function testTaggedStrategiesAreInjectedWithDefaultPriority() : void
+    {
+        $serviceDefinition = new Definition(ProjectFactoryStrategies::class);
+
+        $container = $this->prophesize(ContainerBuilder::class);
+        $container->getDefinition(ProjectFactoryStrategies::class)
+            ->willReturn($serviceDefinition);
+
+        $container->findTaggedServiceIds('phpdoc.reflection.strategy')->willReturn(
+            [
+                'myStrategy' => [],
+            ]
+        );
+
+        $compilerPass = new ReflectionProjectFactoryStrategyPass();
+
+        $compilerPass->process($container->reveal());
+
+        self::assertEquals(
+            [
+                [
+                    'addStrategy',
+                    [
+                        new Reference('myStrategy'),
+                        ProjectFactoryStrategies::DEFAULT_PRIORITY,
+                    ],
+                ],
+            ],
+            $serviceDefinition->getMethodCalls()
+        );
+    }
+
+    /** @covers ::process */
+    public function testTaggedStrategiesAreInjectedWithOverwrittenPriority() : void
+    {
+        $serviceDefinition = new Definition(ProjectFactoryStrategies::class);
+
+        $container = $this->prophesize(ContainerBuilder::class);
+        $container->getDefinition(ProjectFactoryStrategies::class)
+            ->willReturn($serviceDefinition);
+
+        $container->findTaggedServiceIds('phpdoc.reflection.strategy')->willReturn(
+            [
+                'myStrategy' => [],
+                'myStrategyOther' => [
+                    ['priority' => 1100],
+                    [],
+                ],
+            ]
+        );
+
+        $compilerPass = new ReflectionProjectFactoryStrategyPass();
+
+        $compilerPass->process($container->reveal());
+
+        self::assertEquals(
+            [
+                [
+                    'addStrategy',
+                    [
+                        new Reference('myStrategy'),
+                        ProjectFactoryStrategies::DEFAULT_PRIORITY,
+                    ],
+                ],
+                [
+                    'addStrategy',
+                    [
+                        new Reference('myStrategyOther'),
+                        1100,
+                    ],
+                ],
+            ],
+            $serviceDefinition->getMethodCalls()
+        );
+    }
+}

--- a/tests/unit/phpDocumentor/Faker/Provider.php
+++ b/tests/unit/phpDocumentor/Faker/Provider.php
@@ -11,6 +11,8 @@ use League\Flysystem\MountManager;
 use Mockery as m;
 use phpDocumentor\Configuration\SymfonyConfigFactory;
 use phpDocumentor\Parser\FlySystemFactory;
+use phpDocumentor\Reflection\Php\Factory\ContextStack;
+use phpDocumentor\Reflection\Php\Project;
 use phpDocumentor\Transformer\Template;
 use phpDocumentor\Transformer\Transformation;
 use phpDocumentor\Transformer\Transformer;
@@ -74,5 +76,12 @@ final class Provider extends Base
             ->scalarNode(SymfonyConfigFactory::FIELD_CONFIG_VERSION)->defaultValue($version)->end();
 
         return $treebuilder;
+    }
+
+    public function phpParserContext() : ContextStack
+    {
+        return new ContextStack(
+            new Project('test')
+        );
     }
 }

--- a/tests/unit/phpDocumentor/Parser/FileFactoryTest.php
+++ b/tests/unit/phpDocumentor/Parser/FileFactoryTest.php
@@ -17,6 +17,7 @@ use ArrayObject;
 use InvalidArgumentException;
 use phpDocumentor\Parser\FileFactory;
 use phpDocumentor\Parser\Middleware\EmittingMiddleware;
+use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Php\NodesFactory;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -30,6 +31,7 @@ final class FileFactoryTest extends TestCase
     public function testIfFileFactoryIsCreatedUsingAnArray() : void
     {
         FileFactory::createInstance(
+            $this->prophesize(DocBlockFactoryInterface::class)->reveal(),
             NodesFactory::createInstance(),
             new ArrayObject([new EmittingMiddleware()])
         );
@@ -51,6 +53,7 @@ final class FileFactoryTest extends TestCase
         );
 
         FileFactory::createInstance(
+            $this->prophesize(DocBlockFactoryInterface::class)->reveal(),
             NodesFactory::createInstance(),
             new ArrayObject([new stdClass()])
         );

--- a/tests/unit/phpDocumentor/Parser/Middleware/CacheMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Parser/Middleware/CacheMiddlewareTest.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Parser\Middleware;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamFile;
+use phpDocumentor\Faker\Faker;
 use phpDocumentor\Reflection\File;
 use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
 use phpDocumentor\Reflection\Php\File as ReflectedFile;
@@ -32,6 +33,8 @@ use function serialize;
  */
 final class CacheMiddlewareTest extends TestCase
 {
+    use Faker;
+
     /**
      * @covers ::execute
      */
@@ -46,7 +49,11 @@ final class CacheMiddlewareTest extends TestCase
         $middleware = new CacheMiddleware($cacheInterface, new NullLogger());
 
         $response = $middleware->execute(
-            new CreateCommand(new File\LocalFile($file->url()), new ProjectFactoryStrategies([])),
+            new CreateCommand(
+                $this->faker()->phpParserContext(),
+                new File\LocalFile($file->url()),
+                new ProjectFactoryStrategies([])
+            ),
             function () : void {
                 $this->fail('If we entered the next state; then caching failed');
             }
@@ -68,7 +75,11 @@ final class CacheMiddlewareTest extends TestCase
         $middleware = new CacheMiddleware($cacheInterface, new NullLogger());
 
         $response = $middleware->execute(
-            new CreateCommand(new File\LocalFile($file->url()), new ProjectFactoryStrategies([])),
+            new CreateCommand(
+                $this->faker()->phpParserContext(),
+                new File\LocalFile($file->url()),
+                new ProjectFactoryStrategies([])
+            ),
             static function () use ($reflectedFile) {
                 return $reflectedFile;
             }

--- a/tests/unit/phpDocumentor/Parser/Middleware/EmittingMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Parser/Middleware/EmittingMiddlewareTest.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Parser\Middleware;
 
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Event\Dispatcher;
+use phpDocumentor\Faker\Faker;
 use phpDocumentor\Parser\Event\PreFileEvent;
 use phpDocumentor\Reflection\File\LocalFile;
 use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
@@ -28,6 +29,8 @@ use function md5;
  */
 final class EmittingMiddlewareTest extends TestCase
 {
+    use Faker;
+
     /**
      * @covers ::execute
      */
@@ -40,7 +43,11 @@ final class EmittingMiddlewareTest extends TestCase
         $file = new FileDescriptor(md5('result'));
         $file->setPath($filename);
 
-        $command = new CreateCommand(new LocalFile($filename), new ProjectFactoryStrategies([]));
+        $command = new CreateCommand(
+            $this->faker()->phpParserContext(),
+            new LocalFile($filename),
+            new ProjectFactoryStrategies([])
+        );
 
         Dispatcher::getInstance()->addListener(
             'parser.file.pre',

--- a/tests/unit/phpDocumentor/Parser/Middleware/ErrorHandlingMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Parser/Middleware/ErrorHandlingMiddlewareTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Parser\Middleware;
 
 use Exception;
+use phpDocumentor\Faker\Faker;
 use phpDocumentor\Parser\Middleware\ErrorHandlingMiddleware;
 use phpDocumentor\Reflection\File\LocalFile;
 use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
@@ -32,6 +33,7 @@ use Psr\Log\LogLevel;
  */
 final class ErrorHandlingMiddlewareTest extends TestCase
 {
+    use Faker;
     use ProphecyTrait;
 
     /**
@@ -41,7 +43,11 @@ final class ErrorHandlingMiddlewareTest extends TestCase
     {
         $filename = __FILE__;
         $expected = new File('abc', $filename);
-        $command = new CreateCommand(new LocalFile($filename), new ProjectFactoryStrategies([]));
+        $command = new CreateCommand(
+            $this->faker()->phpParserContext(),
+            new LocalFile($filename),
+            new ProjectFactoryStrategies([])
+        );
 
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->log(LogLevel::INFO, 'Starting to parse file: ' . __FILE__, [])->shouldBeCalled();
@@ -65,7 +71,11 @@ final class ErrorHandlingMiddlewareTest extends TestCase
     public function testThatAnErrorIsLogged() : void
     {
         $filename = __FILE__;
-        $command = new CreateCommand(new LocalFile($filename), new ProjectFactoryStrategies([]));
+        $command = new CreateCommand(
+            $this->faker()->phpParserContext(),
+            new LocalFile($filename),
+            new ProjectFactoryStrategies([])
+        );
 
         $logger = $this->prophesize(LoggerInterface::class);
         $logger->log(LogLevel::INFO, 'Starting to parse file: ' . __FILE__, [])->shouldBeCalled();

--- a/tests/unit/phpDocumentor/Parser/Middleware/ReEncodingMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Parser/Middleware/ReEncodingMiddlewareTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Parser\Middleware;
 
+use phpDocumentor\Faker\Faker;
 use phpDocumentor\Parser\ReEncodedFile;
 use phpDocumentor\Reflection\File;
 use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
@@ -29,6 +30,7 @@ use Symfony\Component\String\UnicodeString;
  */
 final class ReEncodingMiddlewareTest extends TestCase
 {
+    use Faker;
     use ProphecyTrait;
 
     /**
@@ -43,7 +45,7 @@ final class ReEncodingMiddlewareTest extends TestCase
         $middleware = new ReEncodingMiddleware();
         $middleware->withEncoding('iso-8859-1');
         $result = $middleware->execute(
-            new CreateCommand($file, new ProjectFactoryStrategies([])),
+            new CreateCommand($this->faker()->phpParserContext(), $file, new ProjectFactoryStrategies([])),
             function (CreateCommand $command) use ($contents) : PhpFile {
                 $reEncodedFile = $command->getFile();
                 $this->assertInstanceOf(ReEncodedFile::class, $reEncodedFile);
@@ -73,7 +75,11 @@ final class ReEncodingMiddlewareTest extends TestCase
         $middleware = new ReEncodingMiddleware();
         $middleware->withEncoding('utf-8');
         $middleware->execute(
-            new CreateCommand($file, new ProjectFactoryStrategies([])),
+            new CreateCommand(
+                $this->faker()->phpParserContext(),
+                $file,
+                new ProjectFactoryStrategies([])
+            ),
             static function () : void {
                 // not important; never called due to exception
             }

--- a/tests/unit/phpDocumentor/Parser/Middleware/StopwatchMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Parser/Middleware/StopwatchMiddlewareTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Parser\Middleware;
 
+use phpDocumentor\Faker\Faker;
 use phpDocumentor\Parser\Middleware\StopwatchMiddleware;
 use phpDocumentor\Reflection\File\LocalFile;
 use phpDocumentor\Reflection\Php\Factory\File\CreateCommand;
@@ -33,6 +34,7 @@ use Symfony\Component\Stopwatch\StopwatchPeriod;
  */
 final class StopwatchMiddlewareTest extends TestCase
 {
+    use Faker;
     use ProphecyTrait;
 
     /**
@@ -41,7 +43,11 @@ final class StopwatchMiddlewareTest extends TestCase
     public function testThatMemoryUsageIsLogged() : void
     {
         $commandFile = new LocalFile(__FILE__);
-        $command = new CreateCommand($commandFile, new ProjectFactoryStrategies([]));
+        $command = new CreateCommand(
+            $this->faker()->phpParserContext(),
+            $commandFile,
+            new ProjectFactoryStrategies([])
+        );
 
         $logger = $this->prophesize(LoggerInterface::class);
         $logger


### PR DESCRIPTION
The new under development version of our reflection lib adds
supports php8 syntax. To be able to support a number of more complex
reflection types like ConstructorPropertyPromotion required some internal
changes to the lib. This required a new way of configuring the strategies.

That's why I introduced the CompilerPass to make it easier to configure new strategies
but also to be more flexible when new strategies are introduced in the lib.