### PR TITLE
Fully support UTF-8 in reSructuredText tables

### DIFF
--- a/src/Guides/Nodes/Table/TableColumn.php
+++ b/src/Guides/Nodes/Table/TableColumn.php
@@ -17,7 +17,6 @@ use LogicException;
 use phpDocumentor\Guides\Nodes\Node;
 use function strlen;
 use function trim;
-use function utf8_encode;
 
 final class TableColumn
 {
@@ -35,7 +34,7 @@ final class TableColumn
 
     public function __construct(string $content, int $colSpan)
     {
-        $this->content = utf8_encode(trim($content));
+        $this->content = trim($content);
         $this->colSpan = $colSpan;
     }
 
@@ -62,7 +61,7 @@ final class TableColumn
 
     public function addContent(string $content) : void
     {
-        $this->content = trim($this->content . utf8_encode($content));
+        $this->content = trim($this->content . $content);
     }
 
     public function incrementRowSpan() : void


### PR DESCRIPTION
Removes the intermediate conversion from UTF-8 to ISO-8859-1 and vice
versa when compiling tables.

This fixes the double encoding that caused #2937 and similar issues. It
also adds support for characters, that are not covered by ISO-8859-1 and
would lead to data loss when compiling tables containing such
characters.