### PR TITLE
Add DeclareStrictTypes sniff to PHPCS ruleset

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -114,4 +114,11 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingAnyTypeHint">
          <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
+    
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="linesCountBeforeDeclare" value="1"/>
+            <property name="spacesCountAroundEqualsSign" value="0"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
This change adds the `SlevomatCodingStandard.TypeHints.DeclareStrictTypes` to the PHPCS ruleset.

A single empty line is needed before the `declare`, and there should be no spaces around the `=` sign.
