### PR TITLE
GH Actions: ubuntu-16.04 is no longer supported

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -312,7 +312,7 @@ jobs:
           path: build/phpDocumentor.phar
 
   e2e:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     name: E2E tests [ubuntu-latest]
     needs:
       - setup
@@ -468,7 +468,7 @@ jobs:
           - '7.4'
           - '8.0'
         operating-system:
-          - ubuntu-16.04
+          - ubuntu-latest
           - windows-latest
           - macOS-latest
     name: E2E tests on PHAR [${{ matrix.php-versions }} | ${{ matrix.operating-system }}]


### PR DESCRIPTION
... use `ubuntu-18.04` or `ubuntu-latest` for `20.04` instead.

Also see:
* https://ubuntu.com/blog/ubuntu-16-04-lts-transitions-to-extended-security-maintenance-esm
* https://github.com/shivammathur/setup-php/issues/452