### PR TITLE
Fix the width of the source view window for source-files with LOOOOON…

### DIFF
--- a/data/templates/default/components/source-modal.css.twig
+++ b/data/templates/default/components/source-modal.css.twig
@@ -31,6 +31,8 @@
     background: #fff;
     position: relative;
     padding: 2em;
+    box-sizing: border-box;
+    max-width:100vw;
 }
 
 .phpdocumentor-modal__close {


### PR DESCRIPTION
…G lines.

The commit restricts the maximum size of the source-window to 100vw and set box-sizing to border-box. Otherwise the source-view window can overflow up to the point where not even the close button is accessible.