### PR TITLE
Add Composer configuration allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,6 +95,9 @@
         "sort-packages": true,
         "platform": {
             "php": "7.4.0"
+        },
+        "allow-plugins": {
+            "symfony/flex": true
         }
     },
     "replace": {


### PR DESCRIPTION
We get the following message when we install this project with a recent version of Composer:
```sh
# composer install
symfony/flex contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "symfony/flex" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]
```

This PR marks `symfony/flex` as trusted so this question is not asked anymore.