### PR TITLE
Add missing return type from method tags

### DIFF
--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -214,6 +214,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
             $method->setDescription($methodTag->getDescription());
             $method->setStatic($methodTag->isStatic());
             $method->setParent($this);
+            $method->setReturnType($methodTag->getResponse()->getType());
 
             $returnTags = $method->getTags()->fetch('return', new Collection())->filter(ReturnDescriptor::class);
             $returnTags->add($methodTag->getResponse());


### PR DESCRIPTION
Hi,

When a method is documented with the method tag, its return type is ignored.

Given this sample:
```php
<?php
/**
 * @method string test()
 */
class Foo
{
    public function __call() {
        return 'OK';
    }
}
```

### BEFORE

![before](https://user-images.githubusercontent.com/2891564/158803219-78909d1a-5258-4dac-9470-8511e005ed72.jpg)

### AFTER

![after](https://user-images.githubusercontent.com/2891564/158803365-03f80e57-c28e-4d8c-a306-2eaf8a8aba44.jpg)


I could add some tests if needed, but I'll need some guidance.