### PR TITLE
Split parser and rendering context

### DIFF
--- a/incubator/guides-markdown/src/Markdown/MarkupLanguageParser.php
+++ b/incubator/guides-markdown/src/Markdown/MarkupLanguageParser.php
@@ -14,7 +14,6 @@ use League\CommonMark\Inline\Element\Code;
 use League\CommonMark\Inline\Element\Link;
 use League\CommonMark\Inline\Element\Text;
 use League\CommonMark\Node\NodeWalker;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Markdown\Parsers\AbstractBlock;
 use phpDocumentor\Guides\MarkupLanguageParser as ParserInterface;
 use phpDocumentor\Guides\Nodes\AnchorNode;
@@ -25,6 +24,7 @@ use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\RawNode;
 use phpDocumentor\Guides\Nodes\SpanNode;
 use phpDocumentor\Guides\Nodes\TitleNode;
+use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\ReferenceBuilder;
 use RuntimeException;
 
@@ -37,7 +37,7 @@ final class MarkupLanguageParser implements ParserInterface
     /** @var DocParser */
     private $markdownParser;
 
-    /** @var Environment|null */
+    /** @var ParserContext|null */
     private $environment;
 
     /** @var array<AbstractBlock> */
@@ -69,7 +69,7 @@ final class MarkupLanguageParser implements ParserInterface
         return strtolower($inputFormat) === 'md';
     }
 
-    public function parse(Environment $environment, string $contents): DocumentNode
+    public function parse(ParserContext $environment, string $contents): DocumentNode
     {
         $this->environment = $environment;
         $environment->reset();
@@ -172,7 +172,7 @@ final class MarkupLanguageParser implements ParserInterface
         return $parser->parse($this, $walker);
     }
 
-    public function getEnvironment(): Environment
+    public function getEnvironment(): ParserContext
     {
         if ($this->environment === null) {
             throw new RuntimeException(

--- a/incubator/guides-restructured-text/src/RestructuredText/Directives/Figure.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Directives/Figure.php
@@ -8,6 +8,7 @@ use phpDocumentor\Guides\Nodes\FigureNode;
 use phpDocumentor\Guides\Nodes\ImageNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
+use phpDocumentor\Guides\UrlGenerator;
 
 use function assert;
 
@@ -22,6 +23,14 @@ use function assert;
  */
 class Figure extends SubDirective
 {
+    /** @var UrlGenerator */
+    private $urlGenerator;
+
+    public function __construct(UrlGenerator $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
     public function getName(): string
     {
         return 'figure';
@@ -37,7 +46,7 @@ class Figure extends SubDirective
         string $data,
         array $options
     ): ?Node {
-        $image = new ImageNode($parser->getEnvironment()->relativeUrl($data));
+        $image = new ImageNode($this->urlGenerator->relativeUrl($data));
         $image = $image->withOptions([
             'width' => $options['width'] ?? null,
             'height' => $options['height'] ?? null,

--- a/incubator/guides-restructured-text/src/RestructuredText/Directives/Image.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Directives/Image.php
@@ -7,6 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\ImageNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
+use phpDocumentor\Guides\UrlGenerator;
 
 /**
  * Renders an image, example :
@@ -17,6 +18,14 @@ use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
  */
 class Image extends Directive
 {
+    /** @var UrlGenerator */
+    private $urlGenerator;
+
+    public function __construct(UrlGenerator $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
     public function getName(): string
     {
         return 'image';
@@ -31,6 +40,6 @@ class Image extends Directive
         string $data,
         array $options
     ): Node {
-        return new ImageNode($parser->getEnvironment()->relativeUrl($data));
+        return new ImageNode($this->urlGenerator->relativeUrl($data));
     }
 }

--- a/incubator/guides-restructured-text/src/RestructuredText/Directives/Toctree.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Directives/Toctree.php
@@ -7,7 +7,6 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\TocNode;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
-use phpDocumentor\Guides\RestructuredText\Toc\GlobSearcher;
 use phpDocumentor\Guides\RestructuredText\Toc\ToctreeBuilder;
 
 class Toctree extends Directive
@@ -15,9 +14,9 @@ class Toctree extends Directive
     /** @var ToctreeBuilder */
     private $toctreeBuilder;
 
-    public function __construct()
+    public function __construct(ToctreeBuilder $toctreeBuilder)
     {
-        $this->toctreeBuilder = new ToctreeBuilder(new GlobSearcher());
+        $this->toctreeBuilder = $toctreeBuilder;
     }
 
     public function getName(): string

--- a/incubator/guides-restructured-text/src/RestructuredText/Directives/Uml.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Directives/Uml.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\CodeNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\UmlNode;
+use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
 
 use function dirname;
@@ -72,23 +72,23 @@ final class Uml extends Directive
         }
     }
 
-    private function loadExternalUmlFile(Environment $environment, string $path): ?string
+    private function loadExternalUmlFile(ParserContext $parserContext, string $path): ?string
     {
         $fileName = sprintf(
             '%s/%s',
-            dirname($environment->getCurrentAbsolutePath()),
+            dirname($parserContext->getCurrentAbsolutePath()),
             $path
         );
 
-        if (!$environment->getOrigin()->has($fileName)) {
-            $environment->addError(
+        if (!$parserContext->getOrigin()->has($fileName)) {
+            $parserContext->addError(
                 sprintf('Tried to include "%s" as a diagram but the file could not be found', $fileName)
             );
 
             return null;
         }
 
-        $value = $environment->getOrigin()->read($fileName);
+        $value = $parserContext->getOrigin()->read($fileName);
 
         return str_replace(['@startuml', '@enduml'], '', $value);
     }

--- a/incubator/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText;
 
 use Doctrine\Common\EventManager;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\MarkupLanguageParser as ParserInterface;
 use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\ReferenceBuilder;
 use phpDocumentor\Guides\References\Doc;
 use phpDocumentor\Guides\References\Reference;
@@ -22,7 +22,7 @@ use function strtolower;
 
 class MarkupLanguageParser implements ParserInterface
 {
-    /** @var Environment|null */
+    /** @var ParserContext|null */
     private $environment;
 
     /** @var Directive[] */
@@ -97,7 +97,7 @@ class MarkupLanguageParser implements ParserInterface
         }
     }
 
-    public function getEnvironment(): Environment
+    public function getEnvironment(): ParserContext
     {
         if ($this->environment === null) {
             throw new RuntimeException(
@@ -130,7 +130,7 @@ class MarkupLanguageParser implements ParserInterface
         return $this->filename ?: '(unknown)';
     }
 
-    public function parse(Environment $environment, string $contents): DocumentNode
+    public function parse(ParserContext $environment, string $contents): DocumentNode
     {
         $this->environment = $environment;
         $this->documentParser = $this->createDocumentParser();

--- a/incubator/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/AdmonitionNodeRenderer.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/AdmonitionNodeRenderer.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\NodeRenderers\Html;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use phpDocumentor\Guides\RestructuredText\Nodes\AdmonitionNode;
 
@@ -35,7 +35,7 @@ class AdmonitionNodeRenderer implements NodeRenderer
         return $node instanceof AdmonitionNode;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof AdmonitionNode === false) {
             throw new InvalidArgumentException('Node must be an instance of ' . AdmonitionNode::class);

--- a/incubator/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/ContainerNodeRenderer.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/ContainerNodeRenderer.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\NodeRenderers\Html;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use phpDocumentor\Guides\RestructuredText\Nodes\ContainerNode;
 
@@ -35,7 +35,7 @@ final class ContainerNodeRenderer implements NodeRenderer
         return $node instanceof ContainerNode;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof ContainerNode === false) {
             throw new InvalidArgumentException('Node must be an instance of ' . ContainerNode::class);

--- a/incubator/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/SidebarNodeRenderer.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/SidebarNodeRenderer.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\NodeRenderers\Html;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use phpDocumentor\Guides\RestructuredText\Nodes\SidebarNode;
 
@@ -35,7 +35,7 @@ final class SidebarNodeRenderer implements NodeRenderer
         return $node instanceof SidebarNode;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof SidebarNode === false) {
             throw new InvalidArgumentException('Node must be an instance of ' . SidebarNode::class);

--- a/incubator/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/TopicNodeRenderer.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/TopicNodeRenderer.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\NodeRenderers\Html;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use phpDocumentor\Guides\RestructuredText\Nodes\TopicNode;
 
@@ -35,7 +35,7 @@ final class TopicNodeRenderer implements NodeRenderer
         return $node instanceof TopicNode;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof TopicNode === false) {
             throw new InvalidArgumentException('Node must be an instance of ' . TopicNode::class);

--- a/incubator/guides-restructured-text/src/RestructuredText/Toc/GlobSearcher.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Toc/GlobSearcher.php
@@ -6,14 +6,20 @@ namespace phpDocumentor\Guides\RestructuredText\Toc;
 
 use Flyfinder\Specification\Glob;
 use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\UrlGenerator;
 
-use function dirname;
-use function ltrim;
 use function rtrim;
-use function str_replace;
 
 class GlobSearcher
 {
+    /** @var UrlGenerator */
+    private $urlGenerator;
+
+    public function __construct(UrlGenerator $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
     /**
      * @return string[]
      */
@@ -25,16 +31,7 @@ class GlobSearcher
         );
         $allFiles = [];
         foreach ($files as $file) {
-            $allFiles[] = $environment->absoluteUrl(
-                ltrim(
-                    str_replace(
-                        dirname($environment->getCurrentAbsolutePath()),
-                        '',
-                        $file['dirname'] . '/' . $file['filename']
-                    ),
-                    '/'
-                )
-            );
+            $allFiles[] = $this->urlGenerator->absoluteUrl($environment->getDirName(), $file['filename']);
         }
 
         return $allFiles;

--- a/incubator/guides-restructured-text/src/RestructuredText/Toc/GlobSearcher.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Toc/GlobSearcher.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Toc;
 
 use Flyfinder\Specification\Glob;
-use phpDocumentor\Guides\Environment;
+use phpDocumentor\Guides\ParserContext;
 
 use function dirname;
 use function ltrim;
@@ -17,7 +17,7 @@ class GlobSearcher
     /**
      * @return string[]
      */
-    public function globSearch(Environment $environment, string $globPattern): array
+    public function globSearch(ParserContext $environment, string $globPattern): array
     {
         $fileSystem = $environment->getOrigin();
         $files = $fileSystem->find(

--- a/incubator/guides-restructured-text/src/RestructuredText/Toc/ToctreeBuilder.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Toc/ToctreeBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Toc;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\ParserContext;
 
 use function array_filter;
 use function array_map;
@@ -29,7 +29,7 @@ class ToctreeBuilder
      * @return string[]
      */
     public function buildToctreeFiles(
-        Environment $environment,
+        ParserContext $environment,
         Node $node,
         array $options
     ): array {

--- a/incubator/guides-restructured-text/src/RestructuredText/Toc/ToctreeBuilder.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Toc/ToctreeBuilder.php
@@ -6,6 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Toc;
 
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\UrlGenerator;
 
 use function array_filter;
 use function array_map;
@@ -18,9 +19,13 @@ class ToctreeBuilder
     /** @var GlobSearcher */
     private $globSearcher;
 
-    public function __construct(GlobSearcher $globSearcher)
+    /** @var UrlGenerator */
+    private $urlGenerator;
+
+    public function __construct(GlobSearcher $globSearcher, UrlGenerator $urlGenerator)
     {
         $this->globSearcher = $globSearcher;
+        $this->urlGenerator = $urlGenerator;
     }
 
     /**
@@ -52,7 +57,10 @@ class ToctreeBuilder
                     $toctreeFiles[] = $globFile;
                 }
             } else {
-                $absoluteUrl = $environment->absoluteUrl($file);
+                $absoluteUrl = $this->urlGenerator->absoluteUrl(
+                    $environment->getDirName(),
+                    $file
+                );
 
                 $toctreeFiles[] = $absoluteUrl;
             }

--- a/incubator/guides/src/MarkupLanguageParser.php
+++ b/incubator/guides/src/MarkupLanguageParser.php
@@ -19,11 +19,11 @@ interface MarkupLanguageParser
 {
     public function supports(string $inputFormat): bool;
 
-    public function getEnvironment(): Environment;
+    public function getEnvironment(): ParserContext;
 
     public function getReferenceBuilder(): ReferenceBuilder;
 
-    public function parse(Environment $environment, string $contents): DocumentNode;
+    public function parse(ParserContext $environment, string $contents): DocumentNode;
 
     public function getDocument(): DocumentNode;
 }

--- a/incubator/guides/src/NodeRenderers/DefaultNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/DefaultNodeRenderer.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 
 use function is_callable;
 use function is_string;
@@ -29,7 +29,7 @@ class DefaultNodeRenderer implements NodeRenderer, NodeRendererFactoryAware
         $this->nodeRendererFactory = $nodeRendererFactory;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         $value = $node->getValue();
 

--- a/incubator/guides/src/NodeRenderers/DocumentNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/DocumentNodeRenderer.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\NodeRenderers;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 
 class DocumentNodeRenderer implements NodeRenderer
 {
@@ -28,7 +28,7 @@ class DocumentNodeRenderer implements NodeRenderer
         $this->nodeRendererFactory = $nodeRendererFactory;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof DocumentNode === false) {
             throw new InvalidArgumentException('Invalid node presented');

--- a/incubator/guides/src/NodeRenderers/FullDocumentNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/FullDocumentNodeRenderer.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\RenderContext;
 
 interface FullDocumentNodeRenderer
 {
-    public function renderDocument(DocumentNode $node, Environment $environment): string;
+    public function renderDocument(DocumentNode $node, RenderContext $environment): string;
 }

--- a/incubator/guides/src/NodeRenderers/Html/DocumentNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/Html/DocumentNodeRenderer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers\Html;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\DocumentNodeRenderer as BaseDocumentRender;
 use phpDocumentor\Guides\NodeRenderers\FullDocumentNodeRenderer;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
@@ -21,6 +20,7 @@ use phpDocumentor\Guides\NodeRenderers\NodeRendererFactory;
 use phpDocumentor\Guides\NodeRenderers\NodeRendererFactoryAware;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use Webmozart\Assert\Assert;
 
@@ -42,14 +42,14 @@ class DocumentNodeRenderer implements NodeRenderer, FullDocumentNodeRenderer, No
         $this->nodeRendererFactory = $nodeRendererFactory;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         Assert::isInstanceOf($node, DocumentNode::class);
 
         return (new BaseDocumentRender($this->nodeRendererFactory))->render($node, $environment);
     }
 
-    public function renderDocument(DocumentNode $node, Environment $environment): string
+    public function renderDocument(DocumentNode $node, RenderContext $environment): string
     {
         $this->renderer->setGuidesEnvironment($environment);
 

--- a/incubator/guides/src/NodeRenderers/Html/Metadata/DocumentTitleNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/Html/Metadata/DocumentTitleNodeRenderer.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers\Html\Metadata;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Metadata\DocumentTitleNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 
 final class DocumentTitleNodeRenderer implements NodeRenderer
@@ -25,7 +25,7 @@ final class DocumentTitleNodeRenderer implements NodeRenderer
         return $node instanceof DocumentTitleNode;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         return $this->renderer->render('title.html.twig', ['title' => $node->getValueString()]);
     }

--- a/incubator/guides/src/NodeRenderers/Html/SpanNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/Html/SpanNodeRenderer.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers\Html;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\SpanNodeRenderer as BaseSpanNodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\SpanNode;
 use phpDocumentor\Guides\References\ResolvedReference;
+use phpDocumentor\Guides\RenderContext;
 
 use function htmlspecialchars;
 use function trim;
@@ -58,7 +58,7 @@ class SpanNodeRenderer extends BaseSpanNodeRenderer
     /**
      * @param string[] $attributes
      */
-    public function link(Environment $environment, ?string $url, string $title, array $attributes = []): string
+    public function link(RenderContext $environment, ?string $url, string $title, array $attributes = []): string
     {
         $url = (string) $url;
 
@@ -80,7 +80,7 @@ class SpanNodeRenderer extends BaseSpanNodeRenderer
     /**
      * @param array<string|null> $value
      */
-    public function reference(Environment $environment, ResolvedReference $reference, array $value): string
+    public function reference(RenderContext $environment, ResolvedReference $reference, array $value): string
     {
         $text = $value['text'] ?: ($reference->getTitle() ?? '');
         $text = trim($text);

--- a/incubator/guides/src/NodeRenderers/Html/TableNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/Html/TableNodeRenderer.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\NodeRenderers\Html;
 
 use LogicException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\TableNode;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use Webmozart\Assert\Assert;
 
@@ -33,7 +33,7 @@ class TableNodeRenderer implements NodeRenderer
         $this->renderer = $renderer;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         Assert::isInstanceOf($node, TableNode::class);
 

--- a/incubator/guides/src/NodeRenderers/Html/TemplatedNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/Html/TemplatedNodeRenderer.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers\Html;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\TemplatedNode;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use Webmozart\Assert\Assert;
 
@@ -21,7 +21,7 @@ final class TemplatedNodeRenderer implements NodeRenderer
         $this->renderer = $renderer;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         Assert::isInstanceOf($node, TemplatedNode::class);
 

--- a/incubator/guides/src/NodeRenderers/Html/TocNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/Html/TocNodeRenderer.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers\Html;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\TocNode;
 use phpDocumentor\Guides\ReferenceBuilder;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Webmozart\Assert\Assert;
@@ -39,7 +39,7 @@ class TocNodeRenderer implements NodeRenderer
         $this->referenceRegistry = $referenceRegistry;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         Assert::isInstanceOf($node, TocNode::class);
 
@@ -80,7 +80,7 @@ class TocNodeRenderer implements NodeRenderer
      * @param mixed[][] $tocItems
      */
     private function buildLevel(
-        Environment $environment,
+        RenderContext $environment,
         TocNode $node,
         ?string $url,
         array $titles,
@@ -119,7 +119,7 @@ class TocNodeRenderer implements NodeRenderer
      *
      * @return array{mixed, string}
      */
-    private function generateTarget(Environment $environment, ?string $url, $title): array
+    private function generateTarget(RenderContext $environment, ?string $url, $title): array
     {
         $anchor = $this->generateAnchorFromTitle($title);
 

--- a/incubator/guides/src/NodeRenderers/LaTeX/DocumentNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/LaTeX/DocumentNodeRenderer.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\NodeRenderers\LaTeX;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\DocumentNodeRenderer as BaseDocumentRender;
 use phpDocumentor\Guides\NodeRenderers\FullDocumentNodeRenderer;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
@@ -23,6 +22,7 @@ use phpDocumentor\Guides\NodeRenderers\NodeRendererFactoryAware;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\MainNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 
 use function count;
@@ -45,7 +45,7 @@ class DocumentNodeRenderer implements NodeRenderer, FullDocumentNodeRenderer, No
         $this->nodeRendererFactory = $nodeRendererFactory;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof DocumentNode === false) {
             throw new InvalidArgumentException('Invalid node presented');
@@ -54,7 +54,7 @@ class DocumentNodeRenderer implements NodeRenderer, FullDocumentNodeRenderer, No
         return (new BaseDocumentRender($this->nodeRendererFactory))->render($node, $environment);
     }
 
-    public function renderDocument(DocumentNode $node, Environment $environment): string
+    public function renderDocument(DocumentNode $node, RenderContext $environment): string
     {
         $this->renderer->setGuidesEnvironment($environment);
 

--- a/incubator/guides/src/NodeRenderers/LaTeX/SpanNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/LaTeX/SpanNodeRenderer.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers\LaTeX;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\SpanNodeRenderer as BaseSpanNodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\SpanNode;
 use phpDocumentor\Guides\References\ResolvedReference;
+use phpDocumentor\Guides\RenderContext;
 
 use function is_string;
 use function substr;
@@ -53,7 +53,7 @@ class SpanNodeRenderer extends BaseSpanNodeRenderer
     /**
      * @param string[] $attributes
      */
-    public function link(Environment $environment, ?string $url, string $title, array $attributes = []): string
+    public function link(RenderContext $environment, ?string $url, string $title, array $attributes = []): string
     {
         $type = 'href';
 
@@ -84,7 +84,7 @@ class SpanNodeRenderer extends BaseSpanNodeRenderer
     /**
      * @param string[] $value
      */
-    public function reference(Environment $environment, ResolvedReference $reference, array $value): string
+    public function reference(RenderContext $environment, ResolvedReference $reference, array $value): string
     {
         $text = $value['text'] ?: $reference->getTitle();
         $url = $reference->getUrl();

--- a/incubator/guides/src/NodeRenderers/LaTeX/SpanNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/LaTeX/SpanNodeRenderer.php
@@ -62,7 +62,7 @@ class SpanNodeRenderer extends BaseSpanNodeRenderer
 
             $url = substr($url, 1);
             $url = $url !== '' ? '#' . $url : '';
-            $url = $environment->getUrl() . $url;
+            $url = $environment->getCurrentFileName() . $url;
         }
 
         return $this->renderer->render(

--- a/incubator/guides/src/NodeRenderers/LaTeX/TableNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/LaTeX/TableNodeRenderer.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\NodeRenderers\LaTeX;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\NodeRenderers\NodeRendererFactory;
 use phpDocumentor\Guides\NodeRenderers\NodeRendererFactoryAware;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\SpanNode;
 use phpDocumentor\Guides\Nodes\TableNode;
+use phpDocumentor\Guides\RenderContext;
 
 use function count;
 use function implode;
@@ -36,7 +36,7 @@ class TableNodeRenderer implements NodeRenderer, NodeRendererFactoryAware
         $this->nodeRendererFactory = $nodeRendererFactory;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof TableNode === false) {
             throw new InvalidArgumentException('Invalid node presented');

--- a/incubator/guides/src/NodeRenderers/LaTeX/TitleNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/LaTeX/TitleNodeRenderer.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\NodeRenderers\LaTeX;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\TitleNode;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 
 class TitleNodeRenderer implements NodeRenderer
@@ -30,7 +30,7 @@ class TitleNodeRenderer implements NodeRenderer
         $this->renderer = $renderer;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof TitleNode === false) {
             throw new InvalidArgumentException('Invalid node presented');

--- a/incubator/guides/src/NodeRenderers/LaTeX/TocNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/LaTeX/TocNodeRenderer.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\NodeRenderers\LaTeX;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\TocNode;
 use phpDocumentor\Guides\ReferenceBuilder;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 
 class TocNodeRenderer implements NodeRenderer
@@ -35,7 +35,7 @@ class TocNodeRenderer implements NodeRenderer
         $this->referenceRegistry = $referenceRegistry;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof TocNode === false) {
             throw new InvalidArgumentException('Invalid node presented');

--- a/incubator/guides/src/NodeRenderers/NodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/NodeRenderer.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 
 interface NodeRenderer
 {
     public function supports(Node $node): bool;
 
-    public function render(Node $node, Environment $environment): string;
+    public function render(Node $node, RenderContext $environment): string;
 }

--- a/incubator/guides/src/NodeRenderers/SpanNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/SpanNodeRenderer.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\NodeRenderers;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\Links\InvalidLink;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\SpanNode;
 use phpDocumentor\Guides\ReferenceBuilder;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use phpDocumentor\Guides\Span\SpanToken;
 use Symfony\Component\String\Slugger\AsciiSlugger;
@@ -51,7 +51,7 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer, NodeRende
         $this->nodeRendererFactory = $nodeRendererFactory;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         if ($node instanceof SpanNode === false) {
             throw new InvalidArgumentException('Invalid node presented');
@@ -69,7 +69,7 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer, NodeRende
     /**
      * @param string[] $attributes
      */
-    public function link(Environment $environment, ?string $url, string $title, array $attributes = []): string
+    public function link(RenderContext $environment, ?string $url, string $title, array $attributes = []): string
     {
         $url = (string) $url;
 
@@ -83,7 +83,7 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer, NodeRende
         );
     }
 
-    private function renderSyntaxes(string $span, Environment $environment): string
+    private function renderSyntaxes(string $span, RenderContext $environment): string
     {
         $span = $this->escape($span);
 
@@ -127,7 +127,7 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer, NodeRende
         return preg_replace('/~/', $this->nbsp(), $span);
     }
 
-    private function renderVariables(string $span, Environment $environment): string
+    private function renderVariables(string $span, RenderContext $environment): string
     {
         return preg_replace_callback(
             '/\|(.+)\|/mUsi',
@@ -158,7 +158,7 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer, NodeRende
         return preg_replace('/ \n/', $this->br(), $span);
     }
 
-    private function renderTokens(SpanNode $node, string $span, Environment $environment): string
+    private function renderTokens(SpanNode $node, string $span, RenderContext $environment): string
     {
         foreach ($node->getTokens() as $token) {
             $span = $this->renderToken($token, $span, $environment);
@@ -167,7 +167,7 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer, NodeRende
         return $span;
     }
 
-    private function renderToken(SpanToken $spanToken, string $span, Environment $environment): string
+    private function renderToken(SpanToken $spanToken, string $span, RenderContext $environment): string
     {
         switch ($spanToken->getType()) {
             case SpanToken::TYPE_LITERAL:
@@ -192,7 +192,7 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer, NodeRende
         );
     }
 
-    private function renderReference(SpanToken $spanToken, string $span, Environment $environment): string
+    private function renderReference(SpanToken $spanToken, string $span, RenderContext $environment): string
     {
         $role = $spanToken->get('section');
         if ($spanToken->get('domain')) {
@@ -217,7 +217,7 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer, NodeRende
         return str_replace($spanToken->getId(), $link, $span);
     }
 
-    private function renderLink(SpanToken $spanToken, string $span, Environment $environment): string
+    private function renderLink(SpanToken $spanToken, string $span, RenderContext $environment): string
     {
         $url = $spanToken->get('url');
         $link = $spanToken->get('link');

--- a/incubator/guides/src/NodeRenderers/SpanRenderer.php
+++ b/incubator/guides/src/NodeRenderers/SpanRenderer.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\References\ResolvedReference;
+use phpDocumentor\Guides\RenderContext;
 
 interface SpanRenderer
 {
@@ -31,12 +31,12 @@ interface SpanRenderer
     /**
      * @param string[] $attributes
      */
-    public function link(Environment $environment, ?string $url, string $title, array $attributes = []): string;
+    public function link(RenderContext $environment, ?string $url, string $title, array $attributes = []): string;
 
     public function escape(string $span): string;
 
     /**
      * @param string[] $value
      */
-    public function reference(Environment $environment, ResolvedReference $reference, array $value): string;
+    public function reference(RenderContext $environment, ResolvedReference $reference, array $value): string;
 }

--- a/incubator/guides/src/NodeRenderers/TemplateNodeRenderer.php
+++ b/incubator/guides/src/NodeRenderers/TemplateNodeRenderer.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\NodeRenderers;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 
 final class TemplateNodeRenderer implements NodeRenderer
@@ -32,7 +32,7 @@ final class TemplateNodeRenderer implements NodeRenderer
         return $node instanceof $this->nodeClass;
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         return $this->renderer->render(
             $this->template,

--- a/incubator/guides/src/Parser.php
+++ b/incubator/guides/src/Parser.php
@@ -105,13 +105,8 @@ final class Parser
         $this->parserContext->reset();
 
         $document = $parser->parse($this->parserContext, $text);
-
-        if ($document instanceof DocumentNode) {
-            $document->setVariables($this->parserContext->getVariables());
-            $this->addDocumentToMetas($this->parserContext->getDestinationPath(), $outputFormat, $document);
-        }
-
-        var_dump($this->parserContext->getErrors());
+        $document->setVariables($this->parserContext->getVariables());
+        $this->addDocumentToMetas($this->parserContext->getDestinationPath(), $outputFormat, $document);
 
         $this->metas         = null;
         $this->parserContext = null;

--- a/incubator/guides/src/Parser.php
+++ b/incubator/guides/src/Parser.php
@@ -15,7 +15,6 @@ use function getcwd;
 use function ltrim;
 use function sprintf;
 use function trim;
-use function var_dump;
 
 /**
  * Determines the correct markup language parser to use based on the input and output format and with it, and parses

--- a/incubator/guides/src/Parser.php
+++ b/incubator/guides/src/Parser.php
@@ -8,8 +8,6 @@ use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemInterface;
 use phpDocumentor\Guides\Nodes\DocumentNode;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use RuntimeException;
 
 use function filemtime;
@@ -17,6 +15,7 @@ use function getcwd;
 use function ltrim;
 use function sprintf;
 use function trim;
+use function var_dump;
 
 /**
  * Determines the correct markup language parser to use based on the input and output format and with it, and parses
@@ -24,14 +23,12 @@ use function trim;
  */
 final class Parser
 {
-    /** @var ?Environment */
-    private $environment = null;
+    /** @var ?ParserContext */
+    private $parserContext = null;
 
     /** @var ?Metas */
     private $metas = null;
 
-    /** @var LoggerInterface */
-    private $logger;
 
     /** @var UrlGenerator */
     private $urlGenerator;
@@ -44,11 +41,9 @@ final class Parser
      */
     public function __construct(
         UrlGenerator $urlGenerator,
-        iterable $parserStrategies,
-        ?LoggerInterface $logger = null
+        iterable $parserStrategies
     ) {
         $this->urlGenerator = $urlGenerator;
-        $this->logger = $logger ?? new NullLogger();
 
         foreach ($parserStrategies as $strategy) {
             $this->registerStrategy($strategy);
@@ -73,7 +68,7 @@ final class Parser
         }
 
         $this->metas = $metas;
-        $this->environment = $this->createEnvironment(
+        $this->parserContext = $this->createParserContext(
             $sourcePath,
             $fileName,
             $origin,
@@ -91,33 +86,35 @@ final class Parser
         string $inputFormat = 'rst',
         string $outputFormat = 'html'
     ): DocumentNode {
-        if ($this->metas === null || $this->environment === null) {
+        if ($this->metas === null || $this->parserContext === null) {
             // if Metas or Environment is not set; then the prepare method hasn't been called and we consider
             // this a one-off parse of dynamic RST content.
             $this->prepare(new Metas(), null, '', '', 'index');
         }
 
-        $this->environment->setCurrentAbsolutePath(
+        $this->parserContext->setCurrentAbsolutePath(
             $this->buildPathOnFileSystem(
-                $this->environment->getCurrentFileName(),
-                $this->environment->getCurrentDirectory(),
+                $this->parserContext->getCurrentFileName(),
+                $this->parserContext->getCurrentDirectory(),
                 $inputFormat
             )
         );
 
         $parser = $this->determineParser($inputFormat);
 
-        $this->environment->reset();
+        $this->parserContext->reset();
 
-        $document = $parser->parse($this->environment, $text);
+        $document = $parser->parse($this->parserContext, $text);
 
         if ($document instanceof DocumentNode) {
-            $document->setVariables($this->environment->getVariables());
-            $this->addDocumentToMetas($this->environment->getDestinationPath(), $outputFormat, $document);
+            $document->setVariables($this->parserContext->getVariables());
+            $this->addDocumentToMetas($this->parserContext->getDestinationPath(), $outputFormat, $document);
         }
 
-        $this->metas = null;
-        $this->environment = null;
+        var_dump($this->parserContext->getErrors());
+
+        $this->metas         = null;
+        $this->parserContext = null;
 
         return $document;
     }
@@ -133,25 +130,21 @@ final class Parser
         throw new RuntimeException('Unable to parse document, no matching parsing strategy could be found');
     }
 
-    private function createEnvironment(
+    private function createParserContext(
         string $sourcePath,
         string $file,
         FilesystemInterface $origin,
         string $destinationPath,
         int $initialHeaderLevel
-    ): Environment {
-        $environment = new Environment(
+    ): ParserContext {
+        return new ParserContext(
+            $file,
+            $sourcePath,
             $destinationPath,
             $initialHeaderLevel,
-            $this->logger,
             $origin,
-            $this->metas,
             $this->urlGenerator
         );
-        $environment->setCurrentFileName($file);
-        $environment->setCurrentDirectory($sourcePath);
-
-        return $environment;
     }
 
     private function buildPathOnFileSystem(string $file, string $currentDirectory, string $extension): string
@@ -162,7 +155,7 @@ final class Parser
     /**
      * @return array<array<string|null>>
      */
-    private function compileTableOfContents(DocumentNode $document, Environment $environment): array
+    private function compileTableOfContents(DocumentNode $document, ParserContext $parserContext): array
     {
         $result = [];
         $nodes = $document->getTocs();
@@ -170,7 +163,7 @@ final class Parser
             $files = $toc->getFiles();
 
             foreach ($files as $key => $file) {
-                $files[$key] = $environment->canonicalUrl($file);
+                $files[$key] = $parserContext->canonicalUrl($file);
             }
 
             $result[] = $files;
@@ -179,29 +172,29 @@ final class Parser
         return $result;
     }
 
-    private function buildDocumentUrl(Environment $environment, string $extension): string
+    private function buildDocumentUrl(ParserContext $parserContext, string $extension): string
     {
-        return $environment->getUrl() . '.' . $extension;
+        return $parserContext->getUrl() . '.' . $extension;
     }
 
-    private function buildOutputUrl(string $destinationPath, string $outputFormat, Environment $environment): string
+    private function buildOutputUrl(string $destinationPath, string $outputFormat, ParserContext $parserContext): string
     {
         $outputFolder = $destinationPath ? $destinationPath . '/' : '';
 
-        return $outputFolder . $this->buildDocumentUrl($environment, $outputFormat);
+        return $outputFolder . $this->buildDocumentUrl($parserContext, $outputFormat);
     }
 
     private function addDocumentToMetas(string $destinationPath, string $outputFormat, DocumentNode $document): void
     {
         $this->metas->set(
-            $this->environment->getCurrentFileName(),
-            $this->buildOutputUrl($destinationPath, $outputFormat, $this->environment),
+            $this->parserContext->getCurrentFileName(),
+            $this->buildOutputUrl($destinationPath, $outputFormat, $this->parserContext),
             $document->getTitle() ? $document->getTitle()->getValueString() : '',
             $document->getTitles(),
-            $this->compileTableOfContents($document, $this->environment),
-            (int) filemtime($this->environment->getCurrentAbsolutePath()),
+            $this->compileTableOfContents($document, $this->parserContext),
+            (int) filemtime($this->parserContext->getCurrentAbsolutePath()),
             $document->getDependencies(),
-            $this->environment->getLinks()
+            $this->parserContext->getLinks()
         );
     }
 }

--- a/incubator/guides/src/Parser.php
+++ b/incubator/guides/src/Parser.php
@@ -163,7 +163,7 @@ final class Parser
             $files = $toc->getFiles();
 
             foreach ($files as $key => $file) {
-                $files[$key] = $parserContext->canonicalUrl($file);
+                $files[$key] =  $this->urlGenerator->canonicalUrl($parserContext->getDirName(), $file);
             }
 
             $result[] = $files;

--- a/incubator/guides/src/ParserContext.php
+++ b/incubator/guides/src/ParserContext.php
@@ -138,21 +138,9 @@ class ParserContext
     }
 
     //Parser (assets) & renderer
-    public function relativeUrl(?string $url): string
+    private function relativeUrl(?string $url): string
     {
         return $this->urlGenerator->relativeUrl($url);
-    }
-
-    //TocTree builder
-    public function absoluteUrl(string $url): string
-    {
-        return $this->urlGenerator->absoluteUrl($this->getDirName(), $url);
-    }
-
-    //Toc, Resolver
-    public function canonicalUrl(string $url): ?string
-    {
-        return $this->urlGenerator->canonicalUrl($this->getDirName(), $url);
     }
 
     //Parser, Toc

--- a/incubator/guides/src/ParserContext.php
+++ b/incubator/guides/src/ParserContext.php
@@ -44,6 +44,7 @@ class ParserContext
     /** @var string[] */
     private $anonymous = [];
 
+    /** @var string[] */
     private $errors = [];
 
     /** @var string */
@@ -70,20 +71,16 @@ class ParserContext
         $this->reset();
     }
 
-    //Parser
     public function reset(): void
     {
         $this->titleLetters = [];
         $this->currentTitleLevel = 0;
     }
 
-    //Parser
     public function getInitialHeaderLevel(): int
     {
         return $this->initialHeaderLevel;
     }
-
-    //Parser to populate, renderer to restore
 
     /**
      * @param mixed $value
@@ -93,8 +90,6 @@ class ParserContext
         $this->variables[$variable] = $value;
     }
 
-    //Parser to stash after parsing completed
-
     /**
      * @return array<string|SpanNode>
      */
@@ -103,7 +98,6 @@ class ParserContext
         return $this->variables;
     }
 
-    //Parser
     public function setLink(string $name, string $url): void
     {
         $name = strtolower(trim($name));
@@ -115,19 +109,15 @@ class ParserContext
         $this->links[$name] = trim($url);
     }
 
-    //Parser (span)
     public function resetAnonymousStack(): void
     {
         $this->anonymous = [];
     }
 
-    //Parser (span)
     public function pushAnonymous(string $name): void
     {
         $this->anonymous[] = strtolower(trim($name));
     }
-
-    //Parser to stash after parsing completed
 
     /**
      * @return string[]
@@ -137,19 +127,16 @@ class ParserContext
         return $this->links;
     }
 
-    //Parser (assets) & renderer
     private function relativeUrl(?string $url): string
     {
         return $this->urlGenerator->relativeUrl($url);
     }
 
-    //Parser, Toc
     public function absoluteRelativePath(string $url): string
     {
         return $this->currentDirectory . '/' . $this->getDirName() . '/' . $this->relativeUrl($url);
     }
 
-    //Toc
     public function getDirName(): string
     {
         $dirname = dirname($this->currentFileName);
@@ -161,37 +148,31 @@ class ParserContext
         return $dirname;
     }
 
-    //Parser
     public function getCurrentFileName(): string
     {
         return $this->currentFileName;
     }
 
-    //Parser, Renderer
     public function getOrigin(): FilesystemInterface
     {
         return $this->origin;
     }
 
-    //Parser
     public function getCurrentDirectory(): string
     {
         return $this->currentDirectory;
     }
 
-    //Parser, (metas)
     public function getDestinationPath(): string
     {
         return $this->destinationPath;
     }
 
-    //Parser, Renderer
     public function getUrl(): string
     {
         return $this->currentFileName;
     }
 
-    //Parser
     public function getLevel(string $letter): int
     {
         foreach ($this->titleLetters as $level => $titleLetter) {
@@ -211,8 +192,6 @@ class ParserContext
         $this->errors[] = $message;
     }
 
-    //Parser, Renderer
-
     /**
      * Register the current file's absolute path on the Origin file system.
      *
@@ -223,8 +202,6 @@ class ParserContext
     {
         $this->currentAbsolutePath = $path;
     }
-
-    //Parser, Renderer
 
     /**
      * Return the current file's absolute path on the Origin file system.
@@ -240,6 +217,7 @@ class ParserContext
         return $this->currentAbsolutePath;
     }
 
+    /** @return string[] */
     public function getErrors(): array
     {
         return $this->errors;

--- a/incubator/guides/src/ReferenceBuilder.php
+++ b/incubator/guides/src/ReferenceBuilder.php
@@ -72,7 +72,7 @@ class ReferenceBuilder
     }
 
     public function resolve(
-        Environment $environment,
+        RenderContext $environment,
         string $role,
         string $data,
         ?Entry $metaEntry = null

--- a/incubator/guides/src/ReferenceBuilder.php
+++ b/incubator/guides/src/ReferenceBuilder.php
@@ -156,7 +156,7 @@ class ReferenceBuilder
      *
      * @return string[]|null
      */
-    public function found(Environment $environment, string $section, array $data): ?array
+    public function found(string $currentFileName, string $section, array $data): ?array
     {
         $role = $section;
         if ($data['domain'] ?? '') {
@@ -171,7 +171,7 @@ class ReferenceBuilder
             return null;
         }
 
-        $this->addMissingReferenceSectionError($environment->getCurrentFileName(), $role);
+        $this->addMissingReferenceSectionError($currentFileName, $role);
 
         return null;
     }

--- a/incubator/guides/src/References/Doc.php
+++ b/incubator/guides/src/References/Doc.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\References;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\ReferenceBuilder;
+use phpDocumentor\Guides\RenderContext;
 
 /**
  * @link https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html
@@ -48,7 +48,7 @@ class Doc extends Reference
         return $this->name;
     }
 
-    public function resolve(Environment $environment, string $data): ?ResolvedReference
+    public function resolve(RenderContext $environment, string $data): ?ResolvedReference
     {
         return $this->resolver->resolve($environment, $data);
     }

--- a/incubator/guides/src/References/Php/ClassReference.php
+++ b/incubator/guides/src/References/Php/ClassReference.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\References\Php;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\References\ResolvedReference;
+use phpDocumentor\Guides\RenderContext;
 
 use function sprintf;
 use function str_replace;
@@ -30,7 +30,7 @@ final class ClassReference extends Reference
         return 'class';
     }
 
-    public function resolve(Environment $environment, string $data): ResolvedReference
+    public function resolve(RenderContext $environment, string $data): ResolvedReference
     {
         // TODO: The location of the resolved class should come from the TOC and not like this
         $classPath = sprintf('%s/classes/%s.html', '', str_replace('\\', '-', $data));

--- a/incubator/guides/src/References/Php/FunctionReference.php
+++ b/incubator/guides/src/References/Php/FunctionReference.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\References\Php;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\References\ResolvedReference;
+use phpDocumentor\Guides\RenderContext;
 use RuntimeException;
 
 /**
@@ -27,7 +27,7 @@ final class FunctionReference extends Reference
         return 'func';
     }
 
-    public function resolve(Environment $environment, string $data): ResolvedReference
+    public function resolve(RenderContext $environment, string $data): ResolvedReference
     {
         throw new RuntimeException(
             'Not supported until Guides can read the API Documentation TOC because '

--- a/incubator/guides/src/References/Php/MethodReference.php
+++ b/incubator/guides/src/References/Php/MethodReference.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\References\Php;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\References\ResolvedReference;
+use phpDocumentor\Guides\RenderContext;
 use RuntimeException;
 
 use function explode;
@@ -32,7 +32,7 @@ final class MethodReference extends Reference
         return 'meth';
     }
 
-    public function resolve(Environment $environment, string $data): ResolvedReference
+    public function resolve(RenderContext $environment, string $data): ResolvedReference
     {
         // TODO: The location of the resolved method or class should come from the TOC and not like this
 

--- a/incubator/guides/src/References/Php/NamespaceReference.php
+++ b/incubator/guides/src/References/Php/NamespaceReference.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\References\Php;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\References\ResolvedReference;
+use phpDocumentor\Guides\RenderContext;
 
 use function sprintf;
 use function str_replace;
@@ -32,7 +32,7 @@ final class NamespaceReference extends Reference
         return 'namespace';
     }
 
-    public function resolve(Environment $environment, string $data): ResolvedReference
+    public function resolve(RenderContext $environment, string $data): ResolvedReference
     {
         // TODO: The location of the resolved namespace should come from the TOC and not like this
         $className = str_replace('\\\\', '\\', $data);

--- a/incubator/guides/src/References/Reference.php
+++ b/incubator/guides/src/References/Reference.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\References;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\ReferenceBuilder;
+use phpDocumentor\Guides\RenderContext;
 
 /**
  * A reference is something that can be resolved in the document, for instance:
@@ -56,10 +56,10 @@ abstract class Reference
     /**
      * Resolve the reference and returns an array
      *
-     * @param Environment $environment the Environment in use
+     * @param RenderContext $environment the Environment in use
      * @param string $data the data of the reference
      */
-    abstract public function resolve(Environment $environment, string $data): ?ResolvedReference;
+    abstract public function resolve(RenderContext $environment, string $data): ?ResolvedReference;
 
     /**
      * Called when a reference is just found

--- a/incubator/guides/src/References/Resolver.php
+++ b/incubator/guides/src/References/Resolver.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\References;
 
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Meta\Entry;
+use phpDocumentor\Guides\RenderContext;
 
 class Resolver
 {
@@ -22,7 +22,7 @@ class Resolver
      * @param string[] $attributes
      */
     public function resolve(
-        Environment $environment,
+        RenderContext $environment,
         string $data,
         array $attributes = []
     ): ?ResolvedReference {
@@ -45,7 +45,7 @@ class Resolver
      * @param string[] $attributes
      */
     private function resolveFileReference(
-        Environment $environment,
+        RenderContext $environment,
         string $url,
         array $attributes = []
     ): ?ResolvedReference {
@@ -67,7 +67,7 @@ class Resolver
      * @param string[] $attributes
      */
     private function resolveAnchorReference(
-        Environment $environment,
+        RenderContext $environment,
         string $data,
         array $attributes = []
     ): ?ResolvedReference {
@@ -85,7 +85,7 @@ class Resolver
      */
     private function createResolvedReference(
         ?string $file,
-        Environment $environment,
+        RenderContext $environment,
         Entry $entry,
         array $attributes = [],
         ?string $anchor = null

--- a/incubator/guides/src/References/Resolver.php
+++ b/incubator/guides/src/References/Resolver.php
@@ -46,11 +46,11 @@ class Resolver
      */
     private function resolveFileReference(
         Environment $environment,
-        string $data,
+        string $url,
         array $attributes = []
     ): ?ResolvedReference {
         $entry = null;
-        $file = $environment->canonicalUrl($data);
+        $file = $environment->canonicalUrl($url);
 
         if ($file !== null) {
             $entry = $environment->getMetas()->get($file);

--- a/incubator/guides/src/RenderContext.php
+++ b/incubator/guides/src/RenderContext.php
@@ -21,7 +21,7 @@ use function dirname;
 use function strtolower;
 use function trim;
 
-class Environment
+class RenderContext
 {
     /** @var UrlGenerator */
     private $urlGenerator;

--- a/incubator/guides/src/Renderer.php
+++ b/incubator/guides/src/Renderer.php
@@ -27,6 +27,7 @@ use phpDocumentor\Transformer\Writer\Graph\PlantumlRenderer;
 use phpDocumentor\Transformer\Writer\Twig\EnvironmentFactory;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Twig\Environment;
 use Webmozart\Assert\Assert;
 
 use function count;
@@ -37,7 +38,7 @@ class Renderer implements FullDocumentNodeRenderer
     /** @var EnvironmentFactory */
     private $twigFactory;
 
-    /** @var \Twig\Environment|null */
+    /** @var Environment|null */
     private $twig;
 
     /** @var LoggerInterface */
@@ -120,7 +121,7 @@ class Renderer implements FullDocumentNodeRenderer
         $this->outputRenderer->setDestination($destination);
     }
 
-    public function renderDocument(DocumentNode $node, Environment $environment): string
+    public function renderDocument(DocumentNode $node, RenderContext $environment): string
     {
         return $this->outputRenderer->renderDocument($node, $environment);
     }
@@ -130,7 +131,7 @@ class Renderer implements FullDocumentNodeRenderer
      *   extension; and this extension would actually be nice to re-use in the rest of phpDocumentor as well. First,
      *   make it work here; then adapt for the rest :)
      */
-    public function setGuidesEnvironment(Environment $environment): void
+    public function setGuidesEnvironment(RenderContext $environment): void
     {
         $this->twig->addGlobal('env', $environment);
     }

--- a/incubator/guides/src/Renderer/OutputFormatRenderer.php
+++ b/incubator/guides/src/Renderer/OutputFormatRenderer.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\Renderer;
 
 use InvalidArgumentException;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\NodeRenderers\FullDocumentNodeRenderer;
 use phpDocumentor\Guides\NodeRenderers\NodeRendererFactory;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 
 class OutputFormatRenderer
 {
@@ -58,12 +58,12 @@ class OutputFormatRenderer
         $this->templateRenderer->setDestination($destination);
     }
 
-    public function render(Node $node, Environment $environment): string
+    public function render(Node $node, RenderContext $environment): string
     {
         return $this->nodeRendererFactory->get($node)->render($node, $environment);
     }
 
-    public function renderDocument(DocumentNode $node, Environment $environment): string
+    public function renderDocument(DocumentNode $node, RenderContext $environment): string
     {
         $renderer = $this->nodeRendererFactory->get($node);
         if ($renderer instanceof FullDocumentNodeRenderer === false) {

--- a/incubator/guides/src/Twig/AssetsExtension.php
+++ b/incubator/guides/src/Twig/AssetsExtension.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\Twig;
 
 use League\Flysystem\FilesystemInterface;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use phpDocumentor\Transformer\Writer\Graph\PlantumlRenderer;
 use Psr\Log\LoggerInterface;
@@ -88,7 +88,7 @@ final class AssetsExtension extends AbstractExtension
         }
 
         $environment = $context['env'] ?? null;
-        if (!$environment instanceof Environment) {
+        if (!$environment instanceof RenderContext) {
             throw new RuntimeException('Environment must be set in the twig global state to render nodes');
         }
 
@@ -100,9 +100,9 @@ final class AssetsExtension extends AbstractExtension
         return $this->plantumlRenderer->render($source);
     }
 
-    private function copyAsset(?Environment $environment, ?FilesystemInterface $destination, string $path): string
+    private function copyAsset(?RenderContext $environment, ?FilesystemInterface $destination, string $path): string
     {
-        if (!$environment instanceof Environment) {
+        if (!$environment instanceof RenderContext) {
             return $path;
         }
 

--- a/incubator/guides/tests/unit/Nodes/TitleNodeTest.php
+++ b/incubator/guides/tests/unit/Nodes/TitleNodeTest.php
@@ -15,15 +15,15 @@ namespace phpDocumentor\Guides\Nodes;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\ReferenceBuilder;
 
 final class TitleNodeTest extends MockeryTestCase
 {
     public function test_it_can_be_created_with_a_title_slug_and_depth(): void
     {
-        $environment = m::mock(Environment::class);
+        $environment = m::mock(ParserContext::class);
         $environment->shouldReceive('getTitleLetters')->andReturn(['a']);
         $environment->shouldReceive('resetAnonymousStack');
 

--- a/src/phpDocumentor/Guides/Handlers/RenderHandler.php
+++ b/src/phpDocumentor/Guides/Handlers/RenderHandler.php
@@ -17,12 +17,12 @@ use IteratorAggregate;
 use League\Flysystem\FilesystemInterface;
 use phpDocumentor\Descriptor\DocumentDescriptor;
 use phpDocumentor\Descriptor\GuideSetDescriptor;
-use phpDocumentor\Guides\Environment;
 use phpDocumentor\Guides\Metas;
 use phpDocumentor\Guides\ReferenceBuilder;
 use phpDocumentor\Guides\References\Doc;
 use phpDocumentor\Guides\References\Reference;
 use phpDocumentor\Guides\RenderCommand;
+use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer;
 use phpDocumentor\Guides\UrlGenerator;
 use phpDocumentor\Transformer\Router\Router;
@@ -80,7 +80,7 @@ final class RenderHandler
 
     private function render(
         GuideSetDescriptor $documentationSet,
-        Environment $environment,
+        RenderContext $environment,
         FilesystemInterface $destination
     ): void {
         /** @var DocumentDescriptor $descriptor */
@@ -124,7 +124,7 @@ final class RenderHandler
     private function renderDocument(
         DocumentDescriptor $descriptor,
         string $destinationPath,
-        Environment $environment,
+        RenderContext $environment,
         GuideSetDescriptor $documentationSet
     ): string {
         $document = $descriptor->getDocumentNode();
@@ -154,8 +154,8 @@ final class RenderHandler
     private function createEnvironment(
         string $outputFolder,
         FilesystemInterface $origin
-    ): Environment {
-        $environment = new Environment(
+    ): RenderContext {
+        $environment = new RenderContext(
             $outputFolder,
             $origin,
             $this->metas,


### PR DESCRIPTION
To be able to refactor more, I spitted the rendering and parser context to be more verbose what is used when. 
This allowed me to clean up some odd parts in the code. 