### PR TITLE
Tests: fix an incorrect namespace

### DIFF
--- a/tests/unit/Guides/RestructuredText/Twig/AssetsExtensionTest.php
+++ b/tests/unit/Guides/RestructuredText/Twig/AssetsExtensionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace phpDocumentor\Guides\Twig;
+namespace phpDocumentor\Guides\RestructuredText\Twig;
 
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
Fixes the following issue when running `composer install`:
```
Class phpDocumentor\Guides\Twig\AssetsExtensionTest located in ./tests/unit/Guides/RestructuredText/Twig/AssetsExtensionTest.php does not comply with psr-4 autoloading standard. Skipping.
```