### PR TITLE
Fix yaml unmarshal error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,4 +15,4 @@
   runs:
     using: 'docker'
     image: 'Dockerfile'
-    entrypoint: '/opt/phpdoc/bin/githubaction'
+    entrypoint: ["/opt/phpdoc/bin/githubaction"]


### PR DESCRIPTION
Trying to run the action as a step in a Github workflow results in this error.

```
Error: yaml: unmarshal errors:
  line 18: cannot unmarshal !!str `/opt/ph...` into []string
```

The step is defined as such:

```yml
            - name: Generate API docs
              uses: phpDocumentor/phpDocumentor@master
              with:
                args: -d src -t build/docs
```

Ran with `nektos/act` on my local machine because I have thus far been unsuccessful in getting the action to run on Github.