### PR TITLE
GH Actions: allow for manually triggering a workflow

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -3,6 +3,8 @@ on:
     - cron: 0 0 1 * * # run monthly
   repository_dispatch: # run manually
     types: [check-link]
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 name: Broken Link Check
 jobs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - master
   pull_request:
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 name: Qa workflow
 env:
   extensions: mbstring, intl, iconv, libxml, dom, json, simplexml, zlib, fileinfo


### PR DESCRIPTION
Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

This is useful if, for instance, an external action script or composer dependency has broken.
Once a fix is available, failing builds for open PRs can be retriggered manually instead of having to be re-pushed to retrigger the workflow.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/