### PR TITLE
Purge caches upon version change

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -15,10 +15,8 @@ framework:
         pools:
             files:
                 adapter: app.projectcache.provider
-                default_lifetime: 2629743 # 1 month
             descriptors:
                 adapter: app.projectcache.provider
-                default_lifetime: 2629743 # 1 month
 
 services:
     app.projectcache.provider:

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -15,8 +15,10 @@ framework:
         pools:
             files:
                 adapter: app.projectcache.provider
+                default_lifetime: 2629743 # 1 month
             descriptors:
                 adapter: app.projectcache.provider
+                default_lifetime: 2629743 # 1 month
 
 services:
     app.projectcache.provider:

--- a/docs/DESIGN.rst
+++ b/docs/DESIGN.rst
@@ -73,7 +73,6 @@ Outline
   - More Specific Type-Hinting
   - Describing Relations
   - Working with Markers
-  - Writing more with less
 - Integrating into your site
   - Add your own menu items
   - Adjust styling to match your own
@@ -83,6 +82,9 @@ Outline
 - Extending phpDocumentor
   - Adding Custom Tags
   - Adding Custom Directives
+- Features
+  - Caching
+  - Inheritance
 - References
   - Command-line arguments
   - Configuration

--- a/docs/features/caching.rst
+++ b/docs/features/caching.rst
@@ -1,0 +1,115 @@
+#######
+Caching
+#######
+
+**********************
+Please read this first
+**********************
+
+By default, phpDocumentor comes pre-configured to run optimally and has caching enabled. This chapter is here to
+help you become acquainted with the caching system and how you could tweak it. Thus, if you came here looking how to
+make phpDocumentor even faster; it's already on!
+
+Since caching is enabled by default, this document will focus on how to influence the way phpDocumentor caches and the
+impact of this.
+
+******************
+Where's the cache?
+******************
+
+Especially when you integrate phpDocumentor in a Continuous Integration environment, it is useful to know where
+phpDocumentor caches to, or even to change where it caches to. This can be helpful when you want to tweak your
+pipeline.
+
+The default location is: ``${Current Working Directory}/.phpdoc/cache``.
+
+This will make sure the cache stays with your project. Which is useful when running it using Docker, caching artefacts
+in your continuous integration environment and more.
+
+Changing the caching location
+=============================
+
+Sometimes, you want control over your cache location. phpDocumentor provides that through the following means:
+
+1. The ``--cache-path`` command-line option, or
+2. The ``paths/cache`` key in a configuration file.
+
+To clarify how to integrate it in your configuration, here is an example:
+
+.. code-block:: xml
+
+   <?xml version="1.0" encoding="UTF-8" ?>
+   <phpdocumentor ...>
+       ...
+       <paths>
+       	   ...
+           <cache>.phpdoc/cache</cache>
+       </paths>
+       ...
+   </phpdocumentor>
+
+Both means support absolute and relative paths.
+
+.. important::
+
+   Relative paths are resolved differently in both methods. When provided to the command-line, it will be relative to
+   your current working directory; when present in the configuration file, it is relative to the configuration file's
+   location.
+
+********************
+How does it help me?
+********************
+
+Quick sidebar first: phpDocumentor works by reading _source files_, plucking the juicy bits out and combine that with
+a series of templates into a website.
+
+Why is this important to know? So it is easier to understand that phpDocumentor can only cache the first part; where it
+reads the source files and plucks the juicy bits from them. It is these juicy bits that we remember for each individual
+file.
+
+Thus, when you run phpDocumentor on your source files, it will check whether the file has changed since it saw last
+time. Read it if it does and cache that. Combining this information into a website is much harder to cache since it
+becomes highly integrated from this point onwards.
+
+Disabling the cache
+===================
+
+I'm not sure why you want to, but phpDocumentor makes it possible to disable the cache. Though, sometimes it can be
+helpful to disable the cache temporarily if you suspect a caching issue is the cause of unexpected behaviour.
+
+To disable the cache, this is done temporarily by adding the ``--force`` command-line option when running it. But you
+can also configure it in your configuration file as a more permanent solution using the ``use-cache`` boolean option:
+
+.. code-block:: xml
+
+   <?xml version="1.0" encoding="UTF-8" ?>
+   <phpdocumentor ...>
+       ...
+       <use-cache>false</use-cache>
+       <paths>
+           ...
+	   </paths>
+       ...
+   </phpdocumentor>
+
+When is the cache cleared?
+==========================
+
+Without passing the ``--force`` command-line argument or manually deleting the contents of the cache folder.
+phpDocumentor will decide to clear the cache in any of the following situations.
+
+After upgrading phpDocumentor
+-----------------------------
+
+Things change in phpDocumentor, and some of these changes are new to cached information. Without clearing the cache we
+would possibly make incorrect assumptions about your code or even throw errors. As such, to ensure that your
+documentation is correct phpDocumentor will purge all it's caches when you use a new version of phpDocumentor for the
+first time.
+
+After changing the configuration
+--------------------------------
+
+To be precise: when the options are changed related to reading and interpreting your source file, that is when the cache
+is flushed. The reason for this is that some information is, or should be, discarded when phpDocumentor runs; and this
+is stored in the cache. As such, when your configuration changes compared to the previous run, phpDocumentor needs to
+do a full analysis on all source files from scratch.

--- a/docs/features/index.rst
+++ b/docs/features/index.rst
@@ -1,0 +1,7 @@
+Features
+========
+
+.. toctree::
+    :maxdepth: 2
+
+    caching

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
 
    getting-started/index
    guides/index
+   features/index
    references/index
    internals/index
    hand-written-docs/index

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,9 @@ parameters:
   inferPrivatePropertyTypeFromConstructor: true
   treatPhpDocTypesAsCertain: false
   ignoreErrors:
+    # This is intended to check if a placeholder was replace by box; but phpstan does not know this :)
+    - "/Strict comparison using !== between '@package_version@' and '@package_version@' will always evaluate to false./"
+
     # PHPStan does not play nice with Symfony Config's fluid interface
     - '#.*NodeDefinition::prototype.*#'
     - '#.*NodeDefinition::addDefaultChildrenIfNoneSet.*#'

--- a/src/phpDocumentor/Application.php
+++ b/src/phpDocumentor/Application.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor;
 
+use Jean85\PrettyVersions;
+use OutOfBoundsException;
 use RuntimeException;
 
 use function date_default_timezone_set;
@@ -21,6 +23,8 @@ use function file_exists;
 use function file_get_contents;
 use function ini_get;
 use function ini_set;
+use function ltrim;
+use function sprintf;
 use function trim;
 
 /**
@@ -32,9 +36,25 @@ use function trim;
  */
 final class Application
 {
+    private const VERSION = '@package_version@';
+
     public static function VERSION(): string
     {
-        return trim(file_get_contents(__DIR__ . '/../../VERSION'));
+        $version = self::VERSION;
+
+        $trickBoxIntoNotReplacingThisScalar = sprintf('%s%s%s', '@', 'package_version', '@');
+        $didBoxReplaceTheVersionPlaceholder = $trickBoxIntoNotReplacingThisScalar !== self::VERSION;
+
+        if ($didBoxReplaceTheVersionPlaceholder === false) {
+            $version = trim(file_get_contents(__DIR__ . '/../../VERSION'));
+            try {
+                $version = PrettyVersions::getRootPackageVersion()->getPrettyVersion();
+                $version = sprintf('%s', ltrim($version, 'v'));
+            } catch (OutOfBoundsException $e) {
+            }
+        }
+
+        return $version;
     }
 
     public static function templateDirectory(): string

--- a/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
+++ b/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Configuration;
 use League\Uri\Contracts\UriInterface;
 use phpDocumentor\Dsn;
 use phpDocumentor\Path;
+use Symfony\Component\Filesystem\Path as SymfonyPath;
 use Webmozart\Assert\Assert;
 
 use function array_map;
@@ -26,6 +27,8 @@ use function current;
 use function end;
 use function explode;
 use function implode;
+
+use const DIRECTORY_SEPARATOR;
 
 final class CommandlineOptionsMiddleware implements MiddlewareInterface
 {
@@ -105,8 +108,13 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
 
     private function overwriteCacheFolder(Configuration $configuration): Configuration
     {
-        if (isset($this->options['cache-folder']) && $this->options['cache-folder']) {
-            $configuration['phpdocumentor']['paths']['cache'] = new Path($this->options['cache-folder']);
+        $cacheFolder = $this->options['cache-folder'] ?? null;
+        if ($cacheFolder !== null) {
+            if (SymfonyPath::isAbsolute($cacheFolder) === false) {
+                $cacheFolder = $this->currentWorkingDir->getPath() . DIRECTORY_SEPARATOR . $cacheFolder;
+            }
+
+            $configuration['phpdocumentor']['paths']['cache'] = new Path($cacheFolder);
         }
 
         return $configuration;

--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Console;
 
-use Jean85\PrettyVersions;
-use OutOfBoundsException;
 use Symfony\Bundle\FrameworkBundle\Console\Application as BaseApplication;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -22,22 +20,17 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-use function file_get_contents;
-use function ltrim;
 use function sprintf;
 use function strlen;
-use function trim;
 
 class Application extends BaseApplication
 {
-    public const VERSION = '@package_version@';
-
     public function __construct(KernelInterface $kernel)
     {
         parent::__construct($kernel);
 
         $this->setName('phpDocumentor');
-        $this->setVersion($this->detectVersion());
+        $this->setVersion(\phpDocumentor\Application::VERSION());
     }
 
     protected function getCommandName(InputInterface $input): ?string
@@ -84,27 +77,7 @@ class Application extends BaseApplication
      */
     public function getLongVersion(): string
     {
-        return sprintf('%s <info>%s</info>', $this->getName(), $this->getVersion());
-    }
-
-    private function detectVersion(): string
-    {
-        $version = self::VERSION;
-
-        // prevent replacing the version by the PEAR building
-        if (sprintf('%s%s%s', '@', 'package_version', '@') === self::VERSION) {
-            $version = trim(file_get_contents(__DIR__ . '/../../../VERSION'));
-            // @codeCoverageIgnoreStart
-            try {
-                $version = PrettyVersions::getRootPackageVersion()->getPrettyVersion();
-                $version = sprintf('v%s', ltrim($version, 'v'));
-            } catch (OutOfBoundsException $e) {
-            }
-
-            // @codeCoverageIgnoreEnd
-        }
-
-        return $version;
+        return sprintf('%s <info>v%s</info>', $this->getName(), $this->getVersion());
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapper.php
+++ b/src/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapper.php
@@ -34,8 +34,7 @@ class ProjectDescriptorMapper
 
     public const KEY_SETTINGS = 'phpDocumentor-projectDescriptor-settings';
 
-    /** @var AdapterInterface $cache */
-    private $cache;
+    private AdapterInterface $cache;
 
     /**
      * Initializes this mapper with the given cache instance.

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor/Settings.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor/Settings.php
@@ -21,20 +21,19 @@ use phpDocumentor\Configuration\ApiSpecification;
 final class Settings
 {
     /** @var bool Represents whether this settings object has been modified */
-    private $isModified = false;
+    private bool $isModified = false;
 
     /** @var int a bitflag representing which visibilities are contained and allowed in this project */
-    private $visibility = ApiSpecification::VISIBILITY_DEFAULT;
+    private int $visibility = ApiSpecification::VISIBILITY_DEFAULT;
 
-    /** @var bool */
-    private $includeSource = false;
+    private bool $includeSource = false;
 
     /**
      * A flexible list of settings that can be used by Writers, templates and more as additional settings.
      *
-     * @var (string|bool)[]
+     * @var array<string|bool>
      */
-    private $custom = [];
+    private array $custom = [];
 
     /**
      * Stores the visibilities that are allowed to be executed as a bitflag.

--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -162,7 +162,11 @@ class ProjectDescriptorBuilder
 
     public function setApiSpecification(ApiSpecification $apiSpecification): void
     {
+        // TODO: Any change in the API Specification compared to a previous (cached) run should invalidate that cache.
         $this->apiSpecification = $apiSpecification;
+
+        // TODO: The setVisibility call should purge the cache; but once we are here, cache has already been loaded..
+        $this->setVisibility($apiSpecification->calculateVisiblity());
     }
 
     public function createApiDocumentationSet(Project $project): void
@@ -175,6 +179,7 @@ class ProjectDescriptorBuilder
             $customSettings = array_merge($service->getDefaultSettings(), $customSettings);
         }
 
+        // TODO: This call should purge the cache; but once we are here, cache has already been loaded..
         $this->getProjectDescriptor()->getSettings()->setCustom($customSettings);
 
         foreach ($project->getFiles() as $file) {

--- a/src/phpDocumentor/Parser/Cache/FilesystemAdapter.php
+++ b/src/phpDocumentor/Parser/Cache/FilesystemAdapter.php
@@ -13,12 +13,17 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Parser\Cache;
 
+use phpDocumentor\Application;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Traits\FilesystemTrait;
 
+use function md5;
+use function sprintf;
 use function sys_get_temp_dir;
+
+use const DIRECTORY_SEPARATOR;
 
 final class FilesystemAdapter extends AbstractAdapter implements PruneableInterface
 {
@@ -26,15 +31,17 @@ final class FilesystemAdapter extends AbstractAdapter implements PruneableInterf
         init as doInit;
     }
 
-    private const TTL_ONE_YEAR = 31556926;
+    private const TTL_ONE_MONTH = 2_629_743;
 
-    public function __construct(string $namespace = 'phpdoc', int $defaultLifetime = self::TTL_ONE_YEAR)
+    public function __construct(string $namespace = 'phpdoc', int $defaultLifetime = self::TTL_ONE_MONTH)
     {
         $this->marshaller = new DefaultMarshaller();
 
-        parent::__construct($namespace, $defaultLifetime);
+        parent::__construct($this->prefixNamespaceWithVersion($namespace), $defaultLifetime);
 
-        $this->init($namespace, sys_get_temp_dir() . '/phpdocumentor');
+        $directory = sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, 'phpdocumentor');
+
+        $this->init($namespace, $directory);
     }
 
     /**
@@ -42,9 +49,28 @@ final class FilesystemAdapter extends AbstractAdapter implements PruneableInterf
      *
      * With phpDocumentor you can set the caching folder in your configuration; this poses an interesting problem with
      * the default FilesystemAdapter of Symfony as that only allows you to set the caching folder upon instantiation.
+     *
+     * This method prefixes the namespace with a hash of the current application version. We do this because changes
+     * between versions, even minor ones, can cause unexpected issues due to serialization. As a trade-off, we thus
+     * force a fresh cache if you use a new/different version of phpDocumentor.
+     *
+     * For example:
+     *
+     *     If a new property is added to a descriptor, upon unserialize PHP will attempt to populate that
+     *     with the default property value, or fail if none is provided, but that default may not be the actual result.
+     *
+     *     Since phpDocumentor runs fast enough for the occasional cache clear, this will have limited impact for end
+     *     users and guarantees that the cached state is correct.
      */
     public function init(string $namespace, string $directory): void
     {
-        $this->doInit($namespace, $directory);
+        $prefixNamespaceWithVersion = $this->prefixNamespaceWithVersion($namespace);
+
+        $this->doInit($prefixNamespaceWithVersion, $directory);
+    }
+
+    private function prefixNamespaceWithVersion(string $namespace): string
+    {
+        return sprintf('%s-%s', md5(Application::VERSION()), $namespace);
     }
 }

--- a/src/phpDocumentor/Parser/Cache/Locator.php
+++ b/src/phpDocumentor/Parser/Cache/Locator.php
@@ -45,14 +45,13 @@ use function sprintf;
  */
 class Locator
 {
-    /** @var ?Path */
-    private $path;
+    private ?Path $path;
 
-    /** @var FilesystemAdapter */
-    private $fileCache;
+    /** @var CacheInterface&FilesystemAdapter */
+    private CacheInterface $fileCache;
 
-    /** @var FilesystemAdapter */
-    private $descriptorCache;
+    /** @var CacheInterface&FilesystemAdapter */
+    private CacheInterface $descriptorCache;
 
     public function __construct(CacheInterface $files, CacheInterface $descriptors)
     {
@@ -73,7 +72,7 @@ class Locator
 
     public function locate(string $namespace = ''): Path
     {
-        $namespacePath = rtrim(sprintf('%s/%s', (string) $this->root(), $namespace), '/');
+        $namespacePath = rtrim(sprintf('%s/%s', $this->root(), $namespace), '/');
 
         if (!is_dir($namespacePath) && !@mkdir($namespacePath, 0777, true)) {
             $error = error_get_last();

--- a/src/phpDocumentor/Parser/Middleware/CacheMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/CacheMiddleware.php
@@ -31,15 +31,13 @@ use function unserialize;
 
 final class CacheMiddleware implements Middleware
 {
-    /** @var CacheInterface */
-    private $cache;
+    private CacheInterface $cache;
 
-    /** @var LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
     public function __construct(CacheInterface $files, LoggerInterface $logger)
     {
-        $this->cache  = $files;
+        $this->cache = $files;
         $this->logger = $logger;
     }
 
@@ -47,13 +45,11 @@ final class CacheMiddleware implements Middleware
      * Executes this middle ware class.
      * A middle ware class MUST return a File object or call the $next callable.
      *
-     * @param callable(Command): object $next
-     *
-     * @return File
+     * @param callable(Command): File $next
      *
      * @throws InvalidArgumentException
      */
-    public function execute(Command $command, callable $next): object
+    public function execute(Command $command, callable $next): File
     {
         Assert::isInstanceOf($command, CreateCommand::class);
 
@@ -69,6 +65,10 @@ final class CacheMiddleware implements Middleware
             }
         );
 
-        return unserialize(base64_decode($cacheResponse));
+        $unserializedObject = unserialize(base64_decode($cacheResponse));
+
+        Assert::isInstanceOf($unserializedObject, File::class);
+
+        return $unserializedObject;
     }
 }

--- a/src/phpDocumentor/Pipeline/Stage/Cache/PurgeCachesWhenForced.php
+++ b/src/phpDocumentor/Pipeline/Stage/Cache/PurgeCachesWhenForced.php
@@ -19,14 +19,9 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 
 final class PurgeCachesWhenForced
 {
-    /** @var AdapterInterface  */
-    private $filesCache;
-
-    /** @var AdapterInterface  */
-    private $descriptorsCache;
-
-    /** @var LoggerInterface  */
-    private $logger;
+    private AdapterInterface $filesCache;
+    private AdapterInterface $descriptorsCache;
+    private LoggerInterface $logger;
 
     public function __construct(
         AdapterInterface $filesCache,

--- a/src/phpDocumentor/Pipeline/Stage/Parser/ParseFiles.php
+++ b/src/phpDocumentor/Pipeline/Stage/Parser/ParseFiles.php
@@ -54,7 +54,7 @@ final class ParseFiles
 
         $builder = $payload->getBuilder();
         $builder->setApiSpecification($apiConfig);
-        $builder->setVisibility($apiConfig->calculateVisiblity());
+
         $encoding = $apiConfig['encoding'] ?? '';
         if ($encoding) {
             $this->reEncodingMiddleware->withEncoding($encoding);
@@ -66,6 +66,7 @@ final class ParseFiles
 
         $this->log('Parsing files', LogLevel::NOTICE);
         $project = $this->parser->parse($payload->getFiles());
+
         $payload->getBuilder()->createApiDocumentationSet($project);
 
         return $payload;

--- a/tests/unit/phpDocumentor/ApplicationTest.php
+++ b/tests/unit/phpDocumentor/ApplicationTest.php
@@ -15,9 +15,6 @@ namespace phpDocumentor;
 
 use PHPUnit\Framework\TestCase;
 
-use function file_get_contents;
-use function trim;
-
 /**
  * @coversDefaultClass \phpDocumentor\Application
  * @covers ::__construct
@@ -25,11 +22,4 @@ use function trim;
  */
 final class ApplicationTest extends TestCase
 {
-    /**
-     * @covers ::VERSION
-     */
-    public function testItReturnsTheVersionNumberFromTheVersionFile(): void
-    {
-        $this->assertSame(trim(file_get_contents(__DIR__ . '/../../../VERSION')), Application::VERSION());
-    }
 }


### PR DESCRIPTION
In issue https://github.com/phpDocumentor/phpDocumentor/issues/3147, it was noted that there might very well be caching issues at play after a version upgrade. Since in the past we had a mechanism to force a cache purge after updating phpDocumentor, I dived into the caching mechanism to see if that was broken.

I found that the caching mechanism indeed no longer purges after a version change, this PR will reintroduce that behaviour and add extra documentation on how caching works.

TODO

- [x] Make version number available to purging mechanism
- [x] Add version number to cache namespace, if the version changes the cache is 'empty'
- [x] Write cache docs