### PR TITLE
3002: Render externally written UML Diagrams

### DIFF
--- a/data/templates/default/guides/uml.html.twig
+++ b/data/templates/default/guides/uml.html.twig
@@ -1,6 +1,6 @@
 {% apply spaceless %}
-    <figure{% if node.classesString %} class="{{ node.classesString }}"{% endif %}>
+    <figure class="phpdocumentor-uml-diagram{% if node.classesString %}  {{ node.classesString }}{% endif %}">
         {{ uml(node.value) }}
-    {% if node.caption %}<figcaption>test{{ node.caption }}</figcaption>{% endif %}
+    {% if node.caption %}<figcaption>{{ node.caption }}</figcaption>{% endif %}
     </figure>
 {% endapply %}

--- a/data/templates/default/objects/images.css.twig
+++ b/data/templates/default/objects/images.css.twig
@@ -7,3 +7,8 @@
     font-style: italic;
     font-size: 80%;
 }
+
+.phpdocumentor-uml-diagram svg {
+    max-width: 100%;
+    height: auto !important;
+}

--- a/docs/internals/flow.puml
+++ b/docs/internals/flow.puml
@@ -1,0 +1,42 @@
+@startuml
+start
+
+:Boot the application|
+
+partition "Parse files into an AST" {
+   :Set parsing parameters;
+   :Find project files;
+   :Remove stale items from Descriptor Cache;
+   :Load Descriptor Cache;
+
+   while (There are unprocessed files?) is (Yes)
+	   if (File is cached) then (No)
+		   :Add File Representation to Project|
+	   else (Yes)
+		   :Load Cached File;
+	   endif;
+   endwhile (No);
+
+   :Write partial texts to Project;
+   :Save Cache to Disk;
+}
+
+partition "Transform AST into artifacts" {
+   :Load Cache From Disk;
+   :Load Templates;
+   :Load Transformations from Templates;
+
+   while (For each Compiler Pass)
+		   if (Pass is "Transformer")
+			   :Transform all files|
+		   elseif (Pass is "Linker")
+			   :Link FQSENs to Descriptors|
+		   else
+			 :Execute compiler pass specific behaviour;
+		   endif;
+   endwhile;
+
+}
+
+stop
+@enduml

--- a/docs/internals/flow.rst
+++ b/docs/internals/flow.rst
@@ -16,8 +16,6 @@ Activity Diagram.
    :Transform AST into artifacts;
    stop
 
-.. uml:: my-external-file.puml
-
 This three step process enables phpDocumentor to break down a project into its most basic components, called Structural
 Elements, and depending on which template was selected generate various types of output.
 

--- a/docs/internals/flow.rst
+++ b/docs/internals/flow.rst
@@ -16,6 +16,8 @@ Activity Diagram.
    :Transform AST into artifacts;
    stop
 
+.. uml:: my-external-file.puml
+
 This three step process enables phpDocumentor to break down a project into its most basic components, called Structural
 Elements, and depending on which template was selected generate various types of output.
 
@@ -41,47 +43,7 @@ In the subchapters I will provide more detail on the individual sections and sho
 this diagram (such as *Boot the application*, *Add File Representation to Project* and other activities that are
 surrounded by an additional border)
 
-.. uml::
-   start
-
-   :Boot the application|
-
-   partition "Parse files into an AST" {
-       :Set parsing parameters;
-       :Find project files;
-       :Remove stale items from Descriptor Cache;
-       :Load Descriptor Cache;
-
-       while (There are unprocessed files?) is (Yes)
-           if (File is cached) then (No)
-               :Add File Representation to Project|
-           else (Yes)
-               :Load Cached File;
-           endif;
-       endwhile (No);
-
-       :Write partial texts to Project;
-       :Save Cache to Disk;
-   }
-
-   partition "Transform AST into artifacts" {
-       :Load Cache From Disk;
-       :Load Templates;
-       :Load Transformations from Templates;
-
-       while (For each Compiler Pass)
-               if (Pass is "Transformer")
-                   :Transform all files|
-               elseif (Pass is "Linker")
-                   :Link FQSENs to Descriptors|
-               else
-                 :Execute compiler pass specific behaviour;
-               endif;
-       endwhile;
-
-   }
-
-   stop
+.. uml:: flow.puml
 
 Boot the Application
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/Guides/Environment.php
+++ b/src/Guides/Environment.php
@@ -99,6 +99,9 @@ class Environment
     /** @var string */
     private $outputFolder;
 
+    /** @var string */
+    private $currentAbsolutePath;
+
     public function __construct(
         Configuration $configuration,
         Renderer $renderer,
@@ -495,5 +498,30 @@ class Environment
     public function getNodeRendererFactory(): NodeRenderers\NodeRendererFactory
     {
         return $this->nodeRendererFactory;
+    }
+
+    /**
+     * Register the current file's absolute path on the Origin file system.
+     *
+     * You would more or less expect getCurrentFileName to return this information; but that filename does
+     * not return the absolute position on Origin but the relative path from the Documentation Root.
+     */
+    public function setCurrentAbsolutePath(string $path): void
+    {
+        $this->currentAbsolutePath = $path;
+    }
+
+    /**
+     * Return the current file's absolute path on the Origin file system.
+     *
+     * In order to load files relative to the current file (such as embedding UML diagrams) the environment
+     * must expose what the absolute path relative to the Origin is.
+     *
+     * @see self::setCurrentAbsolutePath() for more information
+     * @see self::getOrigin() for the filesystem on which to use this path
+     */
+    public function getCurrentAbsolutePath(): string
+    {
+        return $this->currentAbsolutePath;
     }
 }

--- a/src/Guides/RestructuredText/HTML/Directives/Uml.php
+++ b/src/Guides/RestructuredText/HTML/Directives/Uml.php
@@ -44,6 +44,7 @@ final class Uml extends Directive
 
         $value = '';
         $caption = '';
+
         if ($node instanceof CodeNode) {
             $caption = $data;
             $value = $node->getValue();

--- a/src/Guides/RestructuredText/HTML/Directives/Uml.php
+++ b/src/Guides/RestructuredText/HTML/Directives/Uml.php
@@ -89,6 +89,7 @@ final class Uml extends Directive
 
             return null;
         }
+
         $value = $environment->getOrigin()->read($fileName);
         $value = str_replace(['@startuml', '@enduml'], '', $value);
 

--- a/src/Guides/RestructuredText/HTML/Directives/Uml.php
+++ b/src/Guides/RestructuredText/HTML/Directives/Uml.php
@@ -12,7 +12,10 @@ use phpDocumentor\Guides\Nodes\UmlNode;
 use phpDocumentor\Guides\RestructuredText\Directives\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser;
 
+use function dirname;
 use function explode;
+use function sprintf;
+use function str_replace;
 
 /**
  * Renders a uml diagram, example:

--- a/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
+++ b/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
@@ -81,14 +81,14 @@ final class ParseFileHandler
             $command->getOrigin(),
             $this->metas
         );
-        $environment->setCurrentFileName($file);
-        $environment->setCurrentDirectory($directory);
-
         $fileAbsolutePath = $this->buildPathOnFileSystem(
             $file,
             $directory,
             $configuration->getSourceFileExtension()
         );
+        $environment->setCurrentFileName($file);
+        $environment->setCurrentAbsolutePath($fileAbsolutePath);
+        $environment->setCurrentDirectory($directory);
 
         $this->logger->info(sprintf('Parsing %s', $fileAbsolutePath));
         $document = null;

--- a/src/Guides/RestructuredText/Parser/DocumentParser.php
+++ b/src/Guides/RestructuredText/Parser/DocumentParser.php
@@ -505,9 +505,15 @@ class DocumentParser
 
             if ($currentDirective !== null) {
                 try {
+                    // if a Directive is not followed by a CodeNode; this means it totally relies on
+                    // its data and we should not process the $node as part of handling this directive
+                    $directiveNode = $node instanceof CodeNode
+                            ? $node
+                            : new SpanNode($this->environment, $this->directive->getData());
+
                     $currentDirective->process(
                         $this->parser,
-                        $node,
+                        $directiveNode,
                         $this->directive->getVariable(),
                         $this->directive->getData(),
                         $this->directive->getOptions()
@@ -527,7 +533,9 @@ class DocumentParser
                 }
             }
 
-            $node = null;
+            if ($node instanceof CodeNode) {
+                $node = null;
+            }
         }
 
         $this->directive = null;

--- a/src/Guides/Twig/AssetsExtension.php
+++ b/src/Guides/Twig/AssetsExtension.php
@@ -74,8 +74,12 @@ final class AssetsExtension extends AbstractExtension
     /**
      * @param mixed[] $context
      */
-    public function renderNode(array $context, Node $node): string
+    public function renderNode(array $context, ?Node $node): string
     {
+        if ($node === null) {
+            return '';
+        }
+
         $environment = $context['env'] ?? null;
         if (!$environment instanceof Environment) {
             throw new RuntimeException('Environment must be set in the twig global state to render nodes');


### PR DESCRIPTION
Fixes #3002 

This PR contains support for including UML diagrams from external files into the documentation. The changes here will also solve a bug where you could not use Directives without Blocks (single line directives). Prior to this change a single line Directive would also cause the subsequent paragraph or list to disappear because it would be 'parsed' as part of the directive and discarded