### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,7 +1,12 @@
 on: [issues]
 name: Issue Triage
+permissions:
+  contents: read
+
 jobs:
   add-new-issues-to-project-column:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: add-new-issues-to-organization-based-project-column

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -263,6 +263,9 @@ jobs:
           path: build/phpDocumentor.phar
 
   e2e:
+    permissions:
+      actions: read  # for cypress-io/github-action to correctly identify workflow run
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     name: E2E tests [ubuntu-latest]
     if: github.repository == 'phpDocumentor/phpDocumentor'
@@ -384,6 +387,9 @@ jobs:
       run: php tools/phpunit --testsuite=unit,integration
 
   e2e-matrix:
+    permissions:
+      actions: read  # for cypress-io/github-action to correctly identify workflow run
+      contents: read  # for actions/checkout to fetch code
     runs-on: ${{ matrix.operating-system }}
     if: github.repository == 'phpDocumentor/phpDocumentor'
     strategy:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
