### PR TITLE
Update function signature to show return by reference

### DIFF
--- a/data/templates/clean/elements/method.html.twig
+++ b/data/templates/clean/elements/method.html.twig
@@ -5,7 +5,7 @@
             <article class="method">
                 <h3 class="{{ method.visibility }} {% if method.deprecated %}deprecated{% endif %}">{{ method.name }}()</h3>
                 <a href="#source-view" role="button" class="pull-right btn" data-toggle="modal" style="font-size: 1.1em; padding: 9px 14px"><i class="icon-code"></i></a>
-                <pre class="signature" style="margin-right: 54px;">{{ method.name }}({% for argument in method.arguments %}{{ argument.types ? argument.types|join('|')~' ' }} <span class="argument">{{ argument.isVariadic ? '...' }}${{ argument.name }}{{ argument.default ? ' = '~argument.default }}</span>{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.types ? ': '~method.response.types|join('|') }}</pre>
+                <pre class="signature" style="margin-right: 54px;">{{ method.hasReturnByReference ? '& '~'' }}{{ method.name }}({% for argument in method.arguments %}{{ argument.types ? argument.types|join('|')~' ' }} <span class="argument">{{ argument.isVariadic ? '...' }}${{ argument.name }}{{ argument.default ? ' = '~argument.default }}</span>{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.types ? ': '~method.response.types|join('|') }}</pre>
                 <p><em>{{ method.summary }}</em></p>
                 {{ method.description|markdown|raw }}
 

--- a/data/templates/default/components/method-signature.html.twig
+++ b/data/templates/default/components/method-signature.html.twig
@@ -3,6 +3,7 @@
     {% if node.abstract %}<span class="phpdocumentor-signature__abstract">abstract</span>{% endif %}
     {% if node.final %}<span class="phpdocumentor-signature__final">final</span>{% endif %}
     {% if node.static %}<span class="phpdocumentor-signature__static">static</span>{% endif %}
+    {% if node.hasReturnByReference %}<span class="phpdocumentor-signature__reference-operator">&amp;</span>{% endif %}
     {% apply spaceless %}
     <span class="phpdocumentor-signature__name">{{ node.name }}</span>
     <span>(</span>

--- a/data/templates/responsive-twig/class.html.twig
+++ b/data/templates/responsive-twig/class.html.twig
@@ -61,7 +61,7 @@
                         <a id="method_{{ method.name }}"></a>
                         <div class="element clickable method {{ method.visibility }} {{ method.deprecated ? 'deprecated' }} method_{{ method.name }}{{ method.parent.name != node.name ? ' inherited' : '' }}" data-toggle="collapse" data-target=".method_{{ method.name }} .collapse">
                             <h2>{{ method.summary ?: method.name }}</h2>
-                            <pre>{{ method.name }}({% for argument in method.arguments %}{{ argument.type ? argument.type }}{{ argument.byReference ? '&' }}{{ argument.name }}{{ argument.default is not null ? ' = '~argument.default }}{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.type ? ': '~method.response.type }}</pre>
+                            <pre>{{ method.hasReturnByReference ? '& '~'' }}{{ method.name }}({% for argument in method.arguments %}{{ argument.type ? argument.type }}{{ argument.byReference ? '&' }}{{ argument.name }}{{ argument.default is not null ? ' = '~argument.default }}{% if not loop.last %}, {% endif %}{% endfor %}) {{ method.response.type ? ': '~method.response.type }}</pre>
                             <div class="labels">
                                 {% if method.parent.name != node.name %}<span class="label">inherited</span>{% endif %}
                                 {% if method.static %}<span class="label">static</span>{% endif %}

--- a/data/templates/xml/method.xml.twig
+++ b/data/templates/xml/method.xml.twig
@@ -1,5 +1,5 @@
 {# @var method phpDocumentor\Descriptor\MethodDescriptor #}
-<method final="{{ method.final | export }}" abstract="{{ method.abstract | export }}" static="{{ method.static | export }}" namespace="{{ method.namespace }}" line="{{ method.line }}" visibility="{{ method.visibility }}">
+<method final="{{ method.final | export }}" abstract="{{ method.abstract | export }}" static="{{ method.static | export }}" namespace="{{ method.namespace }}" line="{{ method.line }}" visibility="{{ method.visibility }}" returnByReference="{{ method.hasReturnByReference | export }}">
     <name>{{ method.name }}</name>
     <full_name>{{ method.fullyQualifiedStructuralElementName }}</full_name>
     <value>{{ method.value }}</value>

--- a/data/templates/xml/structure.xml.twig
+++ b/data/templates/xml/structure.xml.twig
@@ -22,7 +22,7 @@
 
             {# @var function \phpDocumentor\Descriptor\FunctionDescriptor #}
             {% for function in file.functions %}
-                <function namespace="{{ function.namespace }}" line="{{ function.line }}" package="{{ function.package }}">
+                <function namespace="{{ function.namespace }}" line="{{ function.line }}" package="{{ function.package }}" returnByReference="{{ function.hasReturnByReference | export }}">
                     <name>{{ function.name }}</name>
                     <full_name>{{ function.fullyQualifiedStructuralElementName }}</full_name>
                     {{ include('docblock.xml.twig', {descriptor: function}) }}

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssembler.php
@@ -86,6 +86,7 @@ class FunctionAssembler extends AssemblerAbstract
             -strlen($reflector->getName()) - 2
         ), '\\'));
         $descriptor->setReturnType($reflector->getReturnType());
+        $descriptor->setHasReturnByReference($reflector->getHasReturnByReference());
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
@@ -83,6 +83,7 @@ class MethodAssembler extends AssemblerAbstract
         $descriptor->setStatic($reflector->isStatic());
         $descriptor->setLine($reflector->getLocation()->getLineNumber());
         $descriptor->setReturnType($reflector->getReturnType());
+        $descriptor->setHasReturnByReference($reflector->getHasReturnByReference());
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/FunctionDescriptor.php
+++ b/src/phpDocumentor/Descriptor/FunctionDescriptor.php
@@ -32,6 +32,9 @@ class FunctionDescriptor extends DescriptorAbstract implements Interfaces\Functi
     /** @var Type */
     private $returnType;
 
+    /** @var bool */
+    private $hasReturnByReference = false;
+
     /**
      * Initializes the all properties representing a collection with a new Collection object.
      */
@@ -73,5 +76,15 @@ class FunctionDescriptor extends DescriptorAbstract implements Interfaces\Functi
     public function setReturnType(Type $returnType): void
     {
         $this->returnType = $returnType;
+    }
+
+    public function setHasReturnByReference(bool $hasReturnByReference): void
+    {
+        $this->hasReturnByReference = $hasReturnByReference;
+    }
+
+    public function getHasReturnByReference(): bool
+    {
+        return $this->hasReturnByReference;
     }
 }

--- a/src/phpDocumentor/Descriptor/MethodDescriptor.php
+++ b/src/phpDocumentor/Descriptor/MethodDescriptor.php
@@ -50,6 +50,9 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
     /** @var Type */
     private $returnType;
 
+    /** @var bool */
+    private $hasReturnByReference = false;
+
     /**
      * Initializes the all properties representing a collection with a new Collection object.
      */
@@ -281,5 +284,15 @@ class MethodDescriptor extends DescriptorAbstract implements Interfaces\MethodIn
     public function setReturnType(Type $returnType): void
     {
         $this->returnType = $returnType;
+    }
+
+    public function setHasReturnByReference(bool $hasReturnByReference): void
+    {
+        $this->hasReturnByReference = $hasReturnByReference;
+    }
+
+    public function getHasReturnByReference(): bool
+    {
+        return $this->hasReturnByReference;
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/FunctionAssemblerTest.php
@@ -86,7 +86,8 @@ class FunctionAssemblerTest extends TestCase
             $namespace,
             $functionName,
             $argument,
-            $this->givenADocBlockObject()
+            $this->givenADocBlockObject(),
+            true
         );
         $argumentDescriptor = new ArgumentDescriptor();
         $argumentDescriptor->setName($argumentName);
@@ -107,6 +108,7 @@ class FunctionAssemblerTest extends TestCase
 
         $argument = $descriptor->getArguments()->get($argumentName);
         $this->assertSame($argumentDescriptor, $argument);
+        $this->assertTrue($descriptor->getHasReturnByReference());
     }
 
     /**
@@ -116,11 +118,16 @@ class FunctionAssemblerTest extends TestCase
         string $namespace,
         string $functionName,
         Argument $argumentMock,
-        DocBlock $docBlockMock
+        DocBlock $docBlockMock,
+        bool $hasReturnByReference = false
     ): Function_ {
         $functionReflectorMock = new Function_(
             new Fqsen('\\' . $namespace . '\\' . $functionName . '()'),
-            $docBlockMock
+            $docBlockMock,
+            null,
+            null,
+            null,
+            $hasReturnByReference
         );
 
         $functionReflectorMock->addArgument($argumentMock);


### PR DESCRIPTION
Fixes #3186

The signature for functions returning a reference now looks like this:
![returning-reference-fixed](https://user-images.githubusercontent.com/2891564/159941914-30c38085-fdb9-4991-a5c3-62b089bfd951.jpg)

