### PR TITLE
Restore functionality of the 'replace' directive

### DIFF
--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1,7 +1,7 @@
 Getting started
 ===============
 
-Is this the first time you work with phpDocumentor? You have come to the right section in the documentation! In the
+Is this the first time you work with |phpdoc|? You have come to the right section in the documentation! In the
 chapters included of this section we will talk you through the installation, configuration and how to generate your
 documentation.
 
@@ -12,3 +12,5 @@ documentation.
     configuration
     what-is-a-docblock
     generating-documentation
+
+.. |phpdoc| replace:: phpDocumentor

--- a/src/Guides/Environment.php
+++ b/src/Guides/Environment.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Guides;
 use InvalidArgumentException;
 use League\Flysystem\FilesystemInterface;
 use phpDocumentor\Guides\Meta\Entry;
+use phpDocumentor\Guides\Nodes\SpanNode;
 use phpDocumentor\Guides\References\Reference;
 use phpDocumentor\Guides\References\ResolvedReference;
 use Psr\Log\LoggerInterface;
@@ -277,6 +278,14 @@ class Environment
         }
 
         return $default;
+    }
+
+    /**
+     * @return array<string|SpanNode>
+     */
+    public function getVariables(): array
+    {
+        return $this->variables;
     }
 
     public function setLink(string $name, string $url): void

--- a/src/Guides/Handlers/RenderHandler.php
+++ b/src/Guides/Handlers/RenderHandler.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Guides\Handlers;
 
 use IteratorAggregate;
 use League\Flysystem\FilesystemInterface;
+use phpDocumentor\Descriptor\DocumentDescriptor;
 use phpDocumentor\Descriptor\GuideSetDescriptor;
 use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Metas;
@@ -84,6 +85,8 @@ final class RenderHandler
         FilesystemInterface $destination
     ): void {
         $this->initReferences($environment, $this->references);
+
+        /** @var DocumentDescriptor $descriptor */
         foreach ($documentationSet->getDocuments() as $file => $descriptor) {
             $document = $descriptor->getDocumentNode();
             $target = $documentationSet->getOutput() . '/' . $this->router->generate($descriptor);
@@ -94,6 +97,9 @@ final class RenderHandler
             $environment->setCurrentDirectory($directory);
             foreach ($descriptor->getLinks() as $link => $url) {
                 $environment->setLink($link, $url);
+            }
+            foreach ($descriptor->getVariables() as $key => $value) {
+                $environment->setVariable($key, $value);
             }
 
             /** @var FullDocumentNodeRenderer $renderer */

--- a/src/Guides/Handlers/RenderHandler.php
+++ b/src/Guides/Handlers/RenderHandler.php
@@ -95,9 +95,11 @@ final class RenderHandler
 
             $environment->setCurrentFileName($file);
             $environment->setCurrentDirectory($directory);
+
             foreach ($descriptor->getLinks() as $link => $url) {
                 $environment->setLink($link, $url);
             }
+
             foreach ($descriptor->getVariables() as $key => $value) {
                 $environment->setVariable($key, $value);
             }

--- a/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
+++ b/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
@@ -117,7 +117,8 @@ final class ParseFileHandler
                 $document->getTitles(),
                 $document->getTocs(),
                 $environment->getDependencies(),
-                $environment->getLinks()
+                $environment->getLinks(),
+                $environment->getVariables()
             )
         );
 

--- a/src/Guides/RestructuredText/Parser/DocumentParser.php
+++ b/src/Guides/RestructuredText/Parser/DocumentParser.php
@@ -505,15 +505,9 @@ class DocumentParser
 
             if ($currentDirective !== null) {
                 try {
-                    // if a Directive is not followed by a CodeNode; this means it totally relies on
-                    // its data and we should not process the $node as part of handling this directive
-                    $directiveNode = $node instanceof CodeNode
-                            ? $node
-                            : new SpanNode($this->environment, $this->directive->getData());
-
                     $currentDirective->process(
                         $this->parser,
-                        $directiveNode,
+                        $node instanceof CodeNode ? $node : null,
                         $this->directive->getVariable(),
                         $this->directive->getData(),
                         $this->directive->getOptions()

--- a/src/phpDocumentor/Descriptor/DocumentDescriptor.php
+++ b/src/phpDocumentor/Descriptor/DocumentDescriptor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\SpanNode;
 use phpDocumentor\Guides\Nodes\TocNode;
 
 final class DocumentDescriptor implements Descriptor
@@ -42,11 +43,15 @@ final class DocumentDescriptor implements Descriptor
     /** @var string[] */
     private $links;
 
+    /** @var array<string|SpanNode> */
+    private $variables;
+
     /**
      * @param string[][] $titles
      * @param TocNode[] $tocs
      * @param string[] $depends
      * @param string[] $links
+     * @param array<string|SpanNode> $variables
      */
     public function __construct(
         DocumentNode $documentNode,
@@ -56,7 +61,8 @@ final class DocumentDescriptor implements Descriptor
         array $titles,
         array $tocs,
         array $depends,
-        array $links
+        array $links,
+        array $variables
     ) {
         $this->documentNode = $documentNode;
         $this->hash = $hash;
@@ -66,6 +72,7 @@ final class DocumentDescriptor implements Descriptor
         $this->tocs = $tocs;
         $this->depends = $depends;
         $this->links = $links;
+        $this->variables = $variables;
     }
 
     public function getDocumentNode(): DocumentNode
@@ -110,6 +117,19 @@ final class DocumentDescriptor implements Descriptor
     public function getLinks(): array
     {
         return $this->links;
+    }
+
+    /**
+     * Returns variables collected during the parsing of s document.
+     *
+     * The 'replace' directive, for example, stores the replacement as a variable on the Document. To be able to
+     * access the variables collected during parsing, we can store a series of variables here.
+     *
+     * @return SpanNode[]|string[]
+     */
+    public function getVariables(): array
+    {
+        return $this->variables;
     }
 
     public function getName(): string


### PR DESCRIPTION
In the process of splitting the parsing from the rendering, we did not
take into account that variables were stored on the Environment class.
In the original implementation this Environment class shared state
between just about everything in the whole app.

By pushing the variables into the DocumentDescriptor and restoring it
when rendering, the replace functionality now works again.

Additionally, I found a slight bug in the DocumentParser; when a
Directive is followed by something other than a CodeNode we want to
ignore it and not pass it as a SpanNode to the directive's process
function. In that scenario, the deeper business logic will convert that
SpanNode into a piece of text on the page. Which you do not want.

Fixes #3006 