### PR TITLE
When typing an array, show that in docs

### DIFF
--- a/src/phpDocumentor/Configuration/VersionSpecification.php
+++ b/src/phpDocumentor/Configuration/VersionSpecification.php
@@ -15,14 +15,13 @@ namespace phpDocumentor\Configuration;
 
 class VersionSpecification
 {
-    /** @var string */
-    private $number;
+    private string $number;
 
-    /** @var array<int, ApiSpecification> */
-    public $api;
+    /** @var array<array-key, ApiSpecification> */
+    public array $api = [];
 
     /** @var array<mixed>|null */
-    public $guides;
+    public ?array $guides = null;
 
     /**
      * @param array<int, ApiSpecification> $api

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/PropertyAssembler.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor\Builder\Reflector;
 
+use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\PropertyDescriptor;
+use phpDocumentor\Descriptor\Tag\VarDescriptor;
 use phpDocumentor\Reflection\Php\Property;
 
 use function strlen;
@@ -49,7 +51,22 @@ class PropertyAssembler extends AssemblerAbstract
         $this->assembleDocBlock($data->getDocBlock(), $propertyDescriptor);
         $propertyDescriptor->setStartLocation($data->getLocation());
         $propertyDescriptor->setEndLocation($data->getEndLocation());
+        $this->overwriteTypeFromDocBlock($propertyDescriptor);
 
         return $propertyDescriptor;
+    }
+
+    private function overwriteTypeFromDocBlock(PropertyDescriptor $propertyDescriptor): void
+    {
+        /** @var Collection<VarDescriptor> $varTags */
+        $varTags = $propertyDescriptor->getTags()
+            ->fetch('var', new Collection())
+            ->filter(VarDescriptor::class);
+
+        if ($varTags->count() !== 1) {
+            return;
+        }
+
+        $propertyDescriptor->setType($varTags[0]->getType());
     }
 }


### PR DESCRIPTION
Properties that are arrays need to be typed using a DocBlock; but when a
typehint _and_ a DocBlock was specified; the contents of the DocBlock's
var tag was gone.

This change will introduce similar behaviour to the ArgumentAssembler by
overriding the type of the Descriptor from that of the found var tag.

I did bake in that it will only do that when there is 1 var tag; when
there are none or multiple it will not do this to prevent issues.

Fixes #3155 