### PR TITLE
Improve writer collection implementation

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -212,19 +212,26 @@ services:
     ## Writers ########################################################################
     ###################################################################################
 
-    phpDocumentor\Transformer\Writer\FileIo: ~
-    phpDocumentor\Transformer\Writer\Sourcecode: ~
-    phpDocumentor\Transformer\Writer\Graph: ~
-    phpDocumentor\Transformer\Writer\Twig: ~
+    phpDocumentor\Transformer\Writer\FileIo:
+      tags:
+        - { name: "phpdoc.transformer.writer", key: 'FileIo'}
+
+    phpDocumentor\Transformer\Writer\Sourcecode:
+      tags:
+        - { name: "phpdoc.transformer.writer", key: 'sourcecode' }
+
+    phpDocumentor\Transformer\Writer\Graph:
+      tags:
+        - { name: "phpdoc.transformer.writer", key: 'Graph' }
+
+    phpDocumentor\Transformer\Writer\Twig:
+      tags:
+        - { name: "phpdoc.transformer.writer", key: 'twig' }
+
     phpDocumentor\Transformer\Writer\Twig\EnvironmentFactory: ~
 
     phpDocumentor\Transformer\Writer\Collection:
-        calls:
-            - { method: offsetSet, arguments: ['FileIo', '@phpDocumentor\Transformer\Writer\FileIo']}
-            - { method: offsetSet, arguments: ['sourcecode', '@phpDocumentor\Transformer\Writer\Sourcecode']}
-            - { method: offsetSet, arguments: ['Graph', '@phpDocumentor\Transformer\Writer\Graph']}
-            - { method: offsetSet, arguments: ['twig', '@phpDocumentor\Transformer\Writer\Twig']}
-            - { method: offsetSet, arguments: ['RenderGuide', '@phpDocumentor\Transformer\Writer\RenderGuide']}
+        arguments: [!tagged_iterator { tag: 'phpdoc.transformer.writer', index_by: 'key' }]
 
     phpDocumentor\Transformer\Writer\Graph\PlantumlRenderer:
       arguments:
@@ -238,6 +245,9 @@ services:
     phpDocumentor\Transformer\Writer\RenderGuide:
       arguments:
         $outputFormats: !tagged_iterator phpdoc.guides.format
+      tags:
+        - { name: "phpdoc.transformer.writer", key: 'RenderGuide'}
+
 
     phpDocumentor\Pipeline\Stage\Parser\ParseGuides:
       arguments:

--- a/src/phpDocumentor/Transformer/Template/Factory.php
+++ b/src/phpDocumentor/Transformer/Template/Factory.php
@@ -96,7 +96,7 @@ class Factory
 
         /** @var Transformation $transformation */
         foreach ($template as $transformation) {
-            $writer = $this->writerCollection[$transformation->getWriter()];
+            $writer = $this->writerCollection->get($transformation->getWriter());
             $writer->checkRequirements();
         }
 

--- a/src/phpDocumentor/Transformer/Transformer.php
+++ b/src/phpDocumentor/Transformer/Transformer.php
@@ -151,7 +151,7 @@ class Transformer
             }
 
             $isInitialized[] = $writerName;
-            $writer = $this->writers[$writerName];
+            $writer = $this->writers->get($writerName);
             $this->initializeWriter($writer, $project, $transformation->template());
         }
     }
@@ -227,7 +227,7 @@ class Transformer
         $preTransformationEvent = PreTransformationEvent::create($this, $transformation);
         $this->eventDispatcher->dispatch($preTransformationEvent, self::EVENT_PRE_TRANSFORMATION);
 
-        $writer = $this->writers[$transformation->getWriter()];
+        $writer = $this->writers->get($transformation->getWriter());
         $writer->transform($project, $transformation);
 
         $postTransformationEvent = PostTransformationEvent::createInstance($this);

--- a/tests/unit/phpDocumentor/Transformer/Template/FactoryTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Template/FactoryTest.php
@@ -21,7 +21,6 @@ use phpDocumentor\Parser\FlySystemFactory;
 use phpDocumentor\Transformer\Writer\Collection as WriterCollection;
 use phpDocumentor\Transformer\Writer\WriterAbstract;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
@@ -50,13 +49,15 @@ final class FactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->globalTemplates = vfsStream::setup();
-        $this->writerCollectionMock = $this->prophesize(WriterCollection::class);
-        $this->writerCollectionMock->offsetGet(Argument::any())->willReturn(
-            $this->prophesize(WriterAbstract::class)->reveal()
-        );
         $this->flySystemFactory = $this->faker()->flySystemFactory();
         $this->fixture = new Factory(
-            $this->writerCollectionMock->reveal(),
+            new WriterCollection(
+                [
+                    'FileIo' => $this->prophesize(WriterAbstract::class)->reveal(),
+                    'twig' => $this->prophesize(WriterAbstract::class)->reveal(),
+                    'Graph' => $this->prophesize(WriterAbstract::class)->reveal(),
+                ]
+            ),
             $this->flySystemFactory,
             vfsStream::url('root')
         );


### PR DESCRIPTION
The writer collection was extending \ArrayObject which caused errors on
php 8.1 since the return types were not matching the php return types.

But when looking at the purpose of this class using a collection like this
doesn't make sense. The writer collection should be immutable after the application
was booted. So I rewrote the implementation to be more driven by the symfony service
container. And removing the extend of ArrayObject which is not needed.