### PR TITLE
Add support for php:class role in Guides

### DIFF
--- a/docs/internals/configuration.rst
+++ b/docs/internals/configuration.rst
@@ -7,8 +7,8 @@ Introduction
 phpDocumentor's configuration module provides the application with the ability to load configuration from disk and
 augments that with the information provided by the user when they started phpDocumentor.
 
-In doing this it populates an entity of class `phpDocumentor\Configuration\Configuration` and adjusts this when newer
-configuration options become available.
+In doing this it populates an entity of class :php:class:`phpDocumentor\Configuration\Configuration` and adjusts this
+when newer configuration options become available.
 
     Please note: this is a mutable object that may change during the life cycle of the application by design.
 

--- a/src/Guides/Environment.php
+++ b/src/Guides/Environment.php
@@ -147,7 +147,7 @@ class Environment
 
     public function registerReference(Reference $reference): void
     {
-        $this->references[$reference->getName()] = $reference;
+        $this->references[$reference->getRole()] = $reference;
     }
 
     public function resolve(string $section, string $data): ?ResolvedReference
@@ -202,17 +202,22 @@ class Environment
     /**
      * @return string[]|null
      */
-    public function found(string $section, string $data): ?array
+    public function found(string $section, array $data): ?array
     {
-        if (isset($this->references[$section])) {
-            $reference = $this->references[$section];
+        $role = $section;
+        if ($data['domain'] ?? '') {
+            $role = $data['domain'] . ':' . $role;
+        }
 
-            $reference->found($this, $data);
+        if (isset($this->references[$role])) {
+            $reference = $this->references[$role];
+
+            $reference->found($this, $data['url']);
 
             return null;
         }
 
-        $this->addMissingReferenceSectionError($section);
+        $this->addMissingReferenceSectionError($role);
 
         return null;
     }

--- a/src/Guides/Environment.php
+++ b/src/Guides/Environment.php
@@ -200,6 +200,7 @@ class Environment
     }
 
     /**
+     * @param string[] $data
      * @return string[]|null
      */
     public function found(string $section, array $data): ?array

--- a/src/Guides/Environment.php
+++ b/src/Guides/Environment.php
@@ -200,7 +200,8 @@ class Environment
     }
 
     /**
-     * @param string[] $data
+     * @param array{anchor: ?string, domain: string, section: string, text: ?string, url: ?string} $data
+     *
      * @return string[]|null
      */
     public function found(string $section, array $data): ?array

--- a/src/Guides/Handlers/RenderHandler.php
+++ b/src/Guides/Handlers/RenderHandler.php
@@ -79,14 +79,14 @@ final class RenderHandler
     }
 
     private function render(
-        GuideSetDescriptor $documtationSet,
+        GuideSetDescriptor $documentationSet,
         Environment $environment,
         FilesystemInterface $destination
     ): void {
         $this->initReferences($environment, $this->references);
-        foreach ($documtationSet->getDocuments() as $file => $descriptor) {
+        foreach ($documentationSet->getDocuments() as $file => $descriptor) {
             $document = $descriptor->getDocumentNode();
-            $target = $documtationSet->getOutput() . '/' . $this->router->generate($descriptor);
+            $target = $documentationSet->getOutput() . '/' . $this->router->generate($descriptor);
 
             $directory = dirname($target);
 

--- a/src/Guides/NodeRenderers/SpanNodeRenderer.php
+++ b/src/Guides/NodeRenderers/SpanNodeRenderer.php
@@ -183,7 +183,12 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer
 
     private function renderReference(SpanToken $spanToken, string $span): string
     {
-        $reference = $this->environment->resolve($spanToken->get('section'), $spanToken->get('url'));
+        $role = $spanToken->get('section');
+        if ($spanToken->get('domain')) {
+            $role = $spanToken->get('domain') . ':' . $role;
+        }
+
+        $reference = $this->environment->resolve($role, $spanToken->get('url'));
 
         if ($reference === null) {
             $this->environment->addInvalidLink(new InvalidLink($spanToken->get('url')));

--- a/src/Guides/References/Php/ClassReference.php
+++ b/src/Guides/References/Php/ClassReference.php
@@ -11,30 +11,34 @@ declare(strict_types=1);
  * @link https://phpdoc.org
  */
 
-namespace phpDocumentor\Guides\References;
+namespace phpDocumentor\Guides\References\Php;
 
 use phpDocumentor\Guides\Environment;
+use phpDocumentor\Guides\References\ResolvedReference;
 
 use function sprintf;
 use function str_replace;
-use function strtolower;
 
 /**
  * @link https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html
+ * @link https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html
  */
-class PhpFunctionReference extends Reference
+final class ClassReference extends Reference
 {
     public function getName(): string
     {
-        return 'php:func';
+        return 'class';
     }
 
     public function resolve(Environment $environment, string $data): ResolvedReference
     {
+        // TODO: The location of the resolved class should come from the TOC and not like this
+        $classPath = sprintf('%s/classes/%s.html', '', str_replace('\\', '-', $data));
+
         return new ResolvedReference(
             $environment->getCurrentFileName(),
             $data,
-            sprintf('%s/function.%s.php', '', str_replace('_', '-', strtolower($data))),
+            $classPath,
             [],
             ['title' => $data]
         );

--- a/src/Guides/References/Php/FunctionReference.php
+++ b/src/Guides/References/Php/FunctionReference.php
@@ -11,35 +11,27 @@ declare(strict_types=1);
  * @link https://phpdoc.org
  */
 
-namespace phpDocumentor\Guides\References;
+namespace phpDocumentor\Guides\References\Php;
 
 use phpDocumentor\Guides\Environment;
-
-use function sprintf;
-use function str_replace;
-use function strrchr;
-use function substr;
+use phpDocumentor\Guides\References\ResolvedReference;
+use RuntimeException;
 
 /**
  * @link https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html
  */
-class NamespaceReference extends Reference
+final class FunctionReference extends Reference
 {
     public function getName(): string
     {
-        return 'php:namespace';
+        return 'func';
     }
 
     public function resolve(Environment $environment, string $data): ResolvedReference
     {
-        $className = str_replace('\\\\', '\\', $data);
-
-        return new ResolvedReference(
-            $environment->getCurrentFileName(),
-            substr(strrchr($className, '\\'), 1),
-            sprintf('%s/%s.html', '', str_replace('\\', '/', $className)),
-            [],
-            ['title' => $className]
+        throw new RuntimeException(
+            'Not supported until Guides can read the API Documentation TOC because '
+            . 'functions do not have their own files but are documented in their file\'s document.'
         );
     }
 }

--- a/src/Guides/References/Php/MethodReference.php
+++ b/src/Guides/References/Php/MethodReference.php
@@ -11,9 +11,10 @@ declare(strict_types=1);
  * @link https://phpdoc.org
  */
 
-namespace phpDocumentor\Guides\References;
+namespace phpDocumentor\Guides\References\Php;
 
 use phpDocumentor\Guides\Environment;
+use phpDocumentor\Guides\References\ResolvedReference;
 use RuntimeException;
 
 use function explode;
@@ -24,15 +25,17 @@ use function strpos;
 /**
  * @link https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#python-roles
  */
-class PhpMethodReference extends Reference
+final class MethodReference extends Reference
 {
     public function getName(): string
     {
-        return 'php:meth';
+        return 'meth';
     }
 
     public function resolve(Environment $environment, string $data): ResolvedReference
     {
+        // TODO: The location of the resolved method or class should come from the TOC and not like this
+
         $className = explode('::', $data)[0];
         $className = str_replace('\\\\', '\\', $className);
 
@@ -43,11 +46,12 @@ class PhpMethodReference extends Reference
         }
 
         $methodName = explode('::', $data)[1];
+        $classPath = sprintf('%s/classes/%s.html', '', str_replace('\\', '-', $data));
 
         return new ResolvedReference(
             $environment->getCurrentFileName(),
             $methodName . '()',
-            sprintf('%s/%s.html#method_%s', '', str_replace('\\', '/', $className), $methodName),
+            sprintf('%s.html#method_%s', $classPath, $methodName),
             [],
             [
                 'title' => sprintf('%s::%s()', $className, $methodName),

--- a/src/Guides/References/Php/NamespaceReference.php
+++ b/src/Guides/References/Php/NamespaceReference.php
@@ -11,31 +11,38 @@ declare(strict_types=1);
  * @link https://phpdoc.org
  */
 
-namespace phpDocumentor\Guides\References;
+namespace phpDocumentor\Guides\References\Php;
 
 use phpDocumentor\Guides\Environment;
+use phpDocumentor\Guides\References\ResolvedReference;
 
 use function sprintf;
+use function str_replace;
+use function strrchr;
 use function strtolower;
+use function substr;
 
 /**
  * @link https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html
  */
-class PhpClassReference extends Reference
+final class NamespaceReference extends Reference
 {
     public function getName(): string
     {
-        return 'php:class';
+        return 'namespace';
     }
 
     public function resolve(Environment $environment, string $data): ResolvedReference
     {
+        // TODO: The location of the resolved namespace should come from the TOC and not like this
+        $className = str_replace('\\\\', '\\', $data);
+
         return new ResolvedReference(
             $environment->getCurrentFileName(),
-            $data,
-            sprintf('%s/class.%s.php', '', strtolower($data)),
+            substr(strrchr($className, '\\'), 1),
+            sprintf('%s/namespaces/%s.html', '', strtolower(str_replace('\\', '-', $className))),
             [],
-            ['title' => $data]
+            ['title' => $className]
         );
     }
 }

--- a/src/Guides/References/Php/Reference.php
+++ b/src/Guides/References/Php/Reference.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\References\Php;
+
+use phpDocumentor\Guides\References\Reference as BaseReference;
+
+/**
+ * @link https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html
+ * @link https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html
+ */
+abstract class Reference extends BaseReference
+{
+    public function getDomain(): string
+    {
+        return 'php';
+    }
+}

--- a/src/Guides/References/Reference.php
+++ b/src/Guides/References/Reference.php
@@ -28,9 +28,29 @@ use phpDocumentor\Guides\Environment;
 abstract class Reference
 {
     /**
+     * Returns the domain for the role of this reference, or empty in case no domain was detected.
+     *
+     * @link https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html
+     */
+    public function getDomain(): string
+    {
+        return '';
+    }
+
+    /**
      * The name of the reference, i.e the :something:
      */
     abstract public function getName(): string;
+
+    public function getRole(): string
+    {
+        $role = $this->getName();
+        if ($this->getDomain()) {
+            $role = $this->getDomain() . ':' . $role;
+        }
+
+        return $role;
+    }
 
     /**
      * Resolve the reference and returns an array

--- a/src/Guides/RestructuredText/Span/SpanParser.php
+++ b/src/Guides/RestructuredText/Span/SpanParser.php
@@ -130,11 +130,10 @@ class SpanParser
     private function replaceReferences(string $span): string
     {
         return preg_replace_callback(
-            '/:([a-z0-9]+):`(.+)`/mUsi',
+            '/:(?:([a-z0-9]+):)?([a-z0-9]+):`(.+)`/mUsi',
             function ($match) {
-                $section = $match[1];
+                [, $domain, $section, $url] = $match;
 
-                $url = $match[2];
                 $id = $this->generateId();
                 $anchor = null;
 
@@ -149,18 +148,17 @@ class SpanParser
                     $anchor = $match[2];
                 }
 
-                $this->addToken(
-                    SpanToken::TYPE_REFERENCE,
-                    $id,
-                    [
-                        'section' => $section,
-                        'url' => $url,
-                        'text' => $text,
-                        'anchor' => $anchor,
-                    ]
-                );
+                $tokenData = [
+                    'domain' => $domain,
+                    'section' => $section,
+                    'url' => $url,
+                    'text' => $text,
+                    'anchor' => $anchor,
+                ];
 
-                $this->environment->found($section, $url);
+                $this->addToken(SpanToken::TYPE_REFERENCE, $id, $tokenData);
+
+                $this->environment->found($section, $tokenData);
 
                 return $id;
             },

--- a/tests/unit/Guides/References/Php/ClassReferenceTest.php
+++ b/tests/unit/Guides/References/Php/ClassReferenceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\References\Php;
+
+use PHPUnit\Framework\TestCase;
+
+final class ClassReferenceTest extends TestCase
+{
+    public function testDomainNameAndRole(): void
+    {
+        $classReference = new ClassReference();
+
+        self::assertSame('php', $classReference->getDomain());
+        self::assertSame('class', $classReference->getName());
+        self::assertSame('php:class', $classReference->getRole());
+    }
+}


### PR DESCRIPTION
In a guides, we would like to refer to an API element in the same
project. Although references were added for this, Domain support was not
added in the parshing and handling of references. In this change I have
introduced the concept of Domains in reference parsing and changes the
different php roles to work.

See
https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html
for more information on Domains.