### PR TITLE
Support Location attribute on templates

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -163,7 +163,7 @@ jobs:
           composer-options: --optimize-autoloader
 
       - name: PHPStan
-        uses: phpDocumentor/phpstan-ga@master
+        uses: phpDocumentor/phpstan-ga@1.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ phpcbf:
 
 .PHONY: phpstan
 phpstan:
-	docker run -it --rm -v${CURDIR}:/opt/project -w /opt/project phpdoc/phpstan-ga:latest analyse src tests incubator/*/src incubator/*/tests --configuration phpstan.neon ${ARGS}
+	docker run -it --rm -v${CURDIR}:/opt/project -w /opt/project phpdoc/phpstan-ga:1.8 analyse src tests incubator/*/src incubator/*/tests --configuration phpstan.neon ${ARGS}
 
 .PHONY: psalm
 psalm:

--- a/config/stages.yaml
+++ b/config/stages.yaml
@@ -4,6 +4,8 @@ services:
     autoconfigure: true
 
   phpDocumentor\Pipeline\Stage\Configure:
+    arguments:
+      $currentWorkingDir: "@=service('kernel').getWorkingDir()"
     tags:
       - { name: 'phpdoc.pipeline.application.configuration', priority: 10000 }
 

--- a/docs/references/full-config-reference.rst
+++ b/docs/references/full-config-reference.rst
@@ -334,6 +334,16 @@ name
 location
 ~~~~~~~~
 
+[optional] The path where the template can be found. Unless your project uses a custom template in a specific folder,
+this attribute should not be provided. When provided, phpDocumentor will load your template from that folder.
+
+When a relative folder is provided, phpDocumentor will attempt to find that relative to the location of your
+configuration file. An absolute path is also allowed for when you have multiple projects that should use the same
+template.
+
+For example: When the location ``my/phpdoc/templates`` is provided and ``myTemplate`` as name, phpDocumentor will
+attempt to load the template configuration at ``[configPath]/my/phpdoc/templates/myTemplate/template.xml``.
+
 parameters
 ~~~~~~~~~~
 

--- a/incubator/guides-markdown/src/Markdown/MarkupLanguageParser.php
+++ b/incubator/guides-markdown/src/Markdown/MarkupLanguageParser.php
@@ -96,7 +96,7 @@ final class MarkupLanguageParser implements ParserInterface
                 continue;
             }
 
-            if (!$event->isEntering() && $node instanceof Document) {
+            if ($node instanceof Document) {
                 return $document;
             }
 

--- a/incubator/guides/src/Meta/Entry.php
+++ b/incubator/guides/src/Meta/Entry.php
@@ -49,9 +49,6 @@ final class Entry
     /** @var string[] */
     private $resolvedDependencies = [];
 
-    /** @var string[] */
-    private $links;
-
     /** @var string|null */
     private $parent;
 

--- a/incubator/guides/src/Nodes/DocumentNode.php
+++ b/incubator/guides/src/Nodes/DocumentNode.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\Nodes;
 
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
-
 use Webmozart\Assert\Assert;
+
 use function array_filter;
 use function array_map;
 use function array_merge;
@@ -139,7 +139,7 @@ final class DocumentNode extends Node
         $nodes = $this->getNodes(static function ($node): bool {
             return $node instanceof DocumentNode;
         });
-        Assert::allIsInstanceOf($nodes, DocumentNode::class);
+        Assert::allIsInstanceOf($nodes, self::class);
 
         $subDocumentTitles = array_map(
             static function (DocumentNode $node): array {

--- a/incubator/guides/src/Nodes/DocumentNode.php
+++ b/incubator/guides/src/Nodes/DocumentNode.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Guides\Nodes;
 
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 
+use Webmozart\Assert\Assert;
 use function array_filter;
 use function array_map;
 use function array_merge;
@@ -135,13 +136,16 @@ final class DocumentNode extends Node
             $levels[$level] = &$parent[count($parent) - 1][1];
         }
 
+        $nodes = $this->getNodes(static function ($node): bool {
+            return $node instanceof DocumentNode;
+        });
+        Assert::allIsInstanceOf($nodes, DocumentNode::class);
+
         $subDocumentTitles = array_map(
-            static function (DocumentNode $node) {
+            static function (DocumentNode $node): array {
                 return $node->getTitles();
             },
-            $this->getNodes(static function ($node) {
-                return $node instanceof DocumentNode;
-            })
+            $nodes
         );
 
         return array_merge($titles, ...$subDocumentTitles);

--- a/incubator/guides/src/ParserContext.php
+++ b/incubator/guides/src/ParserContext.php
@@ -38,9 +38,6 @@ class ParserContext
     private $currentDirectory;
 
     /** @var string[] */
-    private $variables = [];
-
-    /** @var string[] */
     private $links = [];
 
     /** @var string[] */
@@ -48,9 +45,6 @@ class ParserContext
 
     /** @var string[] */
     private $errors = [];
-
-    /** @var string */
-    private $currentAbsolutePath = '';
 
     public function __construct(
         string $currentFileName,

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -42,5 +42,5 @@
         </guide>
     </version>
     <setting name="guides.enabled" value="true"/>
-    <template name="default"/>
+    <template name="default" />
 </phpdocumentor>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,6 +22,7 @@ parameters:
 
     # Bad design of descriptors.
     - '#Access to an undefined property phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\DescriptorAbstract>>::\$[a-z]+#'
+
     # https://github.com/phpDocumentor/phpDocumentor/issues/2279
     - '#Instanceof between phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\InterfaceDescriptor\|phpDocumentor\\Reflection\\Fqsen>\|phpDocumentor\\Reflection\\Fqsen\|string\|null and phpDocumentor\\Descriptor\\InterfaceDescriptor will always evaluate to false\.#'
 
@@ -36,9 +37,6 @@ parameters:
 
     # Design improvement of configuration needed
     - '#Parameter \#1 \$templates of method phpDocumentor\\Transformer\\Template\\Factory::getTemplates\(\) expects array<int, array\(.*\)>, array<int, string> given\.#'
-
-    # Advanced transformations of array. PHPStan doesn't seem to keep nonEmpty flag through some array functions
-    - '#Method phpDocumentor\\Configuration\\Definition\\Version2::upgrade\(\) should return.+#'
 
     -
             message: "#^Parameter \\#1 \\$value of method phpDocumentor\\\\GraphViz\\\\Graph\\:\\:setCenter\\(\\) expects bool, string given\\.$#"
@@ -64,6 +62,7 @@ parameters:
             message: "#^Parameter \\#1 \\$value of method phpDocumentor\\\\GraphViz\\\\Graph\\:\\:setFontSize\\(\\) expects float, string given\\.$#"
             count: 1
             path: src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
+
   excludes_analyse:
    #test data
     - %currentWorkingDirectory%/tests/features/**/*.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,6 +32,10 @@ parameters:
     # PHPStan doesn't support inheritance of TDescriptor
     - '#Parameter \#2 \$assembler of method phpDocumentor\\Descriptor\\Builder\\AssemblerFactory::(register|registerFallback)\(\) expects phpDocumentor\\Descriptor\\Builder\\AssemblerInterface.* given\.#'
 
+    # PHPStan doesn't support inheritance of a generic in a generic
+    - '/Parameter \#2 \$item of method phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\DescriptorAbstract>>::set\(\)/'
+    - '/Parameter \#1 \$collection of method phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\DescriptorAbstract>::merge\(\)/'
+
     -
             message: "#^Parameter \\#1 \\$value of method phpDocumentor\\\\GraphViz\\\\Graph\\:\\:setCenter\\(\\) expects bool, string given\\.$#"
             count: 1
@@ -57,7 +61,7 @@ parameters:
             count: 1
             path: src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
 
-  excludes_analyse:
+  excludePaths:
    #test data
     - %currentWorkingDirectory%/tests/features/**/*.php
     - %currentWorkingDirectory%/tests/data/*.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,17 +26,11 @@ parameters:
     # https://github.com/phpDocumentor/phpDocumentor/issues/2279
     - '#Instanceof between phpDocumentor\\Descriptor\\Collection<phpDocumentor\\Descriptor\\InterfaceDescriptor\|phpDocumentor\\Reflection\\Fqsen>\|phpDocumentor\\Reflection\\Fqsen\|string\|null and phpDocumentor\\Descriptor\\InterfaceDescriptor will always evaluate to false\.#'
 
-    # phpstan/phpstan/issues/3951
-    - '#Method phpDocumentor\\Descriptor\\ProjectDescriptorBuilder::filterDescriptor\(\) should return TDescriptor of phpDocumentor\\Descriptor\\Descriptor\|null but returns phpDocumentor\\Descriptor\\Filter\\Filterable\|null\.#'
-
     # PHPStan has issue when involving templates and parent types
     - '#Parameter \#1 \$matcher of method phpDocumentor\\Descriptor\\Builder\\AssemblerFactory::(register|registerFallback)\(\) expects phpDocumentor\\Descriptor\\Builder\\Matcher<object>, phpDocumentor\\Descriptor\\Builder\\Matcher<.+> given\.#'
 
     # PHPStan doesn't support inheritance of TDescriptor
     - '#Parameter \#2 \$assembler of method phpDocumentor\\Descriptor\\Builder\\AssemblerFactory::(register|registerFallback)\(\) expects phpDocumentor\\Descriptor\\Builder\\AssemblerInterface.* given\.#'
-
-    # Design improvement of configuration needed
-    - '#Parameter \#1 \$templates of method phpDocumentor\\Transformer\\Template\\Factory::getTemplates\(\) expects array<int, array\(.*\)>, array<int, string> given\.#'
 
     -
             message: "#^Parameter \\#1 \\$value of method phpDocumentor\\\\GraphViz\\\\Graph\\:\\:setCenter\\(\\) expects bool, string given\\.$#"

--- a/src/phpDocumentor/Configuration/ApiSpecification.php
+++ b/src/phpDocumentor/Configuration/ApiSpecification.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Configuration;
 
 use ArrayAccess;
+use phpDocumentor\Configuration\Definition\Version3;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
 use RuntimeException;
@@ -12,6 +13,7 @@ use RuntimeException;
 use function sprintf;
 
 /**
+ * @psalm-import-type ConfigurationApiMap from Version3
  * @implements ArrayAccess<String, mixed>
  */
 final class ApiSpecification implements ArrayAccess
@@ -33,7 +35,12 @@ final class ApiSpecification implements ArrayAccess
     /** @var string */
     private $output;
 
-    /** @var array{paths: array<Path>} */
+    /** @var array{
+     *      hidden: bool,
+     *      symlinks: bool,
+     *      paths: list<string>
+     *  }
+     */
     private $ignore;
 
     /** @var non-empty-list<string> */
@@ -64,7 +71,7 @@ final class ApiSpecification implements ArrayAccess
     private $validate;
 
     /**
-     * @param array{paths: array<Path>} $ignore
+     * @param array{hidden: bool, symlinks: bool, paths: list<string>} $ignore
      * @param non-empty-list<string> $extensions
      * @param array<string> $visibility
      * @param array<string> $markers
@@ -98,11 +105,9 @@ final class ApiSpecification implements ArrayAccess
         $this->validate = $validate;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{ignore-tags: array<string>, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibility: non-empty-array<string>, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}, encoding: string, output: string, default-package-name: string, examples: array{dsn: string, paths: array}, include-source: bool, validate: bool} $api
+     * @param ConfigurationApiMap $api
      */
-    //phpcs:enable Generic.Files.LineLength.TooLong
     public static function createFromArray(array $api): self
     {
         return new self(
@@ -132,6 +137,8 @@ final class ApiSpecification implements ArrayAccess
             ),
             './api',
             [
+                'hidden' => true,
+                'symlinks' => true,
                 'paths' => [],
             ],
             ['php'],
@@ -155,7 +162,7 @@ final class ApiSpecification implements ArrayAccess
     }
 
     /**
-     * @param array{paths: non-empty-array<Path>} $ignore
+     * @param array{hidden: bool, symlinks: bool, paths: list<string>} $ignore
      */
     public function setIgnore(array $ignore): void
     {

--- a/src/phpDocumentor/Configuration/ApiSpecification.php
+++ b/src/phpDocumentor/Configuration/ApiSpecification.php
@@ -9,8 +9,9 @@ use phpDocumentor\Configuration\Definition\Version3;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
 use RuntimeException;
-
 use Webmozart\Assert\Assert;
+
+use function array_map;
 use function sprintf;
 
 /**
@@ -130,7 +131,7 @@ final class ApiSpecification implements ArrayAccess
             isset($api['examples'])
                 ? new Source(
                     Dsn::createFromString($api['examples']['dsn']),
-                    array_map(static fn(string $path) => new Path($path), $api['examples']['paths'])
+                    array_map(static fn (string $path) => new Path($path), $api['examples']['paths'])
                 )
                 : null,
             $api['encoding'],

--- a/src/phpDocumentor/Configuration/Configuration.php
+++ b/src/phpDocumentor/Configuration/Configuration.php
@@ -18,6 +18,7 @@ use phpDocumentor\Dsn;
 use phpDocumentor\Path;
 
 /**
+ * @template-extends ArrayObject<string, mixed>&ConfigurationMap
  * @psalm-type ConfigurationMap = array{
  *     phpdocumentor: array{
  *         configVersion: string,
@@ -35,8 +36,6 @@ use phpDocumentor\Path;
  *         >
  *     }
  * }
- *
- * @template-extends ArrayObject<string, mixed>&ConfigurationMap
  */
 final class Configuration extends ArrayObject
 {

--- a/src/phpDocumentor/Configuration/Configuration.php
+++ b/src/phpDocumentor/Configuration/Configuration.php
@@ -14,9 +14,29 @@ declare(strict_types=1);
 namespace phpDocumentor\Configuration;
 
 use ArrayObject;
+use phpDocumentor\Dsn;
+use phpDocumentor\Path;
 
 /**
- * @template-extends ArrayObject<string, mixed>
+ * @psalm-type ConfigurationMap = array{
+ *     phpdocumentor: array{
+ *         configVersion: string,
+ *         title?: string,
+ *         paths: array{output: Dsn, cache: Path},
+ *         versions: array<string, VersionSpecification>,
+ *         use-cache: bool,
+ *         settings: array<string, mixed>,
+ *         templates: non-empty-array<
+ *             array{
+ *                 name: string,
+ *                 location: ?Path,
+ *                 parameters: array<string, mixed>
+ *             }
+ *         >
+ *     }
+ * }
+ *
+ * @template-extends ArrayObject<string, mixed>&ConfigurationMap
  */
 final class Configuration extends ArrayObject
 {

--- a/src/phpDocumentor/Configuration/ConfigurationFactory.php
+++ b/src/phpDocumentor/Configuration/ConfigurationFactory.php
@@ -24,6 +24,7 @@ use function sprintf;
 
 /**
  * The ConfigurationFactory converts the configuration xml from a Uri into an array.
+ * @psalm-import-type ConfigurationMap from SymfonyConfigFactory
  */
 /*final*/ class ConfigurationFactory
 {
@@ -118,11 +119,9 @@ use function sprintf;
         return $configuration;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, array{ api: array{ignore-tags: array<string>, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibility: non-empty-array<string>, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}, encoding: string, output: string, default-package-name: string, examples: array{dsn: Dsn, paths: array}, include-source: bool, validate: bool}, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param ConfigurationMap $configuration
      */
-    //phpcs:enable Generic.Files.LineLength.TooLong
     private function createConfigurationFromArray(array $configuration): Configuration
     {
         if (isset($configuration['phpdocumentor']['versions'])) {

--- a/src/phpDocumentor/Configuration/ConfigurationFactory.php
+++ b/src/phpDocumentor/Configuration/ConfigurationFactory.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Configuration;
 
 use League\Uri\Contracts\UriInterface;
+use phpDocumentor\Configuration\Definition\Version3;
 use phpDocumentor\Configuration\Exception\InvalidConfigPathException;
-use phpDocumentor\Dsn;
 use phpDocumentor\UriFactory;
 
 use function array_map;
@@ -24,7 +24,11 @@ use function sprintf;
 
 /**
  * The ConfigurationFactory converts the configuration xml from a Uri into an array.
- * @psalm-import-type ConfigurationMap from SymfonyConfigFactory
+ *
+ * @psalm-import-type ConfigurationMap from Version3 as Version3ConfigurationMap
+ * @psalm-type ConfigurationMap = array{
+ *     phpdocumentor: Version3ConfigurationMap
+ * }
  */
 /*final*/ class ConfigurationFactory
 {

--- a/src/phpDocumentor/Configuration/Definition/Normalizable.php
+++ b/src/phpDocumentor/Configuration/Definition/Normalizable.php
@@ -8,6 +8,7 @@ interface Normalizable
 {
     /**
      * @param array<mixed> $configuration
+     *
      * @return array<mixed>
      */
     public function normalize(array $configuration): array;

--- a/src/phpDocumentor/Configuration/Definition/Normalizable.php
+++ b/src/phpDocumentor/Configuration/Definition/Normalizable.php
@@ -7,14 +7,15 @@ namespace phpDocumentor\Configuration\Definition;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
 
+/**
+ * @template TBaseConfiguration of array
+ * @template TNormalizedConfiguration of array
+ */
 interface Normalizable
 {
-    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, mixed>, settings?: array<mixed>, templates?: non-empty-list<string>} $configuration
-     *
-     * @return array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, array{api: array<int, array{ignore-tags: array, extensions: non-empty-array<string>, markers: non-empty-array<string>, visibillity: string, source: array{dsn: Dsn, paths: array}, ignore: array{paths: array}}>, guides: array}>, settings?: array<mixed>, templates?: non-empty-list<string>}
+     * @param TBaseConfiguration $configuration
+     * @return TNormalizedConfiguration
      */
-    //phpcs:enable Generic.Files.LineLength.TooLong
     public function normalize(array $configuration): array;
 }

--- a/src/phpDocumentor/Configuration/Definition/Normalizable.php
+++ b/src/phpDocumentor/Configuration/Definition/Normalizable.php
@@ -4,18 +4,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration\Definition;
 
-use phpDocumentor\Dsn;
-use phpDocumentor\Path;
-
-/**
- * @template TBaseConfiguration of array
- * @template TNormalizedConfiguration of array
- */
 interface Normalizable
 {
     /**
-     * @param TBaseConfiguration $configuration
-     * @return TNormalizedConfiguration
+     * @param array<mixed> $configuration
+     * @return array<mixed>
      */
     public function normalize(array $configuration): array;
 }

--- a/src/phpDocumentor/Configuration/Definition/Upgradable.php
+++ b/src/phpDocumentor/Configuration/Definition/Upgradable.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration\Definition;
 
+/**
+ * @template TPreviousConfigurationMap of array
+ * @template TUpgradedConfigurationMap of array
+ */
 interface Upgradable
 {
-    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
      * Attempt to upgrade the given result of this definition to a newer version of the configuration.
      *
@@ -21,10 +24,9 @@ interface Upgradable
      * The 'configVersion' field in the result will inform the ConfigurationFactory what the next Configuration
      * definition should be used to parse this result.
      *
-     * @param array<string, mixed> $values
+     * @param TPreviousConfigurationMap $values
      *
-     * @return array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, version?: array{array{api: array{array{default-package-name: string, extensions: array{extensions: array<array-key, string>}, ignore: array{paths: array<array-key, string>}, markers: array{markers: array<array-key, mixed>}, source: array{paths: array<array-key, string>}, visibilities: non-empty-list<string>}}, number: string}}}, settings?: array<mixed>, templates?: non-empty-list<string>}
+     * @return TUpgradedConfigurationMap
      */
-    //phpcs:enable Generic.Files.LineLength.TooLong
     public function upgrade(array $values): array;
 }

--- a/src/phpDocumentor/Configuration/Definition/Upgradable.php
+++ b/src/phpDocumentor/Configuration/Definition/Upgradable.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Configuration\Definition;
 
-/**
- * @template TPreviousConfigurationMap of array
- * @template TUpgradedConfigurationMap of array
- */
 interface Upgradable
 {
     /**
@@ -24,9 +20,9 @@ interface Upgradable
      * The 'configVersion' field in the result will inform the ConfigurationFactory what the next Configuration
      * definition should be used to parse this result.
      *
-     * @param TPreviousConfigurationMap $values
+     * @param array<mixed> $values
      *
-     * @return TUpgradedConfigurationMap
+     * @return array<mixed>
      */
     public function upgrade(array $values): array;
 }

--- a/src/phpDocumentor/Configuration/Definition/Version2.php
+++ b/src/phpDocumentor/Configuration/Definition/Version2.php
@@ -25,6 +25,12 @@ use function getcwd;
 use function implode;
 use function substr;
 
+/**
+ * @psalm-type ConfigurationMap = array<mixed>
+ * @psalm-import-type BaseConfiguration from Version3 as UpgradedConfiguration
+ *
+ * @implements Upgradable<ConfigurationMap, UpgradedConfiguration>
+ */
 final class Version2 implements ConfigurationInterface, Upgradable
 {
     /** @var string This is injected so that the name of the default template can be defined globally in the app */
@@ -148,17 +154,9 @@ final class Version2 implements ConfigurationInterface, Upgradable
         return $treebuilder;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * Upgrades the version 2 configuration to the version 3 configuration.
-     *
-     * @param array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, versions?: array<string, mixed>, settings?: array<mixed>, templates?: non-empty-list<string>, transformer: array{target: string}, parser: array{target: string, default-package-name: string, extensions: array{extensions: array}, visibility: string, markers: array{items: array}}, files: array{files: array, directories: array, ignores: array}, transformations: array{templates: array<string>}} $values
-     *
-     * @return array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: string, cache: string}, version?: array{array{api: array{array{default-package-name: string, extensions: array{extensions: array<array-key, string>}, ignore: array{paths: array<array-key, string>}, markers: array{markers: array<array-key, mixed>}, source: array{paths: array<array-key, string>}, visibilities: non-empty-list<string>}}, number: string}}}, settings?: array<mixed>, templates?: non-empty-list<string>}
-     *
-     * @todo not all options are included yet; finish this
+     * Upgrades the version 2 configuration to the version 3 pre-normalized configuration.
      */
-    //phpcs:enable Generic.Files.LineLength.TooLong
     public function upgrade(array $values): array
     {
         return [

--- a/src/phpDocumentor/Configuration/Definition/Version2.php
+++ b/src/phpDocumentor/Configuration/Definition/Version2.php
@@ -28,8 +28,6 @@ use function substr;
 /**
  * @psalm-type ConfigurationMap = array<mixed>
  * @psalm-import-type BaseConfiguration from Version3 as UpgradedConfiguration
- *
- * @implements Upgradable<ConfigurationMap, UpgradedConfiguration>
  */
 final class Version2 implements ConfigurationInterface, Upgradable
 {
@@ -156,6 +154,10 @@ final class Version2 implements ConfigurationInterface, Upgradable
 
     /**
      * Upgrades the version 2 configuration to the version 3 pre-normalized configuration.
+     *
+     * @param ConfigurationMap $values
+     *
+     * @return UpgradedConfiguration
      */
     public function upgrade(array $values): array
     {

--- a/src/phpDocumentor/Configuration/Definition/Version3.php
+++ b/src/phpDocumentor/Configuration/Definition/Version3.php
@@ -26,7 +26,6 @@ use function var_export;
 
 /**
  * @psalm-type BaseConfiguration = array<mixed>
- *
  * @psalm-type ConfigurationApiMap = array{
  *     ignore-tags: list<string>,
  *     extensions: non-empty-array<string>,
@@ -48,7 +47,6 @@ use function var_export;
  *     validate: bool,
  *     visibility: non-empty-array<array-key, string>
  * }
- *
  * @psalm-type ConfigurationMap = array{
  *     configVersion: string,
  *     title?: string,

--- a/src/phpDocumentor/Configuration/Definition/Version3.php
+++ b/src/phpDocumentor/Configuration/Definition/Version3.php
@@ -26,12 +26,13 @@ use function var_export;
 
 /**
  * @psalm-type BaseConfiguration = array<mixed>
+ *
  * @psalm-type ConfigurationApiMap = array{
  *     ignore-tags: list<string>,
  *     extensions: non-empty-array<string>,
  *     markers: list<string>,
  *     visibility: non-empty-array<string>,
- *     source: array{dsn: Dsn, paths: list<Path>},
+ *     source: array{dsn: Dsn, paths: array<array-key, Path>},
  *     ignore: array{
  *         hidden: bool,
  *         symlinks: bool,
@@ -42,7 +43,7 @@ use function var_export;
  *     output: string,
  *     format: string,
  *     default-package-name: string,
- *     examples?: array{dsn: string, paths: array},
+ *     examples?: array{dsn: string, paths: array<string>},
  *     include-source: bool,
  *     validate: bool,
  *     visibility: non-empty-array<array-key, string>
@@ -60,7 +61,7 @@ use function var_export;
  *             api: list<ConfigurationApiMap>,
  *             guides: list<
  *                 array{
- *                     source: array{dsn: Dsn, paths: Path[]},
+ *                     source: array{dsn: Dsn, paths: array<array-key, Path>},
  *                     output: string,
  *                     format: string,
  *                 }
@@ -69,16 +70,14 @@ use function var_export;
  *     >,
  *     use-cache: bool,
  *     settings: array<string, mixed>,
- *     templates: non-empty-list<
+ *     templates: non-empty-array<
  *         array{
  *             name: string,
  *             location: ?Path,
- *             parameters: list<string, mixed>
+ *             parameters: array<string, mixed>
  *         }
  *     >
  * }
- *
- * @implements Normalizable<BaseConfiguration, ConfigurationMap>
  */
 final class Version3 implements ConfigurationInterface, Normalizable
 {

--- a/src/phpDocumentor/Configuration/Exception/UnsupportedConfigVersionException.php
+++ b/src/phpDocumentor/Configuration/Exception/UnsupportedConfigVersionException.php
@@ -21,7 +21,7 @@ use function sprintf;
 /**
  * @codeCoverageIgnore
  */
-final class UnSupportedConfigVersionException extends RuntimeException
+final class UnsupportedConfigVersionException extends RuntimeException
 {
     /**
      * @param string[] $supportedVersions

--- a/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
+++ b/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
@@ -84,7 +84,7 @@ final class PathNormalizingMiddleware implements MiddlewareInterface
             }
         }
 
-        /** @var array{name: string, location?: ?Path, parameters?: array} $template */
+        /** @var array{name: string, location?: ?Path, parameters?: array<string, mixed>} $template */
         foreach ($configuration['phpdocumentor']['templates'] as $key => $template) {
             $location = $template['location'];
             if ($location instanceof Path && SymfonyPath::isAbsolute((string) $location) === false) {

--- a/src/phpDocumentor/Configuration/Source.php
+++ b/src/phpDocumentor/Configuration/Source.php
@@ -34,10 +34,10 @@ final class Source implements ArrayAccess
     /** @var Dsn */
     private $dsn;
 
-    /** @var Path[] */
+    /** @var array<array-key, Path> */
     private $paths;
 
-    /** @param Path[] $paths */
+    /** @param array<array-key, Path> $paths */
     public function __construct(Dsn $dsn, array $paths)
     {
         $this->dsn = $dsn;

--- a/src/phpDocumentor/Configuration/SymfonyConfigFactory.php
+++ b/src/phpDocumentor/Configuration/SymfonyConfigFactory.php
@@ -15,7 +15,7 @@ namespace phpDocumentor\Configuration;
 
 use phpDocumentor\Configuration\Definition\Normalizable;
 use phpDocumentor\Configuration\Definition\Upgradable;
-use phpDocumentor\Configuration\Exception\UnSupportedConfigVersionException;
+use phpDocumentor\Configuration\Exception\UnsupportedConfigVersionException;
 use phpDocumentor\Configuration\Exception\UpgradeFailedException;
 use RuntimeException;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -136,8 +136,9 @@ class SymfonyConfigFactory
     }
 
     /**
-     * @param array<mixed> $configuration because this method is called as part of the recursive method processConfiguration,
-     *   the provided shape varies and is the output of the normalisation process of provided ConfigurationDefinition.
+     * @param array<mixed> $configuration because this method is called as part of the recursive method
+     *   processConfiguration, the provided shape varies and is the output of the normalisation process of provided
+     *   ConfigurationDefinition.
      *
      * @return array<mixed> this method's output will match the shape of the output of the provided
      *   ConfigurationDefinition.

--- a/src/phpDocumentor/Configuration/SymfonyConfigFactory.php
+++ b/src/phpDocumentor/Configuration/SymfonyConfigFactory.php
@@ -15,7 +15,6 @@ namespace phpDocumentor\Configuration;
 
 use phpDocumentor\Configuration\Definition\Normalizable;
 use phpDocumentor\Configuration\Definition\Upgradable;
-use phpDocumentor\Configuration\Definition\Version3;
 use phpDocumentor\Configuration\Exception\UnSupportedConfigVersionException;
 use phpDocumentor\Configuration\Exception\UpgradeFailedException;
 use RuntimeException;
@@ -28,10 +27,7 @@ use function array_key_last;
 use function array_keys;
 
 /**
- * @psalm-import-type ConfigurationMap from Version3 as Version3ConfigurationMap
- * @psalm-type ConfigurationMap = array{
- *     phpdocumentor: Version3ConfigurationMap
- * }
+ * @psalm-import-type ConfigurationMap from ConfigurationFactory
  */
 class SymfonyConfigFactory
 {

--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -100,7 +100,12 @@ class ProjectDescriptorBuilder
         }
 
         // create Descriptor and populate with the provided data
-        return $this->filterDescriptor($assembler->create($data));
+        $descriptor = $assembler->create($data);
+        if ($descriptor === null) {
+            return null;
+        }
+
+        return $this->filterDescriptor($descriptor);
     }
 
     /**

--- a/src/phpDocumentor/Kernel.php
+++ b/src/phpDocumentor/Kernel.php
@@ -53,6 +53,8 @@ class Kernel extends BaseKernel
      *           - "@=service('kernel').getWorkingDir() ~ '/phpdoc.dist.xml'"
      *           - "@=service('kernel').getWorkingDir() ~ '/phpdoc.xml.dist'"
      * ```
+     *
+     * @noinspection PhpUnused this method is used in the services.yaml and the inspection does not pick this up.
      */
     public function getWorkingDir(): string
     {
@@ -82,10 +84,8 @@ class Kernel extends BaseKernel
      * I am not quite sure why, but without this overridden method Symfony will use the 'src' directory as Project Dir
      * when phpDocumentor is installed using Composer. Without being installed with composer it works fine without
      * this hack.
-     *
-     * @return string
      */
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return parent::getProjectDir();
     }

--- a/src/phpDocumentor/Pipeline/Stage/Configure.php
+++ b/src/phpDocumentor/Pipeline/Stage/Configure.php
@@ -23,55 +23,44 @@ use phpDocumentor\Parser\Cache\Locator;
 use phpDocumentor\Transformer\Writer\Twig\EnvironmentFactory;
 use phpDocumentor\UriFactory;
 use Psr\Log\LoggerInterface;
-use Webmozart\Assert\Assert;
 
-use function getcwd;
 use function realpath;
 use function sprintf;
 
 final class Configure
 {
-    /** @var ConfigurationFactory */
-    private $configFactory;
-
-    /** @var Configuration */
-    private $configuration;
-
-    /** @var LoggerInterface */
-    private $logger;
-
-    /** @var Locator */
-    private $locator;
-
-    /** @var EnvironmentFactory */
-    private $environmentFactory;
+    private ConfigurationFactory $configFactory;
+    private Configuration $configuration;
+    private LoggerInterface $logger;
+    private Locator $locator;
+    private EnvironmentFactory $environmentFactory;
+    private string $currentWorkingDir;
 
     public function __construct(
         ConfigurationFactory $configFactory,
         Configuration $configuration,
         LoggerInterface $logger,
         Locator $locator,
-        EnvironmentFactory $environmentFactory
+        EnvironmentFactory $environmentFactory,
+        string $currentWorkingDir
     ) {
         $this->configFactory = $configFactory;
         $this->configuration = $configuration;
         $this->logger = $logger;
         $this->locator = $locator;
         $this->environmentFactory = $environmentFactory;
+        $this->currentWorkingDir = $currentWorkingDir;
     }
 
     /**
      * @param array<string|string[]> $options
      *
-     * @return array<string, array>
+     * @return array<string, array<mixed>>
      */
     public function __invoke(array $options): array
     {
-        $currentWorkingDir = getcwd();
-        Assert::stringNotEmpty($currentWorkingDir);
-
         $this->configFactory->addMiddleware(
-            new CommandlineOptionsMiddleware($options, $this->configFactory, $currentWorkingDir)
+            new CommandlineOptionsMiddleware($options, $this->configFactory, $this->currentWorkingDir)
         );
         $this->configFactory->addMiddleware(new PathNormalizingMiddleware());
         $this->configFactory->addMiddleware(new ProvideTemplateOverridePathMiddleware($this->environmentFactory));

--- a/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
+++ b/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
@@ -44,14 +44,10 @@ final class InitializeBuilderFromConfig
         $builder->createProjectDescriptor();
         $builder->setName($configuration['phpdocumentor']['title'] ?? '');
         $builder->setPartials($this->partials);
-        $builder->setCustomSettings($configuration['phpdocumentor']['settings'] ?? []);
+        $builder->setCustomSettings($configuration['phpdocumentor']['settings']);
 
         foreach ($configuration['phpdocumentor']['versions'] as $version) {
-            $builder->addVersion(
-                $this->buildVersion(
-                    $version
-                )
-            );
+            $builder->addVersion($this->buildVersion($version));
         }
 
         return $payload;

--- a/src/phpDocumentor/Pipeline/Stage/Parser/Payload.php
+++ b/src/phpDocumentor/Pipeline/Stage/Parser/Payload.php
@@ -14,42 +14,42 @@ declare(strict_types=1);
 namespace phpDocumentor\Pipeline\Stage\Parser;
 
 use phpDocumentor\Configuration\ApiSpecification;
+use phpDocumentor\Configuration\Configuration;
 use phpDocumentor\Configuration\VersionSpecification;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
-use phpDocumentor\Dsn;
-use phpDocumentor\Path;
 use phpDocumentor\Pipeline\Stage\Payload as ApplicationPayload;
 use phpDocumentor\Reflection\File;
+use Webmozart\Assert\Assert;
 
 use function array_merge;
 use function current;
 
+/**
+ * @psalm-import-type ConfigurationMap from Configuration
+ */
 final class Payload extends ApplicationPayload
 {
     /** @var File[] */
-    private $files;
+    private array $files;
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $config
+     * @param ConfigurationMap $config
      * @param File[] $files
      */
-    //phpcs:enable Generic.Files.LineLength.TooLong
     public function __construct(array $config, ProjectDescriptorBuilder $builder, array $files = [])
     {
         parent::__construct($config, $builder);
         $this->files = $files;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
      * @return array<int, ApiSpecification>
      */
-    //phpcs:enable Generic.Files.LineLength.TooLong
     public function getApiConfigs(): array
     {
         // Grep only the first version for now. Multi version support will be added later
         $version = current($this->getConfig()['phpdocumentor']['versions']);
+        Assert::isInstanceOf($version, VersionSpecification::class);
 
         return $version->getApi();
     }

--- a/src/phpDocumentor/Pipeline/Stage/Payload.php
+++ b/src/phpDocumentor/Pipeline/Stage/Payload.php
@@ -13,76 +13,31 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage;
 
-use phpDocumentor\Configuration\VersionSpecification;
+use phpDocumentor\Configuration\Configuration;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
-use phpDocumentor\Dsn;
-use phpDocumentor\Path;
 
+/**
+ * @psalm-import-type ConfigurationMap from Configuration
+ */
 class Payload
 {
-    /**
-     * @var array{
-     *     phpdocumentor: array{
-     *         configVersion: string,
-     *         title?: string,
-     *         use-cache?: bool,
-     *         paths?: array{
-     *             output: Dsn,
-     *             cache: Path
-     *         },
-     *         versions?: array<string, VersionSpecification>,
-     *         settings?: array<mixed>,
-     *         templates?: non-empty-list<string>
-     *     }
-     * }
-     */
-    private $config;
+    /** @var ConfigurationMap */
+    private array $config;
 
-    /** @var ProjectDescriptorBuilder */
-    private $builder;
+    private ProjectDescriptorBuilder $builder;
 
-    // @phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName
     /**
-     * @param array{
-     *     phpdocumentor: array{
-     *         configVersion: string,
-     *         title?: string,
-     *         use-cache?: bool,
-     *         paths?: array{
-     *             output: Dsn,
-     *             cache: Path
-     *         },
-     *         versions?: array<string, VersionSpecification>,
-     *         settings?: array<mixed>,
-     *         templates?: non-empty-list<string>
-     *     }
-     * } $config
+     * @param ConfigurationMap $config
      */
-    // @phpcs:enable Squiz.Commenting.FunctionComment.MissingParamName
     public function __construct(array $config, ProjectDescriptorBuilder $builder)
     {
         $this->config = $config;
         $this->builder = $builder;
     }
 
-    // @phpcs:disable Squiz.Commenting.FunctionComment.MissingParamName
     /**
-     * @return array{
-     *     phpdocumentor: array{
-     *         configVersion: string,
-     *         title?: string,
-     *         use-cache?: bool,
-     *         paths?: array{
-     *             output: Dsn,
-     *             cache: Path
-     *         },
-     *         versions?: array<string, VersionSpecification>,
-     *         settings?: array<mixed>,
-     *         templates?: non-empty-list<string>
-     *     }
-     * }
+     * @return ConfigurationMap
      */
-    // @phpcs:enable Squiz.Commenting.FunctionComment.MissingParamName
     public function getConfig(): array
     {
         return $this->config;

--- a/src/phpDocumentor/Pipeline/Stage/Transform.php
+++ b/src/phpDocumentor/Pipeline/Stage/Transform.php
@@ -81,7 +81,7 @@ class Transform
         Assert::keyExists($configuration['phpdocumentor'], 'paths');
 
         $templates = $this->templateFactory->getTemplates(
-            $configuration['phpdocumentor']['templates'] ?? [],
+            $configuration['phpdocumentor']['templates'],
             $this->createFileSystem($configuration['phpdocumentor']['paths']['output'])
         );
         $project = $payload->getBuilder()->getProjectDescriptor();

--- a/src/phpDocumentor/Pipeline/Stage/TransformToPayload.php
+++ b/src/phpDocumentor/Pipeline/Stage/TransformToPayload.php
@@ -13,26 +13,24 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage;
 
-use phpDocumentor\Configuration\VersionSpecification;
+use phpDocumentor\Configuration\Configuration;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
-use phpDocumentor\Dsn;
-use phpDocumentor\Path;
 
+/**
+ * @psalm-import-type ConfigurationMap from Configuration
+ */
 final class TransformToPayload
 {
-    /** @var ProjectDescriptorBuilder */
-    private $descriptorBuilder;
+    private ProjectDescriptorBuilder $descriptorBuilder;
 
     public function __construct(ProjectDescriptorBuilder $descriptorBuilder)
     {
         $this->descriptorBuilder = $descriptorBuilder;
     }
 
-    //phpcs:disable Generic.Files.LineLength.TooLong
     /**
-     * @param array{phpdocumentor: array{configVersion: string, title?: string, use-cache?: bool, paths?: array{output: Dsn, cache: Path}, versions?: array<string, VersionSpecification>, settings?: array<mixed>, templates?: non-empty-list<string>}} $configuration
+     * @param ConfigurationMap $configuration
      */
-    //phpcs:enable Generic.Files.LineLength.TooLong
     public function __invoke(array $configuration): Payload
     {
         return new Payload($configuration, $this->descriptorBuilder);

--- a/src/phpDocumentor/Transformer/Template/Factory.php
+++ b/src/phpDocumentor/Transformer/Template/Factory.php
@@ -22,6 +22,7 @@ use League\Flysystem\MountManager;
 use phpDocumentor\Dsn;
 use phpDocumentor\Guides\Twig\Templates;
 use phpDocumentor\Parser\FlySystemFactory;
+use phpDocumentor\Path;
 use phpDocumentor\Transformer\Template;
 use phpDocumentor\Transformer\Transformation;
 use phpDocumentor\Transformer\Writer\Collection as WriterCollection;
@@ -69,7 +70,7 @@ class Factory
      * Attempts to find, construct and return a template object with the given template name or (relative/absolute)
      * path.
      *
-     * @param array<int, array{name:string, parameters:array<string, string>}> $templates
+     * @param array<int, array{name:string, location: ?Path, parameters:array<string, string>}> $templates
      */
     public function getTemplates(array $templates, FilesystemInterface $output): Collection
     {
@@ -78,9 +79,14 @@ class Factory
 
         foreach ($templates as $template) {
             $stopWatch->start('load template');
+
+            $templateNameOrLocation = $template['location'] instanceof Path
+                ? ($template['location'] . '/' . $template['name'])
+                : $template['name'];
+
             $loadedTemplates[$template['name']] = $this->loadTemplate(
                 $output,
-                $template['name'],
+                $templateNameOrLocation,
                 $template['parameters'] ?? []
             );
             $stopWatch->stop('load template');

--- a/src/phpDocumentor/Transformer/Template/Factory.php
+++ b/src/phpDocumentor/Transformer/Template/Factory.php
@@ -80,8 +80,9 @@ class Factory
         foreach ($templates as $template) {
             $stopWatch->start('load template');
 
-            $templateNameOrLocation = $template['location'] instanceof Path
-                ? ($template['location'] . '/' . $template['name'])
+            $location = $template['location'] ?? null;
+            $templateNameOrLocation = $location instanceof Path
+                ? ($location . '/' . $template['name'])
                 : $template['name'];
 
             $loadedTemplates[$template['name']] = $this->loadTemplate(

--- a/tests/unit/phpDocumentor/Configuration/Definition/Version3Test.php
+++ b/tests/unit/phpDocumentor/Configuration/Definition/Version3Test.php
@@ -65,9 +65,26 @@ final class Version3Test extends TestCase
         $expected['versions']['1.0.0']['api'][0]['visibility']
             = $expected['versions']['1.0.0']['api'][0]['visibilities'];
         unset($expected['versions']['1.0.0']['api'][0]['visibilities']);
+        $expected['templates'][0]['location'] = null;
+
         $configuration = $definition->normalize($configuration);
 
-        $this->assertEquals($expected, $configuration);
+        self::assertEquals($expected, $configuration);
+    }
+
+    /**
+     * @covers ::normalize
+     */
+    public function testNormalizingAPopulatedTemplateLocationGivesAPath(): void
+    {
+        $definition = new Version3(self::DEFAULT_TEMPLATE_NAME);
+        $configuration = $this->defaultConfigurationOutput();
+        $configuration['templates'][0]['location'] = 'data/templates';
+
+        $result = $definition->normalize($configuration);
+
+        self::assertInstanceOf(Path::class, $result['templates'][0]['location']);
+        self::assertSame('data/templates', (string) $result['templates'][0]['location']);
     }
 
     public function provideTestConfiguration(): array

--- a/tests/unit/phpDocumentor/Configuration/SymfonyConfigFactoryTest.php
+++ b/tests/unit/phpDocumentor/Configuration/SymfonyConfigFactoryTest.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Configuration;
 
 use org\bovigo\vfs\vfsStream;
 use phpDocumentor\Configuration\Definition\Upgradable;
-use phpDocumentor\Configuration\Exception\UnSupportedConfigVersionException;
+use phpDocumentor\Configuration\Exception\UnsupportedConfigVersionException;
 use phpDocumentor\Configuration\Exception\UpgradeFailedException;
 use phpDocumentor\Faker\Faker;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/phpDocumentor/Configuration/SymfonyConfigFactoryTest.php
+++ b/tests/unit/phpDocumentor/Configuration/SymfonyConfigFactoryTest.php
@@ -58,13 +58,13 @@ final class SymfonyConfigFactoryTest extends TestCase
     }
 
     /**
-     * @uses \phpDocumentor\Configuration\Exception\UnSupportedConfigVersionException::create
+     * @uses \phpDocumentor\Configuration\Exception\UnsupportedConfigVersionException::create
      *
      * @covers ::createFromFile
      */
     public function testThrowsExceptionWhenConfigVersionIsNotSupported(): void
     {
-        $this->expectException(UnSupportedConfigVersionException::class);
+        $this->expectException(UnsupportedConfigVersionException::class);
 
         $root = vfsStream::setup();
         $configFile = vfsStream::newFile('config.xml')->withContent(

--- a/tests/unit/phpDocumentor/Pipeline/Stage/ConfigureTest.php
+++ b/tests/unit/phpDocumentor/Pipeline/Stage/ConfigureTest.php
@@ -25,6 +25,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 
+use function getcwd;
 use function sys_get_temp_dir;
 
 /**
@@ -68,7 +69,8 @@ final class ConfigureTest extends TestCase
             new Configuration($config),
             $logger->reveal(),
             $this->cacheLocator->reveal(),
-            $this->prophesize(EnvironmentFactory::class)->reveal()
+            $this->prophesize(EnvironmentFactory::class)->reveal(),
+            getcwd()
         );
 
         self::assertEquals($config, $stage(['config' => 'none']));
@@ -88,7 +90,8 @@ final class ConfigureTest extends TestCase
             new Configuration(),
             $logger->reveal(),
             $this->cacheLocator->reveal(),
-            $this->prophesize(EnvironmentFactory::class)->reveal()
+            $this->prophesize(EnvironmentFactory::class)->reveal(),
+            getcwd()
         );
 
         $stage(['config' => 'some/invalid/file.xml']);
@@ -115,7 +118,8 @@ final class ConfigureTest extends TestCase
             new Configuration(),
             $logger->reveal(),
             $this->cacheLocator->reveal(),
-            $this->prophesize(EnvironmentFactory::class)->reveal()
+            $this->prophesize(EnvironmentFactory::class)->reveal(),
+            getcwd()
         );
 
         $actual = $stage([]);
@@ -145,7 +149,8 @@ final class ConfigureTest extends TestCase
             new Configuration(),
             $logger->reveal(),
             $this->cacheLocator->reveal(),
-            $this->prophesize(EnvironmentFactory::class)->reveal()
+            $this->prophesize(EnvironmentFactory::class)->reveal(),
+            getcwd()
         );
 
         $actual = $stage(['config' => __FILE__]);

--- a/tests/unit/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfigTest.php
+++ b/tests/unit/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfigTest.php
@@ -33,6 +33,17 @@ final class InitializeBuilderFromConfigTest extends TestCase
         $builder->setPartials($partials)->shouldBeCalledOnce();
         $builder->setCustomSettings([])->shouldBeCalledOnce();
 
-        $fixture(new Payload(['phpdocumentor' => ['title' => 'my-title', 'versions' => []]], $builder->reveal()));
+        $fixture(
+            new Payload(
+                [
+                    'phpdocumentor' => [
+                        'title' => 'my-title',
+                        'versions' => [],
+                        'settings' => [],
+                    ],
+                ],
+                $builder->reveal()
+            )
+        );
     }
 }


### PR DESCRIPTION
In this commit, I have added handling, tests and documentation for the
'location' attribute in the template configuration entry. This should
now work and attempt to load the template from the given directory on
the host's filesystem.

Because I kept running into issues with how phpstan and psalm interpret
the configuration array shape; I have also cleaned that part up and used
psalm-type definitions to provide a reusable shape. I chose not to use
phpstan-type annotations because phpstan understands the psalm
annotations but not vice versa.

Unfortunately, I discovered that we are using an antiquated version of
phpstan that does not like array-shape type aliases. This is fixed in a
newer version but I need @jaapio his input whether we version locked for
a reason.