### PR TITLE
Docker shouldn't run `help run` by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,3 @@ COPY --from=build /opt/phpdoc /opt/phpdoc
 RUN echo "memory_limit=-1" >> /usr/local/etc/php/conf.d/phpdoc.ini && phpdoc cache:warm
 
 ENTRYPOINT ["/opt/phpdoc/bin/phpdoc"]
-
-CMD ["help", "run"]


### PR DESCRIPTION
The CMD line with help run will prevent people from running
phpDocumentor without command line arguments (for example: when they
use the config file).

And phpDocumentor was written in such a way that the help will be shown
when it doesn't know what to do :)

Fixes #3268 