### PR TITLE
POC: extensions 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "league/tactician-bundle": "^1.2",
         "league/uri": "~6.3.0",
         "league/uri-interfaces": "^2.0",
+        "phar-io/manifest": "^2.0",
         "phpdocumentor/flyfinder": "^1.0",
         "phpdocumentor/graphviz": "^2.0",
         "phpdocumentor/guides": "*@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f846b56496ec43e39aa1a2d8f17e8e13",
+    "content-hash": "781d9c955f6fdf8122e76a6904c7520d",
     "packages": [
         {
             "name": "doctrine/event-manager",
@@ -1155,6 +1155,117 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.0"
             },
             "time": "2021-09-20T12:20:58+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
+            },
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "phpdocumentor/flyfinder",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -80,6 +80,7 @@ services:
     phpDocumentor\:
         resource: '../src/phpDocumentor/*'
         exclude:
+          - '../src/phpDocumentor/Extension'
           - '../src/phpDocumentor/**/Messages'
           - '../src/phpDocumentor/Pipeline/Stage'
           - '../src/phpDocumentor/Transformer/**/{Event, Exception}/{**}'
@@ -124,6 +125,12 @@ services:
     phpDocumentor\Descriptor\Builder\AssemblerFactory:
         class: 'phpDocumentor\Descriptor\Builder\AssemblerFactory'
         factory: ['phpDocumentor\Descriptor\Builder\AssemblerFactory', 'createDefault']
+
+    phpDocumentor\Extension\ExtensionHandler:
+        arguments:
+          $cacheDir: ''
+          $extensionsDir: ''
+        factory: ['\phpDocumentor\Extension\ExtensionHandler', 'getInstance']
 
     phpDocumentor\Descriptor\Filter\Filter:
         arguments:

--- a/src/phpDocumentor/AutoloaderLocator.php
+++ b/src/phpDocumentor/AutoloaderLocator.php
@@ -23,9 +23,21 @@ use function json_decode;
 
 final class AutoloaderLocator
 {
+    /** @var ?ClassLoader */
+    private static $classLoader;
+
+    public static function loader(): ClassLoader
+    {
+        return self::autoload();
+    }
+
     public static function autoload(): ClassLoader
     {
-        return require self::findVendorPath() . '/autoload.php';
+        if (static::$classLoader instanceof ClassLoader === false) {
+            static::$classLoader = require static::findVendorPath() . '/autoload.php';
+        }
+
+        return static::$classLoader;
     }
 
     /**

--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Console;
 
 use Jean85\PrettyVersions;
 use OutOfBoundsException;
+use phpDocumentor\Version;
 use Symfony\Bundle\FrameworkBundle\Console\Application as BaseApplication;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -29,14 +30,12 @@ use function trim;
 
 class Application extends BaseApplication
 {
-    public const VERSION = '@package_version@';
-
     public function __construct(KernelInterface $kernel)
     {
         parent::__construct($kernel);
 
         $this->setName('phpDocumentor');
-        $this->setVersion($this->detectVersion());
+        $this->setVersion((new Version())->getVersion());
     }
 
     protected function getCommandName(InputInterface $input): ?string
@@ -84,25 +83,5 @@ class Application extends BaseApplication
     public function getLongVersion(): string
     {
         return sprintf('%s <info>%s</info>', $this->getName(), $this->getVersion());
-    }
-
-    private function detectVersion(): string
-    {
-        $version = self::VERSION;
-
-        // prevent replacing the version by the PEAR building
-        if (sprintf('%s%s%s', '@', 'package_version', '@') === self::VERSION) {
-            $version = trim(file_get_contents(__DIR__ . '/../../../VERSION'));
-            // @codeCoverageIgnoreStart
-            try {
-                $version = PrettyVersions::getRootPackageVersion()->getPrettyVersion();
-                $version = sprintf('v%s', ltrim($version, 'v'));
-            } catch (OutOfBoundsException $e) {
-            }
-
-            // @codeCoverageIgnoreEnd
-        }
-
-        return $version;
     }
 }

--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Console;
 
-use Jean85\PrettyVersions;
-use OutOfBoundsException;
 use phpDocumentor\Version;
 use Symfony\Bundle\FrameworkBundle\Console\Application as BaseApplication;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
@@ -23,10 +21,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-use function file_get_contents;
-use function ltrim;
 use function sprintf;
-use function trim;
 
 class Application extends BaseApplication
 {

--- a/src/phpDocumentor/Extension/DirectoryLoader.php
+++ b/src/phpDocumentor/Extension/DirectoryLoader.php
@@ -4,6 +4,45 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Extension;
 
-final class DirectoryLoader
+use DirectoryIterator;
+use PharIo\Manifest\Manifest;
+use PharIo\Manifest\ManifestLoader;
+
+final class DirectoryLoader implements ExtensionLoader
 {
+    public function supports(DirectoryIterator $dir): bool
+    {
+        return $dir->isDir() && $this->findManifestFile(new DirectoryIterator($dir->getPathname())) !== null;
+    }
+
+    public function loadManifest(DirectoryIterator $dir): ?Manifest
+    {
+        $file = $this->findManifestFile($dir);
+        if ($file === null) {
+            return null;
+        }
+
+        return ManifestLoader::fromFile($file->getPathName());
+    }
+
+    private function findManifestFile(DirectoryIterator $dir): ?DirectoryIterator
+    {
+        foreach ($dir as $file) {
+            if ($file->isDot()) {
+                continue;
+            }
+
+            if ($file->isFile() === false) {
+                continue;
+            }
+
+            if ($file->getFileName() !== 'manifest.xml') {
+                continue;
+            }
+
+            return $file;
+        }
+
+        return null;
+    }
 }

--- a/src/phpDocumentor/Extension/DirectoryLoader.php
+++ b/src/phpDocumentor/Extension/DirectoryLoader.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace phpDocumentor\Extension;
 
 use DirectoryIterator;
-use PharIo\Manifest\Manifest;
 use PharIo\Manifest\ManifestLoader;
 
 final class DirectoryLoader implements ExtensionLoader
@@ -15,14 +14,14 @@ final class DirectoryLoader implements ExtensionLoader
         return $dir->isDir() && $this->findManifestFile(new DirectoryIterator($dir->getPathname())) !== null;
     }
 
-    public function loadManifest(DirectoryIterator $dir): ?Manifest
+    public function load(DirectoryIterator $dir): ?Extension
     {
         $file = $this->findManifestFile($dir);
         if ($file === null) {
             return null;
         }
 
-        return ManifestLoader::fromFile($file->getPathName());
+        return Extension::fromManifest(ManifestLoader::fromFile($file->getPathName()), $file->getPath());
     }
 
     private function findManifestFile(DirectoryIterator $dir): ?DirectoryIterator

--- a/src/phpDocumentor/Extension/DirectoryLoader.php
+++ b/src/phpDocumentor/Extension/DirectoryLoader.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+final class DirectoryLoader
+{
+}

--- a/src/phpDocumentor/Extension/Extension.php
+++ b/src/phpDocumentor/Extension/Extension.php
@@ -6,6 +6,10 @@ namespace phpDocumentor\Extension;
 
 use PharIo\Manifest\Manifest;
 
+use function array_pop;
+use function explode;
+use function implode;
+
 final class Extension
 {
     /** @var Manifest */

--- a/src/phpDocumentor/Extension/Extension.php
+++ b/src/phpDocumentor/Extension/Extension.php
@@ -17,15 +17,19 @@ final class Extension
     /** @var string */
     private $path;
 
+    /** @var string */
+    private $name;
+
     private function __construct(Manifest $manifest, string $path)
     {
         $this->manifest = $manifest;
         $this->path = $path;
         foreach ($manifest->getBundledComponents() as $component) {
-            $this->namespace = trim($component->getName(), '\\') . '\\';
+            $parts = explode('\\', $component->getName());
+            $this->name = array_pop($parts);
+            $this->namespace = implode('\\', $parts) . '\\';
             break;
         }
-
     }
 
     public static function fromManifest(Manifest $manifest, string $path): self
@@ -45,7 +49,7 @@ final class Extension
 
     public function getExtensionClass(): string
     {
-        return $this->namespace . 'Extension';
+        return $this->namespace . $this->name;
     }
 
     public function getNamespace(): string
@@ -56,5 +60,10 @@ final class Extension
     public function getPath(): string
     {
         return $this->path;
+    }
+
+    public function getManifest(): Manifest
+    {
+        return $this->manifest;
     }
 }

--- a/src/phpDocumentor/Extension/Extension.php
+++ b/src/phpDocumentor/Extension/Extension.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\Manifest;
+
+final class Extension
+{
+    /** @var Manifest */
+    private $manifest;
+
+    /** @var string */
+    private $namespace;
+
+    /** @var string */
+    private $path;
+
+    private function __construct(Manifest $manifest, string $path)
+    {
+        $this->manifest = $manifest;
+        $this->path = $path;
+        foreach ($manifest->getBundledComponents() as $component) {
+            $this->namespace = trim($component->getName(), '\\') . '\\';
+            break;
+        }
+
+    }
+
+    public static function fromManifest(Manifest $manifest, string $path): self
+    {
+        return new self($manifest, $path);
+    }
+
+    public function getName(): string
+    {
+        return $this->manifest->getName()->asString();
+    }
+
+    public function getVersion(): string
+    {
+        return $this->manifest->getVersion()->getVersionString();
+    }
+
+    public function getExtensionClass(): string
+    {
+        return $this->namespace . 'Extension';
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+}

--- a/src/phpDocumentor/Extension/ExtensionHandler.php
+++ b/src/phpDocumentor/Extension/ExtensionHandler.php
@@ -18,6 +18,7 @@ use Generator;
 use Jean85\PrettyVersions;
 use PharIo\Manifest\ApplicationName;
 use phpDocumentor\AutoloaderLocator;
+use phpDocumentor\Version;
 use Symfony\Component\Config\ResourceCheckerConfigCache;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -59,7 +60,8 @@ final class ExtensionHandler implements EventSubscriberInterface
         $this->extensionsDir = $extensionsDir;
         $this->loaders[] = new DirectoryLoader();
         $this->validator = new Validator(
-            new ApplicationName(PrettyVersions::getRootPackageName())
+            new ApplicationName(PrettyVersions::getRootPackageName()),
+            new Version()
         );
     }
 
@@ -133,11 +135,11 @@ final class ExtensionHandler implements EventSubscriberInterface
 
         $extensions = array_filter($extensions);
         $this->extensions = array_filter($extensions, function (Extension $extension) {
-            return $this->validator->isValid($extension->getManifest());
+            return $this->validator->isValid($extension);
         });
 
         $this->invalidExtensions = array_filter($extensions, function (Extension $extension) {
-            return $this->validator->isValid($extension->getManifest()) === false;
+            return $this->validator->isValid($extension) === false;
         });
 
         return $this->extensions;

--- a/src/phpDocumentor/Extension/ExtensionHandler.php
+++ b/src/phpDocumentor/Extension/ExtensionHandler.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Extension;
+
+use DirectoryIterator;
+use Generator;
+use PharIo\Manifest\Manifest;
+use PharIo\Manifest\ManifestLoader;
+use phpDocumentor\AutoloaderLocator;
+use Symfony\Component\Config\ResourceCheckerConfigCache;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use function array_filter;
+use function file_exists;
+use function trim;
+
+final class ExtensionHandler implements EventSubscriberInterface
+{
+    /**
+     * @var ExtensionHandler
+     */
+    private static $instance;
+
+    /** @var string */
+    private $cacheDir;
+
+    /** @var Manifest[] */
+    private $manifests;
+
+    /** @var ?ResourceCheckerConfigCache */
+    private $cache;
+
+    /** @var string */
+    private $extensionsDir;
+
+    private function __construct(string $cacheDir, string $extensionsDir)
+    {
+        $this->cacheDir = $cacheDir;
+        $this->extensionsDir = $extensionsDir;
+    }
+
+    public static function getInstance(string $cacheDir, string $extensionsDir): self
+    {
+        if (self::$instance instanceof self === false) {
+            self::$instance = new self($cacheDir, $extensionsDir);
+        }
+
+        return self::$instance;
+    }
+
+    public function isFresh(): bool
+    {
+        $extensionConfig = $this->getCache();
+        $fresh = $extensionConfig->isFresh();
+        if ($fresh === false) {
+            $this->refresh();
+        }
+
+        return $fresh;
+    }
+
+    public function refresh(): void
+    {
+        $this->cache->write('', [new ExtensionsResource($this->manifests)]);
+    }
+
+    private function getCache(): ResourceCheckerConfigCache
+    {
+        if ($this->cache instanceof ResourceCheckerConfigCache) {
+            return $this->cache;
+        }
+
+        $this->cache = new ResourceCheckerConfigCache(
+            $this->cacheDir,
+            [new ExtensionLockChecker($this->getManifests())]
+        );
+
+        return $this->cache;
+    }
+
+    /** @return Manifest[] */
+    private function getManifests(): array
+    {
+        if ($this->manifests !== null) {
+            return $this->manifests;
+        }
+
+        if (file_exists($this->extensionsDir) === false) {
+            $this->manifests = [];
+
+            return $this->manifests;
+        }
+
+        $manifests = [];
+        $iterator = new DirectoryIterator($this->extensionsDir);
+        foreach ($iterator as $dir) {
+            if ($dir->isDot()) {
+                continue;
+            }
+
+            if (!$dir->isDir()) {
+                continue;
+            }
+
+            $manifests[$dir->getPathName()] = $this->loadManifest(new DirectoryIterator($dir->getPathName()));
+        }
+
+        $this->manifests = array_filter($manifests);
+
+        return $this->manifests;
+    }
+
+    /** @return Generator<class-string> */
+    public function loadExtensions(): Generator
+    {
+        foreach ($this->getManifests() as $path => $manifest) {
+            foreach ($manifest->getBundledComponents() as $component) {
+                $namespace = trim($component->getName(), '\\') . '\\';
+                AutoloaderLocator::loader()->addPsr4($namespace, [$path]);
+
+                yield $namespace . 'Extension';
+            }
+        }
+    }
+
+    private function loadManifest(DirectoryIterator $dir): ?Manifest
+    {
+        foreach ($dir as $file) {
+            if ($file->isDot()) {
+                continue;
+            }
+
+            if ($file->isFile() === false) {
+                continue;
+            }
+
+            if ($file->getFileName() !== 'manifest.xml') {
+                continue;
+            }
+
+            return ManifestLoader::fromFile($file->getPathName());
+        }
+
+        return null;
+    }
+
+    public function onBoot(ConsoleCommandEvent $event): void
+    {
+        $output = $event->getOutput();
+        $manifests = $this->getManifests();
+        if (count($manifests) > 0) {
+            $output->writeln('loaded extensions:');
+            foreach ($manifests as $manifest) {
+                $output->writeln(
+                    $manifest->getName()->asString() . ':' . $manifest->getVersion()->getVersionString(),
+                    OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_NORMAL
+                );
+            }
+        }
+    }
+
+    /** @return string[] */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'console.command' => 'onBoot'
+        ];
+    }
+}

--- a/src/phpDocumentor/Extension/ExtensionLoader.php
+++ b/src/phpDocumentor/Extension/ExtensionLoader.php
@@ -11,5 +11,5 @@ interface ExtensionLoader
 {
     public function supports(DirectoryIterator $dir): bool;
 
-    public function loadManifest(DirectoryIterator $dir): ?Manifest;
+    public function load(DirectoryIterator $dir): ?Extension;
 }

--- a/src/phpDocumentor/Extension/ExtensionLoader.php
+++ b/src/phpDocumentor/Extension/ExtensionLoader.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace phpDocumentor\Extension;
 
 use DirectoryIterator;
-use PharIo\Manifest\Manifest;
 
 interface ExtensionLoader
 {

--- a/src/phpDocumentor/Extension/ExtensionLoader.php
+++ b/src/phpDocumentor/Extension/ExtensionLoader.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use DirectoryIterator;
+use PharIo\Manifest\Manifest;
+
+interface ExtensionLoader
+{
+    public function supports(DirectoryIterator $dir): bool;
+
+    public function loadManifest(DirectoryIterator $dir): ?Manifest;
+}

--- a/src/phpDocumentor/Extension/ExtensionLockChecker.php
+++ b/src/phpDocumentor/Extension/ExtensionLockChecker.php
@@ -24,12 +24,12 @@ use function serialize;
 final class ExtensionLockChecker implements ResourceCheckerInterface
 {
     /** @var Extension[] */
-    private $manifests;
+    private $extensions;
 
     /** @param Extension[] $extensions */
     public function __construct(array $extensions)
     {
-        $this->manifests = $extensions;
+        $this->extensions = $extensions;
     }
 
     public function supports(ResourceInterface $metadata): bool
@@ -41,6 +41,6 @@ final class ExtensionLockChecker implements ResourceCheckerInterface
     {
         Assert::isInstanceOf($resource,ExtensionsResource::class);
 
-        return $resource->getHash() === md5(serialize($this->manifests));
+        return $resource->getHash() === md5(serialize($this->extensions));
     }
 }

--- a/src/phpDocumentor/Extension/ExtensionLockChecker.php
+++ b/src/phpDocumentor/Extension/ExtensionLockChecker.php
@@ -13,11 +13,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Extension;
 
-use PharIo\Manifest\Manifest;
 use Symfony\Component\Config\Resource\ResourceInterface;
 use Symfony\Component\Config\ResourceCheckerInterface;
-
 use Webmozart\Assert\Assert;
+
 use function md5;
 use function serialize;
 
@@ -39,7 +38,7 @@ final class ExtensionLockChecker implements ResourceCheckerInterface
 
     public function isFresh(ResourceInterface $resource, int $timestamp): bool
     {
-        Assert::isInstanceOf($resource,ExtensionsResource::class);
+        Assert::isInstanceOf($resource, ExtensionsResource::class);
 
         return $resource->getHash() === md5(serialize($this->extensions));
     }

--- a/src/phpDocumentor/Extension/ExtensionLockChecker.php
+++ b/src/phpDocumentor/Extension/ExtensionLockChecker.php
@@ -23,13 +23,13 @@ use function serialize;
 
 final class ExtensionLockChecker implements ResourceCheckerInterface
 {
-    /** @var Manifest[] */
+    /** @var Extension[] */
     private $manifests;
 
-    /** @param Manifest[] $manifests */
-    public function __construct(array $manifests)
+    /** @param Extension[] $extensions */
+    public function __construct(array $extensions)
     {
-        $this->manifests = $manifests;
+        $this->manifests = $extensions;
     }
 
     public function supports(ResourceInterface $metadata): bool

--- a/src/phpDocumentor/Extension/ExtensionLockChecker.php
+++ b/src/phpDocumentor/Extension/ExtensionLockChecker.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\Manifest;
+use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Config\ResourceCheckerInterface;
+
+use Webmozart\Assert\Assert;
+use function md5;
+use function serialize;
+
+final class ExtensionLockChecker implements ResourceCheckerInterface
+{
+    /** @var Manifest[] */
+    private $manifests;
+
+    /** @param Manifest[] $manifests */
+    public function __construct(array $manifests)
+    {
+        $this->manifests = $manifests;
+    }
+
+    public function supports(ResourceInterface $metadata): bool
+    {
+        return $metadata instanceof ExtensionsResource;
+    }
+
+    public function isFresh(ResourceInterface $resource, int $timestamp): bool
+    {
+        Assert::isInstanceOf($resource,ExtensionsResource::class);
+
+        return $resource->getHash() === md5(serialize($this->manifests));
+    }
+}

--- a/src/phpDocumentor/Extension/ExtensionsResource.php
+++ b/src/phpDocumentor/Extension/ExtensionsResource.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Extension;
 
-use PharIo\Manifest\Manifest;
 use Symfony\Component\Config\Resource\ResourceInterface;
 
 use function md5;

--- a/src/phpDocumentor/Extension/ExtensionsResource.php
+++ b/src/phpDocumentor/Extension/ExtensionsResource.php
@@ -21,18 +21,18 @@ use function serialize;
 
 final class ExtensionsResource implements ResourceInterface
 {
-    /** @var Manifest[] */
-    private $manifests;
+    /** @var Extension[] */
+    private $extensions;
 
-    /** @param Manifest[] $manifests */
-    public function __construct(array $manifests)
+    /** @param Extension[] $extensions */
+    public function __construct(array $extensions)
     {
-        $this->manifests = $manifests;
+        $this->extensions = $extensions;
     }
 
     public function __toString(): string
     {
-        return serialize($this->manifests);
+        return serialize($this->extensions);
     }
 
     public function getHash(): string

--- a/src/phpDocumentor/Extension/ExtensionsResource.php
+++ b/src/phpDocumentor/Extension/ExtensionsResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\Manifest;
+use Symfony\Component\Config\Resource\ResourceInterface;
+
+use function md5;
+use function serialize;
+
+final class ExtensionsResource implements ResourceInterface
+{
+    /** @var Manifest[] */
+    private $manifests;
+
+    /** @param Manifest[] $manifests */
+    public function __construct(array $manifests)
+    {
+        $this->manifests = $manifests;
+    }
+
+    public function __toString(): string
+    {
+        return serialize($this->manifests);
+    }
+
+    public function getHash(): string
+    {
+        return md5((string) $this);
+    }
+}

--- a/src/phpDocumentor/Extension/Validator.php
+++ b/src/phpDocumentor/Extension/Validator.php
@@ -8,5 +8,8 @@ use PharIo\Manifest\Manifest;
 
 final class Validator
 {
-    public function isValid(Manifest )
+    public function isValid(Manifest $manifest)
+    {
+
+    }
 }

--- a/src/phpDocumentor/Extension/Validator.php
+++ b/src/phpDocumentor/Extension/Validator.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Extension;
 
 use PharIo\Manifest\ApplicationName;
-use PharIo\Manifest\Manifest;
 use PharIo\Version\Version;
+use phpDocumentor\Version as ApplicationVersion;
 
 final class Validator
 {
@@ -16,14 +16,14 @@ final class Validator
     /** @var Version */
     private $applicationVersion;
 
-    public function __construct(ApplicationName $applicationName)
+    public function __construct(ApplicationName $applicationName, ApplicationVersion $applicationVersion)
     {
         $this->applicationName    = $applicationName;
-        $this->applicationVersion = new Version((new \phpDocumentor\Version())->getExtensionVersion());
+        $this->applicationVersion = new Version($applicationVersion->getExtensionVersion());
     }
 
-    public function isValid(Manifest $manifest): bool
+    public function isValid(Extension $extension): bool
     {
-        return $manifest->isExtensionFor($this->applicationName, $this->applicationVersion);
+        return $extension->getManifest()->isExtensionFor($this->applicationName, $this->applicationVersion);
     }
 }

--- a/src/phpDocumentor/Extension/Validator.php
+++ b/src/phpDocumentor/Extension/Validator.php
@@ -4,12 +4,26 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Extension;
 
+use PharIo\Manifest\ApplicationName;
 use PharIo\Manifest\Manifest;
+use PharIo\Version\Version;
 
 final class Validator
 {
-    public function isValid(Manifest $manifest)
-    {
+    /** @var ApplicationName */
+    private $applicationName;
 
+    /** @var Version */
+    private $applicationVersion;
+
+    public function __construct(ApplicationName $applicationName)
+    {
+        $this->applicationName    = $applicationName;
+        $this->applicationVersion = new Version((new \phpDocumentor\Version())->getExtensionVersion());
+    }
+
+    public function isValid(Manifest $manifest): bool
+    {
+        return $manifest->isExtensionFor($this->applicationName, $this->applicationVersion);
     }
 }

--- a/src/phpDocumentor/Extension/Validator.php
+++ b/src/phpDocumentor/Extension/Validator.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\Manifest;
+
+final class Validator
+{
+    public function isValid(Manifest )
+}

--- a/src/phpDocumentor/Kernel.php
+++ b/src/phpDocumentor/Kernel.php
@@ -23,6 +23,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
+use function class_exists;
 use function file_exists;
 use function getcwd;
 use function is_dir;
@@ -130,9 +131,11 @@ class Kernel extends BaseKernel
         }
 
         foreach ($this->extensionHander->loadExtensions() as $extension) {
-            if (class_exists($extension)) {
-                yield new $extension();
+            if (!class_exists($extension)) {
+                continue;
             }
+
+            yield new $extension();
         }
     }
 

--- a/src/phpDocumentor/Version.php
+++ b/src/phpDocumentor/Version.php
@@ -7,6 +7,12 @@ namespace phpDocumentor;
 use Jean85\PrettyVersions;
 use OutOfBoundsException;
 
+use function explode;
+use function file_get_contents;
+use function sprintf;
+use function strpos;
+use function trim;
+
 final class Version
 {
     private const VERSION = '@package_version@';
@@ -34,7 +40,8 @@ final class Version
                     return $version;
                 }
 
-                $version = sprintf('%s-%s+%s',
+                $version = sprintf(
+                    '%s-%s+%s',
                     $version,
                     $packageVersion->getShortVersion(),
                     $packageVersion->getShortReference()
@@ -55,7 +62,7 @@ final class Version
 
     public function getExtensionVersion(): string
     {
-        if (strpos($this->version, '-dev') !== false){
+        if (strpos($this->version, '-dev') !== false) {
             $version = explode('-', $this->version)[0];
 
             return $version . '-dev';

--- a/src/phpDocumentor/Version.php
+++ b/src/phpDocumentor/Version.php
@@ -62,7 +62,7 @@ final class Version
 
     public function getExtensionVersion(): string
     {
-        if (strpos($this->version, '-dev') !== false) {
+        if (strpos($this->version, '-') !== false) {
             $version = explode('-', $this->version)[0];
 
             return $version . '-dev';

--- a/src/phpDocumentor/Version.php
+++ b/src/phpDocumentor/Version.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor;
+
+use Jean85\PrettyVersions;
+use OutOfBoundsException;
+
+final class Version
+{
+    private const VERSION = '@package_version@';
+
+    /** @var string */
+    private $version;
+
+    public function __construct()
+    {
+        $this->version = $this->detectVersion();
+    }
+
+    private function detectVersion(): string
+    {
+        $version = self::VERSION;
+
+        // prevent replacing the version by the PEAR building
+        if (sprintf('%s%s%s', '@', 'package_version', '@') === self::VERSION) {
+            $version = trim(file_get_contents(__DIR__ . '/../../VERSION'));
+            // @codeCoverageIgnoreStart
+            try {
+                $packageVersion = PrettyVersions::getRootPackageVersion();
+
+                if ($packageVersion->getPrettyVersion() === $version) {
+                    return $version;
+                }
+
+                $version = sprintf('%s-%s+%s',
+                    $version,
+                    $packageVersion->getShortVersion(),
+                    $packageVersion->getShortReference()
+                );
+            } catch (OutOfBoundsException $e) {
+            }
+
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $version;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function getExtensionVersion(): string
+    {
+        if (strpos($this->version, '-dev') !== false){
+            $version = explode('-', $this->version)[0];
+
+            return $version . '-dev';
+        }
+
+        return $this->version;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -68,6 +68,12 @@
     "ocramius/package-versions": {
         "version": "1.3.0"
     },
+    "phar-io/manifest": {
+        "version": "2.0.3"
+    },
+    "phar-io/version": {
+        "version": "3.1.0"
+    },
     "php": {
         "version": "7.2.5"
     },

--- a/tests/data/extensions/example/Extension.php
+++ b/tests/data/extensions/example/Extension.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Example;
+
+class Extension
+{
+
+}

--- a/tests/data/extensions/example/manifest.xml
+++ b/tests/data/extensions/example/manifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phar xmlns="https://phar.io/xml/manifest/1.0">
+    <contains name="phpdocumentor/directives" version="1.0" type="extension">
+        <extension for="phpdocumentor/phpdocumentor" compatible="^3.1"/>
+    </contains>
+
+    <copyright>
+        <author name="Jaap van Otterdijk" email="jaap@phpdoc.org"/>
+        <license type="MIT" url="https://github.com/phpdocumentor/phpdocumentor-example-extension/blob/1.0.0/LICENSE"/>
+    </copyright>
+
+    <requires>
+        <php version="^7.2"/>
+    </requires>
+
+    <bundles>
+        <component name="phpDocumentor\Example" version="1.0" />
+    </bundles>
+</phar>

--- a/tests/unit/phpDocumentor/Extension/DirectoryLoaderTest.php
+++ b/tests/unit/phpDocumentor/Extension/DirectoryLoaderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Extension\DirectoryLoader
+ */
+final class DirectoryLoaderTest extends TestCase
+{
+    /**
+     * @covers ::supports
+     * @covers ::findManifestFile
+     */
+    public function testSupportsReturnsFalseWhenNoManifestFileFoundInEmptyDir(): void
+    {
+        $fileSystem = vfsStream::setup('extensions');
+        $fileSystem->addChild(vfsStream::newDirectory('myExtension'));
+
+        $loader = new DirectoryLoader();
+        self::assertFalse($loader->supports(new \DirectoryIterator($fileSystem->url())));
+    }
+
+    /**
+     * @covers ::supports
+     * @covers ::findManifestFile
+     */
+    public function testSupportsReturnsFalseWhenNoManifestFileFound(): void
+    {
+        $fileSystem = vfsStream::setup('extensions');
+        $fileSystem->addChild(vfsStream::newFile('myExtension'));
+
+        $loader = new DirectoryLoader();
+        self::assertFalse($loader->supports(new \DirectoryIterator($fileSystem->url())));
+    }
+
+    /**
+     * @covers ::supports
+     * @covers ::findManifestFile
+     */
+    public function testSupportsReturnsTrueWhenManifestFileFound(): void
+    {
+        $fileSystem = vfsStream::setup('extensions');
+        $fileSystem->addChild(vfsStream::newFile('manifest.xml'));
+
+        $loader = new DirectoryLoader();
+        self::assertTrue($loader->supports(new \DirectoryIterator($fileSystem->url())));
+    }
+
+    /**
+     * @covers ::load
+     * @covers ::findManifestFile
+     */
+    public function testNotSupportedDirectoryReturnsNullOnLoad(): void
+    {
+        $fileSystem = vfsStream::setup('extensions');
+        $fileSystem->addChild(vfsStream::newFile('myExtension'));
+
+        $loader = new DirectoryLoader();
+        self::assertNull($loader->load(new \DirectoryIterator($fileSystem->url())));
+    }
+
+    /**
+     * @covers ::load
+     * @covers ::findManifestFile
+     */
+    public function testExtensionIsCreatedWhenExtensionDirValid(): void
+    {
+        $fileSystem = vfsStream::copyFromFileSystem(__DIR__ . '/../../../data/extensions/example');
+
+        $loader = new DirectoryLoader();
+        $extension = $loader->load(new \DirectoryIterator($fileSystem->url()));
+
+        self::assertInstanceOf(Extension::class, $extension);
+    }
+}

--- a/tests/unit/phpDocumentor/Extension/DirectoryLoaderTest.php
+++ b/tests/unit/phpDocumentor/Extension/DirectoryLoaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Extension;
 
+use DirectoryIterator;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
@@ -22,7 +23,7 @@ final class DirectoryLoaderTest extends TestCase
         $fileSystem->addChild(vfsStream::newDirectory('myExtension'));
 
         $loader = new DirectoryLoader();
-        self::assertFalse($loader->supports(new \DirectoryIterator($fileSystem->url())));
+        self::assertFalse($loader->supports(new DirectoryIterator($fileSystem->url())));
     }
 
     /**
@@ -35,7 +36,7 @@ final class DirectoryLoaderTest extends TestCase
         $fileSystem->addChild(vfsStream::newFile('myExtension'));
 
         $loader = new DirectoryLoader();
-        self::assertFalse($loader->supports(new \DirectoryIterator($fileSystem->url())));
+        self::assertFalse($loader->supports(new DirectoryIterator($fileSystem->url())));
     }
 
     /**
@@ -48,7 +49,7 @@ final class DirectoryLoaderTest extends TestCase
         $fileSystem->addChild(vfsStream::newFile('manifest.xml'));
 
         $loader = new DirectoryLoader();
-        self::assertTrue($loader->supports(new \DirectoryIterator($fileSystem->url())));
+        self::assertTrue($loader->supports(new DirectoryIterator($fileSystem->url())));
     }
 
     /**
@@ -61,7 +62,7 @@ final class DirectoryLoaderTest extends TestCase
         $fileSystem->addChild(vfsStream::newFile('myExtension'));
 
         $loader = new DirectoryLoader();
-        self::assertNull($loader->load(new \DirectoryIterator($fileSystem->url())));
+        self::assertNull($loader->load(new DirectoryIterator($fileSystem->url())));
     }
 
     /**
@@ -73,7 +74,7 @@ final class DirectoryLoaderTest extends TestCase
         $fileSystem = vfsStream::copyFromFileSystem(__DIR__ . '/../../../data/extensions/example');
 
         $loader = new DirectoryLoader();
-        $extension = $loader->load(new \DirectoryIterator($fileSystem->url()));
+        $extension = $loader->load(new DirectoryIterator($fileSystem->url()));
 
         self::assertInstanceOf(Extension::class, $extension);
     }

--- a/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
+++ b/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
@@ -6,6 +6,7 @@ namespace phpDocumentor\Extension;
 
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 use function iterator_to_array;
 
@@ -19,7 +20,7 @@ final class ExtensionHandlerTest extends TestCase
 {
     protected function tearDown(): void
     {
-        $class = new \ReflectionClass(ExtensionHandler::getInstance(
+        $class = new ReflectionClass(ExtensionHandler::getInstance(
             'foo',
             'bar'
         ));

--- a/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
+++ b/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+use function iterator_to_array;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Extension\ExtensionHandler
+ * @covers ::<private>
+ * @covers ::__construct
+ * @covers ::getInstance
+ */
+final class ExtensionHandlerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $class = new \ReflectionClass(ExtensionHandler::getInstance(
+            'foo',
+            'bar'
+        ));
+
+        $instance = $class->getProperty('instance');
+        $instance->setAccessible(true);
+        $instance->setValue(null, null);
+        $instance->setAccessible(false);
+    }
+
+    /**
+     * @covers ::loadExtensions
+     */
+    public function testLoadExtensionsFromEmptyDirResultsInEmptyExtensions(): void
+    {
+        $root = vfsStream::setup();
+        $root->addChild(vfsStream::newDirectory('cache'));
+        $root->addChild(vfsStream::newDirectory('extensions'));
+
+        $cacheDir = $root->url() . '/cache';
+        $extensionsDir = $root->url() . '/extensions';
+
+        $extensionHandler = ExtensionHandler::getInstance($cacheDir, $extensionsDir);
+
+        $manifests = iterator_to_array($extensionHandler->loadExtensions());
+        self::assertCount(0, $manifests);
+    }
+
+    /**
+     * @covers ::loadExtensions
+     */
+    public function testLoadExtensionsFromNonExistingDirResultsInEmptyArray(): void
+    {
+        $root = vfsStream::setup();
+        $root->addChild(vfsStream::newDirectory('cache'));
+        $root->addChild(vfsStream::newDirectory('extensions'));
+
+        $cacheDir = $root->url() . '/cache';
+        $extensionsDir = $root->url() . '/extensions';
+
+        $extensionHandler = ExtensionHandler::getInstance($cacheDir, $extensionsDir . '/notExisting');
+        $manifests = iterator_to_array($extensionHandler->loadExtensions());
+        self::assertCount(0, $manifests);
+    }
+
+    /**
+     * @covers ::loadExtensions
+     */
+    public function testLoadExtensionsIgnoresNonPharFiles(): void
+    {
+        $root = vfsStream::setup();
+        $root->addChild(vfsStream::newDirectory('cache'));
+        $extensionsDir = vfsStream::newDirectory('extensions');
+        $extensionsDir->addChild(vfsStream::newFile('somefile.txt')->withContent('ignore'));
+        $root->addChild($extensionsDir);
+
+        $extensionHandler = ExtensionHandler::getInstance($root->url() . '/cache', $extensionsDir->url());
+        $manifests = iterator_to_array($extensionHandler->loadExtensions());
+        self::assertCount(0, $manifests);
+    }
+
+    /**
+     * @covers ::loadExtensions
+     */
+    public function testLoadExtensionFromDir(): void
+    {
+        $root = vfsStream::setup();
+        $root->addChild(vfsStream::newDirectory('cache'));
+        $extensionsDir = vfsStream::newDirectory('extensions');
+        vfsStream::copyFromFileSystem(__DIR__ . '/../../../data/extensions', $extensionsDir);
+        $root->addChild($extensionsDir);
+
+        $extensionHandler = ExtensionHandler::getInstance($root->url() . '/cache', $extensionsDir->url());
+        $manifests = iterator_to_array($extensionHandler->loadExtensions());
+        self::assertCount(1, $manifests);
+    }
+}

--- a/tests/unit/phpDocumentor/Extension/ExtensionLockCheckerTest.php
+++ b/tests/unit/phpDocumentor/Extension/ExtensionLockCheckerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Extension;
+
+use org\bovigo\vfs\vfsStream;
+use phpDocumentor\Faker\Faker;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Resource\FileResource;
+
+use function time;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Extension\ExtensionLockChecker
+ */
+final class ExtensionLockCheckerTest extends TestCase
+{
+    use Faker;
+
+    /**
+     * @covers ::supports
+     * @covers ::__construct
+     */
+    public function testSupportsExtensionResource(): void
+    {
+        $root = vfsStream::setup();
+        $extensionLockChecker = new ExtensionLockChecker([]);
+
+        self::assertTrue($extensionLockChecker->supports(new ExtensionsResource([])));
+        self::assertFalse($extensionLockChecker->supports(new FileResource($root->url())));
+    }
+
+    /**
+     * @covers ::isFresh
+     * @covers ::__construct
+     */
+    public function testIsNotFreshWhenChangesDetected(): void
+    {
+        $manifest = $this->faker()->extensionManifest();
+
+        $extensionLockChecker = new ExtensionLockChecker([]);
+        self::assertFalse($extensionLockChecker->isFresh(new ExtensionsResource([$manifest]), time()));
+    }
+
+    /**
+     * @covers ::isFresh
+     * @covers ::__construct
+     */
+    public function testIsNotFreshWhenExtensionIsChanged(): void
+    {
+        $manifest = $this->faker()->extensionManifest();
+        $manifest20 = $this->faker()->extensionManifest('2.0.0');
+
+        $extensionLockChecker = new ExtensionLockChecker([$manifest]);
+        self::assertFalse($extensionLockChecker->isFresh(new ExtensionsResource([$manifest20]), time()));
+    }
+
+    /**
+     * @covers ::isFresh
+     * @covers ::__construct
+     */
+    public function testIsFreshWhenWhenEmpty(): void
+    {
+        $extensionLockChecker = new ExtensionLockChecker([]);
+        self::assertTrue($extensionLockChecker->isFresh(new ExtensionsResource([]), time()));
+    }
+}

--- a/tests/unit/phpDocumentor/Extension/ExtensionTest.php
+++ b/tests/unit/phpDocumentor/Extension/ExtensionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\ApplicationName;
+use PharIo\Manifest\AuthorCollection;
+use PharIo\Manifest\BundledComponent;
+use PharIo\Manifest\BundledComponentCollection;
+use PharIo\Manifest\CopyrightInformation;
+use PharIo\Manifest\License;
+use PharIo\Manifest\Manifest;
+use PharIo\Manifest\RequirementCollection;
+use PharIo\Manifest\Url;
+use PharIo\Version\AnyVersionConstraint;
+use PharIo\Version\Version;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \phpDocumentor\Extension\Extension */
+final class ExtensionTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::fromManifest
+     * @covers ::getExtensionClass
+     * @covers ::getVersion
+     * @covers ::getName
+     * @covers ::getNamespace
+     * @covers ::getPath
+     * @covers ::getManifest
+     */
+    public function testExtensionIsCreatedCorrectlyFromManifest(): void
+    {
+        $components = new BundledComponentCollection();
+        $components->add(
+            new BundledComponent(
+                'phpDocumentor\\Example\\ExampleExtension',
+                new Version('1.0.0')
+            )
+        );
+
+        $manifest = new Manifest(
+            new ApplicationName('phpDocumentor/example'),
+            new Version('1.0.0'),
+            new \PharIo\Manifest\Extension(
+                new ApplicationName('phpDocumentor/phpDocumentor'),
+                new AnyVersionConstraint()
+            ),
+            new CopyrightInformation(
+                new AuthorCollection(),
+                new License('mit', new Url('https://phpdoc.org'))
+            ),
+            new RequirementCollection(),
+            $components
+        );
+
+        $extension = Extension::fromManifest($manifest, 'dir');
+
+        self::assertSame('phpDocumentor/example', $extension->getName());
+        self::assertSame('1.0.0', $extension->getVersion());
+        self::assertSame('phpDocumentor\\Example\\ExampleExtension', $extension->getExtensionClass());
+        self::assertSame('phpDocumentor\\Example\\', $extension->getNamespace());
+        self::assertSame($manifest, $extension->getManifest());
+        self::assertSame('dir', $extension->getPath());
+    }
+}

--- a/tests/unit/phpDocumentor/Extension/ExtensionsResouceTest.php
+++ b/tests/unit/phpDocumentor/Extension/ExtensionsResouceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use phpDocumentor\Faker\Faker;
+use PHPUnit\Framework\TestCase;
+
+use function md5;
+use function serialize;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Extension\ExtensionsResource
+ */
+final class ExtensionsResouceTest extends TestCase
+{
+    use Faker;
+
+    /**
+     * @covers ::__construct
+     * @covers ::getHash
+     * @covers ::__toString
+     */
+    public function testHash(): void
+    {
+        $expected = md5(serialize([$this->faker()->extensionManifest()]));
+
+        $resource = new ExtensionsResource([$this->faker()->extensionManifest()]);
+
+        self::assertSame($expected, $resource->getHash());
+    }
+}

--- a/tests/unit/phpDocumentor/Extension/ValidatorTest.php
+++ b/tests/unit/phpDocumentor/Extension/ValidatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\ApplicationName;
+use phpDocumentor\Faker\Faker;
+use phpDocumentor\Version;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \phpDocumentor\Extension\Validator */
+final class ValidatorTest extends TestCase
+{
+    use Faker;
+
+    /**
+     * @covers ::__construct
+     * @covers ::isValid
+     */
+    public function testValidatesExtensionFor(): void
+    {
+        $application = new ApplicationName('phpDocumentor/other');
+        $version = new Version();
+        $validator = new Validator($application, $version);
+
+        $manifest = $this->faker()->extensionManifest('1.0.0');
+        $extension = Extension::fromManifest($manifest, '/extension');
+
+        self::assertFalse($validator->isValid($extension));
+    }
+}

--- a/tests/unit/phpDocumentor/Faker/Provider.php
+++ b/tests/unit/phpDocumentor/Faker/Provider.php
@@ -9,6 +9,17 @@ use League\Flysystem\Adapter\NullAdapter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\MountManager;
 use Mockery as m;
+use PharIo\Manifest\ApplicationName;
+use PharIo\Manifest\AuthorCollection;
+use PharIo\Manifest\BundledComponentCollection;
+use PharIo\Manifest\CopyrightInformation;
+use PharIo\Manifest\Extension;
+use PharIo\Manifest\License;
+use PharIo\Manifest\Manifest;
+use PharIo\Manifest\RequirementCollection;
+use PharIo\Manifest\Url;
+use PharIo\Version\AnyVersionConstraint;
+use PharIo\Version\Version;
 use phpDocumentor\Configuration\ApiSpecification;
 use phpDocumentor\Configuration\Source;
 use phpDocumentor\Configuration\SymfonyConfigFactory;
@@ -199,5 +210,20 @@ final class Provider extends Base
         }
 
         return $rootNamespace;
+    }
+
+    public function extensionManifest(?string $extensionVersion = null): Manifest
+    {
+        return new Manifest(
+            new ApplicationName('phpDocumentor/extension'),
+            new Version($extensionVersion ?? '1.0.0'),
+            new Extension(new ApplicationName('phpDocumentor/phpDocumentor'), new AnyVersionConstraint()),
+            new CopyrightInformation(
+                new AuthorCollection(),
+                new License('MIT', new Url('https://phpdoc.org/licence'))
+            ),
+            new RequirementCollection(),
+            new BundledComponentCollection()
+        );
     }
 }


### PR DESCRIPTION
This PR contains a proof of concept to make phpDocumentor extendable using extensions. 

The code works as is, however we need a number of tests and more stabelized code to merge this. 

- [ ] create 100% code coverage for extension namespace
- [x] add validator for extensions based on manifest data
- [x] test with extensions containing composer dependencies
- [ ] implement phar based extensions. 