### PR TITLE
Source code cannot be viewed from packages, file or namespaces

### DIFF
--- a/data/templates/default/components/element-found-in.html.twig
+++ b/data/templates/default/components/element-found-in.html.twig
@@ -4,6 +4,6 @@
     <span class="phpdocumentor-element-found-in__line">{{ node.line }}</span>
 
     {% if node.file.source %}
-        <a href="{{ target_path }}#source-view.{{ node.line }}"  class="phpdocumentor-element-found-in__source" data-line="{{ node.line }}" data-modal="source-view"></a>
+        <a href="{{ target_path }}#source-view.{{ node.line }}" class="phpdocumentor-element-found-in__source" data-line="{{ node.line }}" data-modal="source-view" data-src="{{ path('files/' ~ node.path ~ '.txt')|raw }}"></a>
     {% endif %}
 </aside>

--- a/data/templates/default/components/source-modal.css.twig
+++ b/data/templates/default/components/source-modal.css.twig
@@ -10,6 +10,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    z-index: 1;
 }
 
 .phpdocumentor-modal__open {

--- a/data/templates/default/components/source-modal.html.twig
+++ b/data/templates/default/components/source-modal.html.twig
@@ -1,74 +1,95 @@
-{% if node.file.source %}
+{% block sourceview_modal %}
 <div class="phpdocumentor-modal" id="source-view">
     <div class="phpdocumentor-modal-bg" data-exit-button></div>
     <div class="phpdocumentor-modal-container">
         <div class="phpdocumentor-modal-content">
-        <pre style="max-height: 500px; overflow-y: scroll" data-src="{{ path('files/' ~ node.path ~ '.txt')|raw }}" class="language-php line-numbers linkable-line-numbers"></pre>
+            <pre style="max-height: 500px; overflow-y: scroll" data-src="{{ node.path ? (path('files/' ~ node.path ~ '.txt')|raw) }}" class="language-php line-numbers linkable-line-numbers"></pre>
         </div>
-        <button data-exit-button class="phpdocumentor-modal__close">X</button>
+        <button data-exit-button class="phpdocumentor-modal__close">&times;</button>
     </div>
 </div>
-{% endif %}
+{% endblock %}
 
-{% block javascripts %}
+{% block modals_script %}
     <script type="text/javascript">
-        function loadExternalCodeSnippets(line) {
-            Array.prototype.slice.call(document.querySelectorAll('pre[data-src]')).forEach((pre) => {
-                var src = pre.getAttribute('data-src').replace( /\\/g, '/');
-                var extension = (src.match(/\.(\w+)$/) || [, ''])[1];
-                var language = 'php';
+        (function () {
+            function loadExternalCodeSnippet(el, url, line) {
+                Array.prototype.slice.call(el.querySelectorAll('pre[data-src]')).forEach((pre) => {
+                    const src = url || pre.getAttribute('data-src').replace(/\\/g, '/');
+                    const language = 'php';
 
-                var code = document.createElement('code');
-                code.className = 'language-' + language;
+                    const code = document.createElement('code');
+                    code.className = 'language-' + language;
+                    pre.textContent = '';
+                    pre.setAttribute('data-line', line)
+                    code.textContent = 'Loading…';
+                    pre.appendChild(code);
 
-                pre.textContent = '';
+                    var xhr = new XMLHttpRequest();
 
-                pre.setAttribute('data-line', line)
-                code.textContent = 'Loading…';
+                    xhr.open('GET', src, true);
 
-                pre.appendChild(code);
-
-                var xhr = new XMLHttpRequest();
-
-                xhr.open('GET', src, true);
-
-                xhr.onreadystatechange = function () {
-                    if (xhr.readyState == 4) {
+                    xhr.onreadystatechange = function () {
+                        if (xhr.readyState !== 4) {
+                            return;
+                        }
 
                         if (xhr.status < 400 && xhr.responseText) {
                             code.textContent = xhr.responseText;
-
                             Prism.highlightElement(code);
+                            return;
                         }
-                        else if (xhr.status >= 400) {
+
+                        if (xhr.status === 404) {
+                            code.textContent = '✖ Error: File could not be found';
+                            return;
+                        }
+
+                        if (xhr.status >= 400) {
                             code.textContent = '✖ Error ' + xhr.status + ' while fetching file: ' + xhr.statusText;
+                            return;
                         }
-                        else {
-                            code.textContent = '✖ Error: File does not exist, is empty or trying to view from localhost';
-                        }
+
+                        code.textContent = '✖ Error: An unknown error occurred';
+                    };
+
+                    xhr.send(null);
+                });
+            }
+
+            const modalButtons = document.querySelectorAll("[data-modal]");
+            const openedAsLocalFile = window.location.protocol === 'file:';
+            if (modalButtons.length > 0 && openedAsLocalFile) {
+                console.warn(
+                    'Viewing the source code is unavailable because you are opening this page from the file:// scheme; ' +
+                    'browsers block XHR requests when a page is opened this way'
+                );
+            }
+
+            modalButtons.forEach(function (trigger) {
+                if (openedAsLocalFile) {
+                    trigger.setAttribute("hidden", "hidden");
+                }
+
+                trigger.addEventListener("click", function (event) {
+                    event.preventDefault();
+                    const modal = document.getElementById(trigger.dataset.modal);
+                    if (!modal) {
+                        console.error(`Modal with id "${trigger.dataset.modal}" could not be found`);
+                        return;
                     }
-                };
+                    modal.classList.add("phpdocumentor-modal__open");
 
-                xhr.send(null);
-            });
-        }
-
-        var modals = document.querySelectorAll("[data-modal]");
-
-        modals.forEach(function (trigger) {
-            trigger.addEventListener("click", function (event) {
-                //event.preventDefault();
-                const modal = document.getElementById(trigger.dataset.modal);
-                modal.classList.add("phpdocumentor-modal__open");
-                loadExternalCodeSnippets(trigger.dataset.line)
-                const exits = modal.querySelectorAll("[data-exit-button]");
-                exits.forEach(function (exit) {
-                    exit.addEventListener("click", function (event) {
-                        event.preventDefault();
-                        modal.classList.remove("phpdocumentor-modal__open");
+                    loadExternalCodeSnippet(modal, trigger.dataset.src || null, trigger.dataset.line)
+                    const exits = modal.querySelectorAll("[data-exit-button]");
+                    exits.forEach(function (exit) {
+                        exit.addEventListener("click", function (event) {
+                            event.preventDefault();
+                            modal.classList.remove("phpdocumentor-modal__open");
+                        });
                     });
                 });
             });
-        });
+        })();
     </script>
 {% endblock %}

--- a/data/templates/default/css/normalize.css.twig
+++ b/data/templates/default/css/normalize.css.twig
@@ -76,7 +76,7 @@ audio:not([controls]) {
 
 [hidden],
 template {
-    display: none;
+    display: none !important;
 }
 
 /* Links

--- a/data/templates/default/file.html.twig
+++ b/data/templates/default/file.html.twig
@@ -9,5 +9,6 @@
 
         {{ include('components/constants.html.twig') }}
         {{ include('components/functions.html.twig') }}
+        {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}

--- a/data/templates/default/namespace.html.twig
+++ b/data/templates/default/namespace.html.twig
@@ -8,5 +8,6 @@
         {{ include('components/table-of-contents.html.twig', {'namespaces': node.children}) }}
         {{ include('components/constants.html.twig') }}
         {{ include('components/functions.html.twig') }}
+        {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}

--- a/data/templates/default/package.html.twig
+++ b/data/templates/default/package.html.twig
@@ -8,5 +8,6 @@
         {{ include('components/table-of-contents.html.twig', {'packages': node.children}) }}
         {{ include('components/constants.html.twig') }}
         {{ include('components/functions.html.twig') }}
+        {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}


### PR DESCRIPTION
In this change, I have reworked the opening of the source code modal to
correctly deal with paths. Previously, the current page's node was used
as a path to the source file; but this is not true when you are on a
package or namespace.

Fixes #3271