### PR TITLE
Bump flex to ^1.17, 1.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "symfony/expression-language": "^5.0",
         "symfony/filesystem": "^5.0",
         "symfony/finder": "5.4.*",
-        "symfony/flex": "^1.3.1",
+        "symfony/flex": "^1.17",
         "symfony/framework-bundle": "^5.0",
         "symfony/http-foundation": "^5.0.7",
         "symfony/http-kernel": "^5.0.8",


### PR DESCRIPTION
https://symfony.com/blog/the-old-flex-infrastructure-is-shutting-down