### PR TITLE
GH Actions: don't include dev dependencies in PHAR

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Install Composer dependencies & cache dependencies
         uses: "ramsey/composer-install@v1"
         with:
-          composer-options: --optimize-autoloader
+          composer-options: --no-dev --optimize-autoloader
 
       - name: warm cache
         uses: phpDocumentor/phar-ga@latest


### PR DESCRIPTION
As they shouldn't be needed in the production PHAR and will allow for the PHAR file to be smaller.