### PR TITLE
PHP 8.1: fix various deprecation warnings

### DIFF
--- a/src/phpDocumentor/Configuration/LegacyArrayAccess.php
+++ b/src/phpDocumentor/Configuration/LegacyArrayAccess.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Configuration;
 
 use InvalidArgumentException;
+use ReturnTypeWillChange;
 
 use function lcfirst;
 use function property_exists;
@@ -23,6 +24,7 @@ use function ucwords;
 trait LegacyArrayAccess
 {
     /** @param string $offset */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         $property = $this->normalizePropertyName($offset);
@@ -35,6 +37,7 @@ trait LegacyArrayAccess
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $property = $this->normalizePropertyName($offset);
@@ -49,6 +52,7 @@ trait LegacyArrayAccess
      * @param string $offset
      * @param mixed $value
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         $property = $this->normalizePropertyName($offset);
@@ -60,6 +64,7 @@ trait LegacyArrayAccess
     }
 
     /** @param string $offset */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         $property = $this->normalizePropertyName($offset);

--- a/src/phpDocumentor/Configuration/Source.php
+++ b/src/phpDocumentor/Configuration/Source.php
@@ -18,6 +18,7 @@ use BadMethodCallException;
 use OutOfBoundsException;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
+use ReturnTypeWillChange;
 
 use function array_map;
 use function in_array;
@@ -107,6 +108,7 @@ final class Source implements ArrayAccess
     }
 
     /** @param string $offset */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return in_array($offset, ['dsn', 'paths']);
@@ -117,6 +119,7 @@ final class Source implements ArrayAccess
      *
      * @return Path[]|Dsn
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         switch ($offset) {
@@ -135,12 +138,14 @@ final class Source implements ArrayAccess
      * @param string $offset
      * @param mixed $value
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         throw new BadMethodCallException('Cannot set offset of ' . self::class);
     }
 
     /** @param string $offset */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         throw new BadMethodCallException('Cannot unset offset of ' . self::class);

--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -19,6 +19,7 @@ use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;
 use OutOfRangeException;
+use ReturnTypeWillChange;
 use Webmozart\Assert\Assert;
 
 use function array_filter;
@@ -129,6 +130,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
      *
      * @return ArrayIterator<string|int, T>
      */
+    #[ReturnTypeWillChange]
     public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->items);
@@ -137,6 +139,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
     /**
      * Returns a count of the number of elements in this collection.
      */
+    #[ReturnTypeWillChange]
     public function count(): int
     {
         return count($this->items);
@@ -166,6 +169,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
      *
      * @param string|int $offset The index to check on.
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return isset($this->items[$offset]);
@@ -178,6 +182,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
      *
      * @return ?T
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->items[$offset] : null;
@@ -191,6 +196,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
      *
      * @throws InvalidArgumentException If the key is null or an empty string.
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         if ($offset === '' || $offset === null) {
@@ -207,6 +213,7 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
      *
      * @param string|int $offset The offset to unset.
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         unset($this->items[$offset]);

--- a/src/phpDocumentor/Transformer/Template.php
+++ b/src/phpDocumentor/Transformer/Template.php
@@ -20,6 +20,7 @@ use InvalidArgumentException;
 use IteratorAggregate;
 use League\Flysystem\MountManager;
 use phpDocumentor\Transformer\Template\Parameter;
+use ReturnTypeWillChange;
 
 use function array_merge;
 use function count;
@@ -186,6 +187,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
      *
      * @throws InvalidArgumentException If an invalid item was received.
      */
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value): void
     {
         if (!$value instanceof Transformation) {
@@ -203,6 +205,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
      *
      * @param int|string $offset The offset to retrieve from.
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset): Transformation
     {
         return $this->transformations[$offset];
@@ -215,6 +218,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
      *
      * @param int|string $offset Index of item to unset.
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset): void
     {
         unset($this->transformations[$offset]);
@@ -229,6 +233,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return bool Returns true on success or false on failure.
      */
+    #[ReturnTypeWillChange]
     public function offsetExists($offset): bool
     {
         return isset($this->transformations[$offset]);
@@ -241,6 +246,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return int The count as an integer.
      */
+    #[ReturnTypeWillChange]
     public function count(): int
     {
         return count($this->transformations);
@@ -279,6 +285,7 @@ final class Template implements ArrayAccess, Countable, IteratorAggregate
     /**
      * @return ArrayIterator<int|string, Transformation>
      */
+    #[ReturnTypeWillChange]
     public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->transformations);


### PR DESCRIPTION
A run on PHP 8.1 currently shows various notices along the lines of:
```
Deprecated: Return type of [CLASSNAME]::[METHODNAME]() should either be compatible with [INTERFACENAME]::[METHODNAME](): [Type], or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

These deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

While this package has a minimum PHP requirement of PHP 7.2 based on the `composer.json` file, several of these return types expect for the PHP 8.0 `mixed` type to be used, so for consistency across the codebase, I've used the attribute for now to silence the warning.

While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will ignored in PHP < 8 and can be safely added.