### PR TITLE
[Guides/Rst] Fix definition list classifier seperator

### DIFF
--- a/incubator/guides-restructured-text/src/RestructuredText/Parser/LineDataParser.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Parser/LineDataParser.php
@@ -162,7 +162,7 @@ class LineDataParser
                     );
                 }
 
-                $parts = explode(':', trim($line));
+                $parts = explode(' : ', trim($line));
 
                 $term = $parts[0];
                 unset($parts[0]);


### PR DESCRIPTION
The separator is " : ", and not only a colon. See also https://github.com/doctrine/rst-parser/pull/154