### PR TITLE
GH Actions: version update for various predefined actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup cache environment
         id: cache-env
@@ -54,7 +54,7 @@ jobs:
     name: Unit tests [7.4 | ubuntu-latest]
     needs: setup
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup cache environment
       id: cache-env
@@ -100,7 +100,7 @@ jobs:
     needs:
       - setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Restore/cache vendor folder
         uses: actions/cache@v2.1.7
         with:
@@ -119,7 +119,7 @@ jobs:
     needs:
       - setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup cache environment
         id: cache-env
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup cache environment
         id: cache-env
@@ -199,7 +199,7 @@ jobs:
     needs:
       - setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup cache environment
         id: cache-env
@@ -257,7 +257,7 @@ jobs:
           args: gpg --command-fd 0 --pinentry-mode loopback -u info@phpdoc.org --batch
             --detach-sign --output build/phpDocumentor.phar.asc build/phpDocumentor.phar
       - name: Upload PHAR file
-        uses: actions/upload-artifact@v2.3.1
+        uses: actions/upload-artifact@v3.0.0
         with:
           name: phpDocumentor.phar
           path: build/phpDocumentor.phar
@@ -269,7 +269,7 @@ jobs:
     needs:
       - setup
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup cache environment
         id: cache-env
@@ -345,7 +345,7 @@ jobs:
     - phpstan
     - codestyle
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup cache environment
       id: cache-env
@@ -402,7 +402,7 @@ jobs:
       - build-phar
     continue-on-error: ${{ matrix.php-versions == '8.0' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup cache environment
         id: cache-env
@@ -428,7 +428,7 @@ jobs:
           tools: pecl
 
       - name: Download PHAR file
-        uses: actions/download-artifact@v2.1.0
+        uses: actions/download-artifact@v3.0.0
         with:
           name: phpDocumentor.phar
           path: build

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'phpDocumentor/phpDocumentor'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@master


### PR DESCRIPTION
A number of predefined actions have had major release, which warrant an update to the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Note: as the `(up|down)load-artifact` actions were fixed to a specific version, I've done the same with the update.

Refs:
* https://github.com/actions/checkout/releases
* https://github.com/actions/download-artifact/releases
* https://github.com/actions/upload-artifact/releases