### PR TITLE
Images were not embedded when generating guides

### DIFF
--- a/src/Guides/Environment.php
+++ b/src/Guides/Environment.php
@@ -101,7 +101,7 @@ class Environment
     private $outputFolder;
 
     /** @var string */
-    private $currentAbsolutePath;
+    private $currentAbsolutePath = '';
 
     public function __construct(
         Configuration $configuration,

--- a/src/Guides/Handlers/RenderHandler.php
+++ b/src/Guides/Handlers/RenderHandler.php
@@ -31,6 +31,7 @@ use function array_merge;
 use function dirname;
 use function get_class;
 use function iterator_to_array;
+use function str_replace;
 
 final class RenderHandler
 {
@@ -92,7 +93,11 @@ final class RenderHandler
 
             // TODO: This is a hack; I want to rework path handling for guides as the Environment, for example,
             //       has a plethora of 'em.
-            $target = str_replace('//', '/', $documentationSet->getOutput() . '/' . $this->router->generate($descriptor));
+            $target = str_replace(
+                '//',
+                '/',
+                $documentationSet->getOutput() . '/' . $this->router->generate($descriptor)
+            );
 
             $directory = dirname($target);
 

--- a/src/Guides/Handlers/RenderHandler.php
+++ b/src/Guides/Handlers/RenderHandler.php
@@ -70,7 +70,7 @@ final class RenderHandler
             $command->getConfiguration(),
             $this->renderer,
             $this->logger,
-            $command->getDestination(),
+            $command->getOrigin(),
             $this->metas
         );
 
@@ -87,13 +87,21 @@ final class RenderHandler
         $this->initReferences($environment, $this->references);
 
         /** @var DocumentDescriptor $descriptor */
-        foreach ($documentationSet->getDocuments() as $file => $descriptor) {
+        foreach ($documentationSet->getDocuments() as $descriptor) {
             $document = $descriptor->getDocumentNode();
-            $target = $documentationSet->getOutput() . '/' . $this->router->generate($descriptor);
+
+            // TODO: This is a hack; I want to rework path handling for guides as the Environment, for example,
+            //       has a plethora of 'em.
+            $target = str_replace('//', '/', $documentationSet->getOutput() . '/' . $this->router->generate($descriptor));
 
             $directory = dirname($target);
 
-            $environment->setCurrentFileName($file);
+            $environment->setCurrentFileName($descriptor->getFile());
+            // TODO: We assume there is one, but there may be multiple. Handling this correctly required rework on how
+            // source locations are propagated.
+            $sourcePath = $documentationSet->getSource()->paths()[0];
+
+            $environment->setCurrentAbsolutePath($sourcePath . '/' . dirname($descriptor->getFile()));
             $environment->setCurrentDirectory($directory);
 
             foreach ($descriptor->getLinks() as $link => $url) {

--- a/src/Guides/RenderCommand.php
+++ b/src/Guides/RenderCommand.php
@@ -19,7 +19,10 @@ use phpDocumentor\Descriptor\GuideSetDescriptor;
 final class RenderCommand
 {
     /** @var FilesystemInterface */
-    private $filesystem;
+    private $origin;
+
+    /** @var FilesystemInterface */
+    private $destination;
 
     /** @var Configuration */
     private $configuration;
@@ -30,11 +33,13 @@ final class RenderCommand
     public function __construct(
         GuideSetDescriptor $documentationSet,
         Configuration $configuration,
-        FilesystemInterface $filesystem
+        FilesystemInterface $origin,
+        FilesystemInterface $destination
     ) {
-        $this->filesystem = $filesystem;
+        $this->destination = $destination;
         $this->configuration = $configuration;
         $this->documentationSet = $documentationSet;
+        $this->origin = $origin;
     }
 
     public function getDocumentationSet(): GuideSetDescriptor
@@ -42,13 +47,18 @@ final class RenderCommand
         return $this->documentationSet;
     }
 
-    public function getDestination(): FilesystemInterface
-    {
-        return $this->filesystem;
-    }
-
     public function getConfiguration(): Configuration
     {
         return $this->configuration;
+    }
+
+    public function getOrigin(): FilesystemInterface
+    {
+        return $this->origin;
+    }
+
+    public function getDestination(): FilesystemInterface
+    {
+        return $this->destination;
     }
 }

--- a/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
+++ b/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
@@ -151,7 +151,7 @@ final class ParseFileHandler
 
     private function buildPathOnFileSystem(string $file, string $currentDirectory, string $extension): string
     {
-        return ltrim(sprintf("%s/%s.%s", trim($currentDirectory, '/'), $file, $extension), '/');
+        return ltrim(sprintf('%s/%s.%s', trim($currentDirectory, '/'), $file, $extension), '/');
     }
 
     private function buildDocumentUrl(Environment $environment, string $extension): string

--- a/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
+++ b/src/Guides/RestructuredText/Handlers/ParseFileHandler.php
@@ -151,7 +151,7 @@ final class ParseFileHandler
 
     private function buildPathOnFileSystem(string $file, string $currentDirectory, string $extension): string
     {
-        return ltrim(trim($currentDirectory, '/') . '/' . $file . '.' . $extension, '/');
+        return ltrim(sprintf("%s/%s.%s", trim($currentDirectory, '/'), $file, $extension), '/');
     }
 
     private function buildDocumentUrl(Environment $environment, string $extension): string

--- a/src/Guides/Twig/AssetsExtension.php
+++ b/src/Guides/Twig/AssetsExtension.php
@@ -103,8 +103,9 @@ final class AssetsExtension extends AbstractExtension
             return $path;
         }
 
-        $sourcePath = $environment->absoluteRelativePath($path);
+        $sourcePath = $environment->getCurrentAbsolutePath() . '/' . $path;
         $outputPath = $environment->outputUrl($path);
+
         Assert::string($outputPath);
         if ($environment->getOrigin()->has($sourcePath) === false) {
             $this->logger->error(sprintf('Image reference not found "%s"', $sourcePath));
@@ -119,7 +120,11 @@ final class AssetsExtension extends AbstractExtension
             return $outputPath;
         }
 
-        $destination->put($outputPath, $fileContents);
+
+        $result = $destination->put($outputPath, $fileContents);
+        if ($result === false) {
+            $this->logger->error(sprintf('Unable to write file "%s"', $outputPath));
+        }
 
         return $outputPath;
     }

--- a/src/Guides/Twig/AssetsExtension.php
+++ b/src/Guides/Twig/AssetsExtension.php
@@ -120,7 +120,6 @@ final class AssetsExtension extends AbstractExtension
             return $outputPath;
         }
 
-
         $result = $destination->put($outputPath, $fileContents);
         if ($result === false) {
             $this->logger->error(sprintf('Unable to write file "%s"', $outputPath));

--- a/src/phpDocumentor/Transformer/Writer/RenderGuide.php
+++ b/src/phpDocumentor/Transformer/Writer/RenderGuide.php
@@ -47,9 +47,8 @@ final class RenderGuide extends WriterAbstract implements ProjectDescriptor\With
 
     /** @var iterable<Format> */
     private $outputFormats;
-    /**
-     * @var FlySystemFactory
-     */
+
+    /** @var FlySystemFactory */
     private $flySystemFactory;
 
     /** @param iterable<Format> $outputFormats */

--- a/tests/unit/Guides/RenderCommandTest.php
+++ b/tests/unit/Guides/RenderCommandTest.php
@@ -16,14 +16,17 @@ final class RenderCommandTest extends MockeryTestCase
 
     public function test_providing_a_destination_to_render_to(): void
     {
+        $origin = $this->prophesize(FilesystemInterface::class)->reveal();
         $destination = $this->prophesize(FilesystemInterface::class)->reveal();
 
         $command = new RenderCommand(
             $this->faker()->guideSetDescriptor(),
             new Configuration('rst', []),
+            $origin,
             $destination
         );
 
+        self::assertSame($origin, $command->getOrigin());
         self::assertSame($destination, $command->getDestination());
     }
 }


### PR DESCRIPTION
Images are copied over when the Asset filter is used in a twig template.
Although you could debate whether it should not be a reference and
copied over in a single pass, the issue arose that the destination file
system with the wrong path was provided as source for the image
location.

This is incorrect, but it also showed that there is room for improvement
in how we deal with paths in guides. This is not addressed in this PR,
but merely that the origin filesystem is passed