### PR TITLE
Extract list parsing into a Subparser

### DIFF
--- a/src/Guides/RestructuredText/Parser/Buffer.php
+++ b/src/Guides/RestructuredText/Parser/Buffer.php
@@ -79,4 +79,9 @@ class Buffer
 
         return $this->lines[$lastLineKey];
     }
+
+    public function clear(): void
+    {
+        $this->lines = [];
+    }
 }

--- a/src/Guides/RestructuredText/Parser/DocumentParser.php
+++ b/src/Guides/RestructuredText/Parser/DocumentParser.php
@@ -167,6 +167,9 @@ class DocumentParser
                     $this->lines
                 );
                 break;
+            case State::COMMENT:
+                $this->subparser = new Subparsers\CommentParser($this->parser, $this->eventManager);
+                break;
         }
     }
 
@@ -330,7 +333,7 @@ class DocumentParser
                 break;
 
             case State::COMMENT:
-                if (!$this->lineChecker->isComment($line) && (trim($line) === '' || $line[0] !== ' ')) {
+                if (!$this->subparser->parse($line)) {
                     $this->setState(State::BEGIN);
 
                     return false;
@@ -444,6 +447,7 @@ class DocumentParser
                 case State::LIST:
                 case State::DEFINITION_LIST:
                 case State::TABLE:
+                case State::COMMENT:
                     $node = $this->subparser->build();
 
                     break;

--- a/src/Guides/RestructuredText/Parser/DocumentParser.php
+++ b/src/Guides/RestructuredText/Parser/DocumentParser.php
@@ -10,9 +10,7 @@ use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\AnchorNode;
 use phpDocumentor\Guides\Nodes\BlockNode;
 use phpDocumentor\Guides\Nodes\CodeNode;
-use phpDocumentor\Guides\Nodes\DefinitionListNode;
 use phpDocumentor\Guides\Nodes\DocumentNode;
-use phpDocumentor\Guides\Nodes\ListNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\QuoteNode;
@@ -94,7 +92,7 @@ class DocumentParser
     /** @var TitleNode[] */
     private $openTitleNodes = [];
 
-    /** @var Subparsers\ListParser */
+    /** @var Subparsers\Subparser */
     private $subparser;
 
     /**
@@ -157,6 +155,21 @@ class DocumentParser
     private function setState(string $state): void
     {
         $this->state = $state;
+        $this->subparser = null;
+
+        switch ($state) {
+            case State::LIST:
+                $this->subparser = new Subparsers\ListParser($this->parser, $this->eventManager);
+                break;
+            case State::DEFINITION_LIST:
+                $this->subparser = new Subparsers\DefinitionListParser(
+                    $this->parser,
+                    $this->eventManager,
+                    $this->buffer,
+                    $this->lines
+                );
+                break;
+        }
     }
 
     private function prepareDocument(string $document): string
@@ -211,7 +224,6 @@ class DocumentParser
                 if (trim($line) !== '') {
                     if ($this->lineChecker->isListLine($line, $this->isCode)) {
                         $this->setState(State::LIST);
-                        $this->subparser = new Subparsers\ListParser($this->parser, $this->eventManager);
 
                         return false;
                     }
@@ -263,24 +275,13 @@ class DocumentParser
                 break;
 
             case State::LIST:
+            case State::DEFINITION_LIST:
                 if (!$this->subparser->parse($line)) {
                     $this->flush();
                     $this->setState(State::BEGIN);
 
                     return false;
                 }
-
-                break;
-
-            case State::DEFINITION_LIST:
-                if ($this->lineChecker->isDefinitionListEnded($line, $this->lines->getNextLine())) {
-                    $this->flush();
-                    $this->setState(State::BEGIN);
-
-                    return false;
-                }
-
-                $this->buffer->push($line);
 
                 break;
 
@@ -456,17 +457,8 @@ class DocumentParser
                     break;
 
                 case State::LIST:
-                    /** @var ListNode $node */
-                    $node = $this->subparser->build();
-
-                    break;
-
                 case State::DEFINITION_LIST:
-                    $definitionList = $this->lineDataParser->parseDefinitionList(
-                        $this->buffer->getLines()
-                    );
-
-                    $node = new DefinitionListNode($definitionList);
+                    $node = $this->subparser->build();
 
                     break;
 

--- a/src/Guides/RestructuredText/Parser/DocumentParser.php
+++ b/src/Guides/RestructuredText/Parser/DocumentParser.php
@@ -264,7 +264,7 @@ class DocumentParser
 
                     if ($this->lineChecker->isDirective($line)) {
                         $this->setState(State::DIRECTIVE);
-                        $this->buffer = new Buffer();
+                        $this->buffer->clear();
                         $this->flush();
                         $this->initDirective($line);
                     } elseif ($this->lineChecker->isDefinitionList($this->lines->getNextLine())) {
@@ -396,9 +396,7 @@ class DocumentParser
                 case State::NORMAL:
                     $this->isCode = $this->prepareCode();
 
-                    $buffer = $this->buffer->getLinesString();
-
-                    $node = new ParagraphNode(new SpanNode($this->environment, $buffer));
+                    $node = new ParagraphNode(new SpanNode($this->environment, $this->buffer->getLinesString()));
 
                     break;
                 case State::SEPARATOR:
@@ -425,7 +423,7 @@ class DocumentParser
 
                     $this->lastTitleNode = $node;
                     $this->document->addNode(new SectionBeginNode($node));
-                    $this->openTitleNodes[] = $node;
+                    $this->openTitleNodes->append($node);
 
                     break;
             }

--- a/src/Guides/RestructuredText/Parser/Subparsers/BlockParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/BlockParser.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
+
+use phpDocumentor\Guides\Nodes\BlockNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\QuoteNode;
+use phpDocumentor\Guides\RestructuredText\Parser;
+use phpDocumentor\Guides\RestructuredText\Parser\LineChecker;
+use phpDocumentor\Guides\RestructuredText\Parser\LineDataParser;
+
+final class BlockParser implements Subparser
+{
+    /** @var Parser */
+    private $parser;
+
+    /** @var LineDataParser */
+    private $lineDataParser;
+
+    /** @var Parser\Buffer */
+    private $buffer;
+
+    /** @var LineChecker */
+    private $lineChecker;
+
+    public function __construct(Parser $parser, Parser\Buffer $buffer)
+    {
+        $this->parser = $parser;
+        $this->lineChecker = new LineChecker($this->lineDataParser);
+        $this->buffer = $buffer;
+    }
+
+    public function parse(string $line): bool
+    {
+        if (!$this->lineChecker->isBlockLine($line)) {
+            return false;
+        }
+
+        $this->buffer->push($line);
+
+        return true;
+    }
+
+    /**
+     * @return QuoteNode
+     */
+    public function build(): ?Node
+    {
+        $lines = $this->buffer->getLines();
+
+        $blockNode = new BlockNode($lines);
+
+        return new QuoteNode($this->parser->getSubParser()->parseLocal($blockNode->getValue()));
+    }
+}

--- a/src/Guides/RestructuredText/Parser/Subparsers/BlockParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/BlockParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
 
+use Doctrine\Common\EventManager;
 use phpDocumentor\Guides\Nodes\BlockNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\QuoteNode;
@@ -16,19 +17,16 @@ final class BlockParser implements Subparser
     /** @var Parser */
     private $parser;
 
-    /** @var LineDataParser */
-    private $lineDataParser;
-
     /** @var Parser\Buffer */
     private $buffer;
 
     /** @var LineChecker */
     private $lineChecker;
 
-    public function __construct(Parser $parser, Parser\Buffer $buffer)
+    public function __construct(Parser $parser, EventManager $eventManager, Parser\Buffer $buffer)
     {
         $this->parser = $parser;
-        $this->lineChecker = new LineChecker($this->lineDataParser);
+        $this->lineChecker = new LineChecker(new LineDataParser($parser, $eventManager));
         $this->buffer = $buffer;
     }
 

--- a/src/Guides/RestructuredText/Parser/Subparsers/CodeParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/CodeParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
 
+use Doctrine\Common\EventManager;
 use phpDocumentor\Guides\Nodes\CodeNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Parser;
@@ -12,22 +13,15 @@ use phpDocumentor\Guides\RestructuredText\Parser\LineDataParser;
 
 final class CodeParser implements Subparser
 {
-    /** @var Parser */
-    private $parser;
-
-    /** @var LineDataParser */
-    private $lineDataParser;
-
     /** @var Parser\Buffer */
     private $buffer;
 
     /** @var LineChecker */
     private $lineChecker;
 
-    public function __construct(Parser $parser, Parser\Buffer $buffer)
+    public function __construct(Parser $parser, EventManager $eventManager, Parser\Buffer $buffer)
     {
-        $this->parser = $parser;
-        $this->lineChecker = new LineChecker($this->lineDataParser);
+        $this->lineChecker = new LineChecker(new LineDataParser($parser, $eventManager));
         $this->buffer = $buffer;
     }
 

--- a/src/Guides/RestructuredText/Parser/Subparsers/CodeParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/CodeParser.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
+
+use phpDocumentor\Guides\Nodes\CodeNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser;
+use phpDocumentor\Guides\RestructuredText\Parser\LineChecker;
+use phpDocumentor\Guides\RestructuredText\Parser\LineDataParser;
+
+final class CodeParser implements Subparser
+{
+    /** @var Parser */
+    private $parser;
+
+    /** @var LineDataParser */
+    private $lineDataParser;
+
+    /** @var Parser\Buffer */
+    private $buffer;
+
+    /** @var LineChecker */
+    private $lineChecker;
+
+    public function __construct(Parser $parser, Parser\Buffer $buffer)
+    {
+        $this->parser = $parser;
+        $this->lineChecker = new LineChecker($this->lineDataParser);
+        $this->buffer = $buffer;
+    }
+
+    public function parse(string $line): bool
+    {
+        if (!$this->lineChecker->isBlockLine($line)) {
+            return false;
+        }
+
+        $this->buffer->push($line);
+
+        return true;
+    }
+
+    /**
+     * @return CodeNode
+     */
+    public function build(): ?Node
+    {
+        return new CodeNode($this->buffer->getLines());
+    }
+}

--- a/src/Guides/RestructuredText/Parser/Subparsers/CommentParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/CommentParser.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
+
+use Doctrine\Common\EventManager;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser;
+use phpDocumentor\Guides\RestructuredText\Parser\LineChecker;
+use phpDocumentor\Guides\RestructuredText\Parser\LineDataParser;
+
+use function trim;
+
+final class CommentParser implements Subparser
+{
+    /** @var LineChecker */
+    private $lineChecker;
+
+    public function __construct(Parser $parser, EventManager $eventManager)
+    {
+        $this->lineChecker = new LineChecker(new LineDataParser($parser, $eventManager));
+    }
+
+    public function parse(string $line): bool
+    {
+        return $this->lineChecker->isComment($line) || (trim($line) !== '' && $line[0] === ' ');
+    }
+
+    public function build(): ?Node
+    {
+        return null;
+    }
+}

--- a/src/Guides/RestructuredText/Parser/Subparsers/DefinitionListParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/DefinitionListParser.php
@@ -48,7 +48,7 @@ final class DefinitionListParser implements Subparser
     /**
      * @return DefinitionListNode
      */
-    public function build(): Node
+    public function build(): ?Node
     {
         $definitionList = $this->lineDataParser->parseDefinitionList($this->buffer->getLines());
 

--- a/src/Guides/RestructuredText/Parser/Subparsers/DefinitionListParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/DefinitionListParser.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
+
+use Doctrine\Common\EventManager;
+use phpDocumentor\Guides\Nodes\DefinitionListNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser;
+use phpDocumentor\Guides\RestructuredText\Parser\LineChecker;
+use phpDocumentor\Guides\RestructuredText\Parser\LineDataParser;
+
+final class DefinitionListParser implements Subparser
+{
+    /** @var LineDataParser */
+    private $lineDataParser;
+
+    /** @var Parser\Buffer */
+    private $buffer;
+
+    /** @var LineChecker */
+    private $lineChecker;
+
+    /** @var Parser\Lines */
+    private $lines;
+
+    public function __construct(Parser $parser, EventManager $eventManager, Parser\Buffer $buffer, Parser\Lines $lines)
+    {
+        $this->lineDataParser = new LineDataParser($parser, $eventManager);
+        $this->lineChecker = new LineChecker($this->lineDataParser);
+
+        $this->buffer = $buffer;
+        $this->lines = $lines;
+    }
+
+    public function parse(string $line): bool
+    {
+        if ($this->lineChecker->isDefinitionListEnded($line, $this->lines->getNextLine())) {
+            return false;
+        }
+
+        $this->buffer->push($line);
+
+        return true;
+    }
+
+    /**
+     * @return DefinitionListNode
+     */
+    public function build(): Node
+    {
+        $definitionList = $this->lineDataParser->parseDefinitionList($this->buffer->getLines());
+
+        return new DefinitionListNode($definitionList);
+    }
+}

--- a/src/Guides/RestructuredText/Parser/Subparsers/ListParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/ListParser.php
@@ -48,7 +48,7 @@ final class ListParser implements Subparser
     /**
      * @return ListNode
      */
-    public function build(): Node
+    public function build(): ?Node
     {
         $this->parseListLine(null, true);
 

--- a/src/Guides/RestructuredText/Parser/Subparsers/ListParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/ListParser.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
+
+use Doctrine\Common\EventManager;
+use phpDocumentor\Guides\Environment;
+use phpDocumentor\Guides\Nodes\ListNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\SpanNode;
+use phpDocumentor\Guides\RestructuredText\Parser;
+use phpDocumentor\Guides\RestructuredText\Parser\LineDataParser;
+use phpDocumentor\Guides\RestructuredText\Parser\ListLine;
+
+use function trim;
+
+final class ListParser
+{
+    /** @var LineDataParser */
+    private $lineDataParser;
+
+    /** @var ListLine|null */
+    private $listLine = null;
+
+    /** @var ListNode */
+    private $nodeBuffer;
+
+    /** @var Environment */
+    private $environment;
+
+    /** @var bool */
+    private $listFlow = true;
+
+    public function __construct(Parser $parser, EventManager $eventManager)
+    {
+        $this->lineDataParser = new LineDataParser($parser, $eventManager);
+        $this->environment = $parser->getEnvironment();
+
+        $this->nodeBuffer = new ListNode();
+    }
+
+    public function parse(string $line): bool
+    {
+        return $this->parseListLine($line);
+    }
+
+    /**
+     * @return ListNode
+     */
+    public function build(): Node
+    {
+        $this->parseListLine(null, true);
+
+        return $this->nodeBuffer;
+    }
+
+    private function parseListLine(?string $line, bool $flush = false): bool
+    {
+        if ($line !== null && trim($line) !== '') {
+            $listLine = $this->lineDataParser->parseListLine($line);
+
+            if ($listLine !== null) {
+                if ($this->listLine instanceof ListLine) {
+                    $this->listLine->setText(new SpanNode($this->environment, $this->listLine->getText()));
+
+                    $this->nodeBuffer->addLine($this->listLine->toArray());
+                }
+
+                $this->listLine = $listLine;
+            } else {
+                if ($this->listLine instanceof ListLine && ($this->listFlow || $line[0] === ' ')) {
+                    $this->listLine->addText($line);
+                } else {
+                    $flush = true;
+                }
+            }
+
+            $this->listFlow = true;
+        } else {
+            $this->listFlow = false;
+        }
+
+        if ($flush) {
+            if ($this->listLine instanceof ListLine) {
+                $this->listLine->setText(new SpanNode($this->environment, $this->listLine->getText()));
+
+                /** @var ListNode $listNode */
+                $listNode = $this->nodeBuffer;
+
+                $listNode->addLine($this->listLine->toArray());
+
+                $this->listLine = null;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Guides/RestructuredText/Parser/Subparsers/ListParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/ListParser.php
@@ -15,7 +15,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\ListLine;
 
 use function trim;
 
-final class ListParser
+final class ListParser implements Subparser
 {
     /** @var LineDataParser */
     private $lineDataParser;

--- a/src/Guides/RestructuredText/Parser/Subparsers/Subparser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/Subparser.php
@@ -10,5 +10,5 @@ interface Subparser
 {
     public function parse(string $line): bool;
 
-    public function build(): Node;
+    public function build(): ?Node;
 }

--- a/src/Guides/RestructuredText/Parser/Subparsers/Subparser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/Subparser.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
+
+use phpDocumentor\Guides\Nodes\Node;
+
+interface Subparser
+{
+    public function parse(string $line): bool;
+
+    public function build(): Node;
+}

--- a/src/Guides/RestructuredText/Parser/Subparsers/TableParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/TableParser.php
@@ -66,7 +66,7 @@ final class TableParser implements Subparser
     /**
      * @return TableNode
      */
-    public function build(): Node
+    public function build(): ?Node
     {
         $this->nodeBuffer->finalize($this->parser, $this->lineChecker);
 

--- a/src/Guides/RestructuredText/Parser/Subparsers/TableParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/TableParser.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
+
+use Doctrine\Common\EventManager;
+use Exception;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\TableNode;
+use phpDocumentor\Guides\RestructuredText\Parser;
+use phpDocumentor\Guides\RestructuredText\Parser\LineChecker;
+use phpDocumentor\Guides\RestructuredText\Parser\LineDataParser;
+
+use function trim;
+
+final class TableParser implements Subparser
+{
+    /** @var Parser */
+    private $parser;
+
+    /** @var TableNode */
+    private $nodeBuffer;
+
+    /** @var Parser\TableParser */
+    private $tableParser;
+
+    /** @var LineChecker */
+    private $lineChecker;
+
+    public function __construct(
+        Parser $parser,
+        EventManager $eventManager,
+        Parser\TableSeparatorLineConfig $tableSeparatorLineConfig,
+        string $openingLine
+    ) {
+        $this->parser = $parser;
+        $this->lineChecker = new LineChecker(new LineDataParser($parser, $eventManager));
+        $this->tableParser = new Parser\TableParser();
+        $this->nodeBuffer = new TableNode($tableSeparatorLineConfig, $this->tableParser->guessTableType($openingLine));
+    }
+
+    public function parse(string $line): bool
+    {
+        if (trim($line) === '') {
+            return false;
+        }
+
+        $separatorLineConfig = $this->tableParser->parseTableSeparatorLine($line);
+
+        // not sure if this is possible, being cautious
+        if (!$this->nodeBuffer instanceof TableNode) {
+            throw new Exception('Node Buffer should be a TableNode instance');
+        }
+
+        // push the separator or content line onto the TableNode
+        if ($separatorLineConfig !== null) {
+            $this->nodeBuffer->pushSeparatorLine($separatorLineConfig);
+        } else {
+            $this->nodeBuffer->pushContentLine($line);
+        }
+
+        return true;
+    }
+
+    /**
+     * @return TableNode
+     */
+    public function build(): Node
+    {
+        $this->nodeBuffer->finalize($this->parser, $this->lineChecker);
+
+        return $this->nodeBuffer;
+    }
+}

--- a/src/Guides/RestructuredText/Parser/Subparsers/TitleParser.php
+++ b/src/Guides/RestructuredText/Parser/Subparsers/TitleParser.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Subparsers;
+
+use ArrayObject;
+use Doctrine\Common\EventManager;
+use phpDocumentor\Guides\Environment;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\SectionEndNode;
+use phpDocumentor\Guides\Nodes\SpanNode;
+use phpDocumentor\Guides\Nodes\TitleNode;
+use phpDocumentor\Guides\RestructuredText\Parser;
+use phpDocumentor\Guides\RestructuredText\Parser\LineChecker;
+use phpDocumentor\Guides\RestructuredText\Parser\LineDataParser;
+
+use function array_search;
+use function trim;
+
+final class TitleParser implements Subparser
+{
+    /** @var LineChecker */
+    private $lineChecker;
+
+    /** @var Parser\Buffer */
+    private $buffer;
+
+    /** @var string */
+    private $specialLetter;
+
+    /** @var Environment */
+    private $environment;
+
+    /** @var TitleNode|null */
+    private $lastTitleNode;
+
+    /** @var DocumentNode */
+    private $document;
+
+    /** @var ArrayObject<int, TitleNode> */
+    private $openTitleNodes;
+
+    /**
+     * @param ArrayObject<int, TitleNode> $openTitleNodes
+     */
+    public function __construct(
+        Parser $parser,
+        EventManager $eventManager,
+        Parser\Buffer $buffer,
+        string $specialLetter,
+        ?TitleNode $lastTitleNode,
+        DocumentNode $document,
+        ArrayObject $openTitleNodes
+    ) {
+        $this->lineChecker = new LineChecker(new LineDataParser($parser, $eventManager));
+        $this->environment = $parser->getEnvironment();
+        $this->buffer = $buffer;
+        $this->specialLetter = $specialLetter;
+        $this->lastTitleNode = $lastTitleNode;
+        $this->document = $document;
+        $this->openTitleNodes = $openTitleNodes;
+    }
+
+    public function parse(string $line): bool
+    {
+        return $this->lineChecker->isComment($line) || (trim($line) !== '' && $line[0] === ' ');
+    }
+
+    /**
+     * @return TitleNode|null
+     */
+    public function build(): ?Node
+    {
+        $data = $this->buffer->getLinesString();
+
+        $level = $this->environment->getLevel((string) $this->specialLetter);
+        $level = $this->environment->getInitialHeaderLevel() + $level - 1;
+
+        $node = new TitleNode(
+            new SpanNode($this->environment, $data),
+            $level
+        );
+
+        if ($this->lastTitleNode !== null) {
+            // current level is less than previous so we need to end all open sections
+            if ($node->getLevel() < $this->lastTitleNode->getLevel()) {
+                foreach ($this->openTitleNodes as $titleNode) {
+                    $this->endOpenSection($titleNode);
+                }
+
+                // same level as the last so just close the last open section
+            } elseif ($node->getLevel() === $this->lastTitleNode->getLevel()) {
+                $this->endOpenSection($this->lastTitleNode);
+            }
+        }
+
+        return $node;
+    }
+
+    private function endOpenSection(TitleNode $titleNode): void
+    {
+        $this->document->addNode(new SectionEndNode($titleNode));
+
+        $key = array_search($titleNode, $this->openTitleNodes->getArrayCopy(), true);
+
+        if ($key === false) {
+            return;
+        }
+
+        unset($this->openTitleNodes[$key]);
+    }
+}


### PR DESCRIPTION
The Guides DocumentParser class contains the code for interpreting
everything. This makes for a bit of spaghetti code and makes it harder
to change or understand the impact of changes.

When you observe the DocumentParser, it has a couple of responsibilities
but the most striking are perhaps the ParseLine and Flush method as
these two contain the big switches that do different things based on the
current state of the system.

By creating the concept of a 'subparser' (working title, may change)
that has a parse and build method (matching the parseLine and Flush) I
think it is possible to move the individual handling of state into
subparsers.

The end-goal is to have clear subparser and that we can rework the
subparsers to match the way the RST spec names things and divides
things.