### PR TITLE
Missing <base> definition in header

### DIFF
--- a/data/templates/clean/layout.html.twig
+++ b/data/templates/clean/layout.html.twig
@@ -10,6 +10,7 @@
     <title>{% block title %}{{ project.name }}{% endblock %}</title>
     <meta name="author" content=""/>
     <meta name="description" content=""/>
+    <base href="../">
 
     <link href="{{ path('css/bootstrap-combined.no-icons.min.css') }}" rel="stylesheet">
     <link href="{{ path('css/font-awesome.min.css') }}" rel="stylesheet">


### PR DESCRIPTION
There is no <base> definition in the output headers in the "clean" template. I believe this will at least partially solve the class link issues. I have no way to test this so it needs to be tested.