### PR TITLE
References to cases are not linked

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/EnumAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/EnumAssembler.php
@@ -102,6 +102,7 @@ final class EnumAssembler extends AssemblerAbstract
                 continue;
             }
 
+            $caseDescriptor->setParent($descriptor);
             $descriptor->getCases()->set($caseDescriptor->getName(), $caseDescriptor);
         }
     }

--- a/src/phpDocumentor/Descriptor/EnumCaseDescriptor.php
+++ b/src/phpDocumentor/Descriptor/EnumCaseDescriptor.php
@@ -19,10 +19,11 @@ namespace phpDocumentor\Descriptor;
  * @api
  * @package phpDocumentor\AST
  */
-final class EnumCaseDescriptor extends DescriptorAbstract implements Interfaces\EnumCaseInterface
+class EnumCaseDescriptor extends DescriptorAbstract implements Interfaces\EnumCaseInterface
 {
-    /** @var string|null */
-    private $value;
+    private ?EnumDescriptor $parent = null;
+
+    private ?string $value;
 
     public function setValue(?string $value): void
     {
@@ -32,5 +33,15 @@ final class EnumCaseDescriptor extends DescriptorAbstract implements Interfaces\
     public function getValue(): ?string
     {
         return $this->value;
+    }
+
+    public function getParent(): ?EnumDescriptor
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?EnumDescriptor $parent): void
+    {
+        $this->parent = $parent;
     }
 }

--- a/src/phpDocumentor/Transformer/Router/Router.php
+++ b/src/phpDocumentor/Transformer/Router/Router.php
@@ -18,6 +18,7 @@ use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\ConstantDescriptor;
 use phpDocumentor\Descriptor\Descriptor;
 use phpDocumentor\Descriptor\DocumentDescriptor;
+use phpDocumentor\Descriptor\EnumCaseDescriptor;
 use phpDocumentor\Descriptor\EnumDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\FunctionDescriptor;
@@ -94,6 +95,14 @@ class Router
             return $this->generateUrlForDescriptor(
                 'class',
                 (string) $node->getFullyQualifiedStructuralElementName()
+            );
+        }
+
+        if ($node instanceof EnumCaseDescriptor && $node->getParent() instanceof EnumDescriptor) {
+            return $this->generateUrlForDescriptor(
+                'class',
+                (string) $node->getParent()->getFullyQualifiedStructuralElementName(),
+                'enumcase_' . $node->getName()
             );
         }
 

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/EnumAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/EnumAssemblerTest.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Builder\Reflector;
 
+use phpDocumentor\Descriptor\EnumCaseDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Php\Enum_;
+use phpDocumentor\Reflection\Php\EnumCase;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
@@ -41,17 +44,54 @@ final class EnumAssemblerTest extends TestCase
     public function testAssembleBasicDescriptor(): void
     {
         $fqsen = new Fqsen('\MyNamespace\Enum');
-        $enum = new Enum_(
-            $fqsen,
-            new String_(),
-            new DocBlock('Summary'),
-            new Location(10, 0)
-        );
+        $enum = $this->givenExampleEnum($fqsen);
 
         $descriptor = $this->assembler->create($enum);
 
         self::assertSame('Enum', $descriptor->getName());
         self::assertSame($fqsen, $descriptor->getFullyQualifiedStructuralElementName());
         self::assertSame(10, $descriptor->getLine());
+        self::assertCount(0, $descriptor->getCases());
+    }
+
+    /**
+     * @covers ::buildDescriptor
+     */
+    public function testEnumsCanHaveCases(): void
+    {
+        $caseFqsen = new Fqsen('\MyNamespace\Enum\Case');
+        $case = new EnumCase($caseFqsen, new DocBlock('Summary'), null, null, 'Hearts');
+
+        $fqsen = new Fqsen('\MyNamespace\Enum');
+        $enum = $this->givenExampleEnum($fqsen);
+        $enum->addCase($case);
+
+        $this->builder
+            ->buildDescriptor(Argument::any(), EnumCaseDescriptor::class)
+            // @phpcs:ignore SlevomatCodingStandard.Functions.StaticClosure.ClosureNotStatic
+            ->will(function ($value) {
+                $enumCaseDescriptor = new EnumCaseDescriptor();
+                $enumCaseDescriptor->setName($value[0]->getName());
+                $enumCaseDescriptor->setValue($value[0]->getValue());
+
+                return $enumCaseDescriptor;
+            });
+
+        $descriptor = $this->assembler->create($enum);
+
+        self::assertCount(1, $descriptor->getCases());
+        self::assertSame($case->getName(), $descriptor->getCases()[$case->getName()]->getName());
+        self::assertSame($case->getValue(), $descriptor->getCases()[$case->getName()]->getValue());
+        self::assertSame($descriptor, $descriptor->getCases()[$case->getName()]->getParent());
+    }
+
+    private function givenExampleEnum(Fqsen $fqsen): Enum_
+    {
+        return new Enum_(
+            $fqsen,
+            new String_(),
+            new DocBlock('Summary'),
+            new Location(10, 0)
+        );
     }
 }


### PR DESCRIPTION
The router did not recognize enum case and did not know how to create a
link to these. This change will alter that so that the linking of the
TOC and of the deeplinks in the docs work.

Fixes #3199 