### PR TITLE
fix: ensure uses/see/link descriptors render to string as expected

### DIFF
--- a/src/phpDocumentor/Descriptor/Tag/LinkDescriptor.php
+++ b/src/phpDocumentor/Descriptor/Tag/LinkDescriptor.php
@@ -41,4 +41,9 @@ class LinkDescriptor extends TagDescriptor
     {
         return $this->link;
     }
+
+    public function __toString(): string
+    {
+        return (string) $this->link;
+    }
 }

--- a/src/phpDocumentor/Descriptor/Tag/SeeDescriptor.php
+++ b/src/phpDocumentor/Descriptor/Tag/SeeDescriptor.php
@@ -34,4 +34,9 @@ class SeeDescriptor extends TagDescriptor
     {
         return $this->reference;
     }
+
+    public function __toString(): string
+    {
+        return (string) $this->reference;
+    }
 }

--- a/src/phpDocumentor/Descriptor/Tag/UsesDescriptor.php
+++ b/src/phpDocumentor/Descriptor/Tag/UsesDescriptor.php
@@ -47,4 +47,9 @@ final class UsesDescriptor extends TagDescriptor
     {
         $this->reference = $reference;
     }
+
+    public function __toString(): string
+    {
+        return (string) $this->reference;
+    }
 }


### PR DESCRIPTION
fixes #3243 

When these descriptors are rendered as part of a `description` in the templates, they are empty