### PR TITLE
Line numbers show 0 with InvalidTag issues

### DIFF
--- a/src/phpDocumentor/Descriptor/Collection.php
+++ b/src/phpDocumentor/Descriptor/Collection.php
@@ -23,6 +23,7 @@ use ReturnTypeWillChange;
 use Webmozart\Assert\Assert;
 
 use function array_filter;
+use function array_key_first;
 use function array_merge;
 use function count;
 
@@ -113,6 +114,18 @@ class Collection implements Countable, IteratorAggregate, ArrayAccess
         }
 
         return $this->offsetGet($index);
+    }
+
+    /**
+     * @return ?T
+     */
+    public function first()
+    {
+        if (count($this->items) === 0) {
+            return null;
+        }
+
+        return $this->items[array_key_first($this->items)];
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/DescriptorAbstract.php
+++ b/src/phpDocumentor/Descriptor/DescriptorAbstract.php
@@ -18,6 +18,7 @@ use phpDocumentor\Descriptor\Tag\AuthorDescriptor;
 use phpDocumentor\Descriptor\Validation\Error;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Location;
+use Webmozart\Assert\Assert;
 
 use function lcfirst;
 use function strpos;
@@ -430,8 +431,8 @@ abstract class DescriptorAbstract implements Filterable
             }
         }
 
-        /** @var Error $error */
         foreach ($errors as $error) {
+            Assert::isInstanceOf($error, Error::class);
             if ($error->getLine() !== 0) {
                 continue;
             }

--- a/src/phpDocumentor/Descriptor/DescriptorAbstract.php
+++ b/src/phpDocumentor/Descriptor/DescriptorAbstract.php
@@ -430,6 +430,20 @@ abstract class DescriptorAbstract implements Filterable
             }
         }
 
+        /** @var Error $error */
+        foreach ($errors as $error) {
+            if ($error->getLine() !== 0) {
+                continue;
+            }
+
+            $startLocation = $this->getStartLocation();
+            if ($startLocation === null) {
+                continue;
+            }
+
+            $error->setLine($startLocation->getLineNumber());
+        }
+
         return $errors;
     }
 

--- a/src/phpDocumentor/Descriptor/Validation/Error.php
+++ b/src/phpDocumentor/Descriptor/Validation/Error.php
@@ -51,6 +51,11 @@ class Error
         return $this->line;
     }
 
+    public function setLine(int $line): void
+    {
+        $this->line = $line;
+    }
+
     public function getSeverity(): string
     {
         return $this->severity;

--- a/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/CollectionTest.php
@@ -41,7 +41,7 @@ final class CollectionTest extends TestCase
     {
         $fixture = new Collection();
 
-        $this->assertEmpty($fixture->getAll());
+        self::assertEmpty($fixture->getAll());
     }
 
     /**
@@ -52,7 +52,7 @@ final class CollectionTest extends TestCase
         $expected = [1, 2];
         $fixture = new Collection($expected);
 
-        $this->assertEquals($expected, $fixture->getAll());
+        self::assertEquals($expected, $fixture->getAll());
     }
 
     /**
@@ -65,11 +65,11 @@ final class CollectionTest extends TestCase
 
         $this->fixture->add('abc');
 
-        $this->assertEquals($expected, $this->fixture->getAll());
+        self::assertEquals($expected, $this->fixture->getAll());
 
         $this->fixture->add('def');
 
-        $this->assertEquals($expectedSecondRun, $this->fixture->getAll());
+        self::assertEquals($expectedSecondRun, $this->fixture->getAll());
     }
 
     /**
@@ -81,15 +81,15 @@ final class CollectionTest extends TestCase
         $expected = ['z' => 'abc'];
         $expectedSecondRun = ['z' => 'abc', 'y' => 'def'];
 
-        $this->assertEquals([], $this->fixture->getAll());
+        self::assertEquals([], $this->fixture->getAll());
 
         $this->fixture->set('z', 'abc');
 
-        $this->assertEquals($expected, $this->fixture->getAll());
+        self::assertEquals($expected, $this->fixture->getAll());
 
         $this->fixture->set('y', 'def');
 
-        $this->assertEquals($expectedSecondRun, $this->fixture->getAll());
+        self::assertEquals($expectedSecondRun, $this->fixture->getAll());
     }
 
     /**
@@ -118,13 +118,13 @@ final class CollectionTest extends TestCase
     public function testRetrievalOfItems(): void
     {
         $this->fixture['a'] = 'abc';
-        $this->assertEquals('abc', $this->fixture->__get('a'));
-        $this->assertEquals('abc', $this->fixture['a']);
-        $this->assertEquals('abc', $this->fixture->get('a'));
-        $this->assertCount(1, $this->fixture);
+        self::assertEquals('abc', $this->fixture->__get('a'));
+        self::assertEquals('abc', $this->fixture['a']);
+        self::assertEquals('abc', $this->fixture->get('a'));
+        self::assertCount(1, $this->fixture);
 
-        $this->assertEquals('def', $this->fixture->fetch(1, 'def'));
-        $this->assertCount(2, $this->fixture);
+        self::assertEquals('def', $this->fixture->fetch(1, 'def'));
+        self::assertCount(2, $this->fixture);
     }
 
     /**
@@ -133,7 +133,18 @@ final class CollectionTest extends TestCase
     public function testRetrieveAllItems(): void
     {
         $this->fixture['a'] = 'abc';
-        $this->assertSame(['a' => 'abc'], $this->fixture->getAll());
+        self::assertSame(['a' => 'abc'], $this->fixture->getAll());
+    }
+
+    /**
+     * @covers ::first
+     */
+    public function testRetrieveFirstItem(): void
+    {
+        $this->fixture['a'] = 'abc';
+        $this->fixture['b'] = 'def';
+
+        self::assertSame('abc', $this->fixture->first());
     }
 
     /**
@@ -142,8 +153,8 @@ final class CollectionTest extends TestCase
     public function testGetIterator(): void
     {
         $this->fixture['a'] = 'abc';
-        $this->assertInstanceOf('ArrayIterator', $this->fixture->getIterator());
-        $this->assertSame(['a' => 'abc'], $this->fixture->getIterator()->getArrayCopy());
+        self::assertInstanceOf('ArrayIterator', $this->fixture->getIterator());
+        self::assertSame(['a' => 'abc'], $this->fixture->getIterator()->getArrayCopy());
     }
 
     /**
@@ -152,23 +163,23 @@ final class CollectionTest extends TestCase
      */
     public function testCountReturnsTheNumberOfElements(): void
     {
-        $this->assertCount(0, $this->fixture);
-        $this->assertEquals(0, $this->fixture->count());
+        self::assertCount(0, $this->fixture);
+        self::assertEquals(0, $this->fixture->count());
 
         $this->fixture[0] = 'abc';
 
-        $this->assertCount(1, $this->fixture);
-        $this->assertEquals(1, $this->fixture->count());
+        self::assertCount(1, $this->fixture);
+        self::assertEquals(1, $this->fixture->count());
 
         $this->fixture[1] = 'def';
 
-        $this->assertCount(2, $this->fixture);
-        $this->assertEquals(2, $this->fixture->count());
+        self::assertCount(2, $this->fixture);
+        self::assertEquals(2, $this->fixture->count());
 
         unset($this->fixture[0]);
 
-        $this->assertCount(1, $this->fixture);
-        $this->assertEquals(1, $this->fixture->count());
+        self::assertCount(1, $this->fixture);
+        self::assertEquals(1, $this->fixture->count());
     }
 
     /**
@@ -179,11 +190,11 @@ final class CollectionTest extends TestCase
         $this->fixture[1] = 'a';
         $this->fixture[2] = 'b';
 
-        $this->assertCount(2, $this->fixture);
+        self::assertCount(2, $this->fixture);
 
         $this->fixture->clear();
 
-        $this->assertCount(0, $this->fixture);
+        self::assertCount(0, $this->fixture);
     }
 
     /**
@@ -191,13 +202,13 @@ final class CollectionTest extends TestCase
      */
     public function testIfExistingElementsAreDetected(): void
     {
-        $this->assertArrayNotHasKey(0, $this->fixture);
-        $this->assertFalse($this->fixture->offsetExists(0));
+        self::assertArrayNotHasKey(0, $this->fixture);
+        self::assertFalse($this->fixture->offsetExists(0));
 
         $this->fixture[0] = 'abc';
 
-        $this->assertArrayHasKey(0, $this->fixture);
-        $this->assertTrue($this->fixture->offsetExists(0));
+        self::assertArrayHasKey(0, $this->fixture);
+        self::assertTrue($this->fixture->offsetExists(0));
     }
 
     /**
@@ -214,7 +225,7 @@ final class CollectionTest extends TestCase
 
         $result = $this->fixture->merge($collection2);
 
-        $this->assertSame($expected, $result->getAll());
+        self::assertSame($expected, $result->getAll());
     }
 
     /**
@@ -230,6 +241,6 @@ final class CollectionTest extends TestCase
 
         $result = $this->fixture->filter(stdClass::class)->getAll();
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/FileDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/FileDescriptorTest.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Descriptor;
 
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
+use phpDocumentor\Descriptor\Validation\Error;
 
 use function array_merge;
 
@@ -49,17 +50,17 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testInitializesWithEmptyCollections(): void
     {
-        $this->assertSame(self::EXAMPLE_HASH, $this->fixture->getHash());
+        self::assertSame(self::EXAMPLE_HASH, $this->fixture->getHash());
 
-        $this->assertInstanceOf(Collection::class, $this->fixture->getNamespaceAliases());
-        $this->assertInstanceOf(Collection::class, $this->fixture->getIncludes());
-        $this->assertInstanceOf(Collection::class, $this->fixture->getConstants());
-        $this->assertInstanceOf(Collection::class, $this->fixture->getFunctions());
-        $this->assertInstanceOf(Collection::class, $this->fixture->getClasses());
-        $this->assertInstanceOf(Collection::class, $this->fixture->getInterfaces());
-        $this->assertInstanceOf(Collection::class, $this->fixture->getTraits());
-        $this->assertInstanceOf(Collection::class, $this->fixture->getEnums());
-        $this->assertInstanceOf(Collection::class, $this->fixture->getMarkers());
+        self::assertInstanceOf(Collection::class, $this->fixture->getNamespaceAliases());
+        self::assertInstanceOf(Collection::class, $this->fixture->getIncludes());
+        self::assertInstanceOf(Collection::class, $this->fixture->getConstants());
+        self::assertInstanceOf(Collection::class, $this->fixture->getFunctions());
+        self::assertInstanceOf(Collection::class, $this->fixture->getClasses());
+        self::assertInstanceOf(Collection::class, $this->fixture->getInterfaces());
+        self::assertInstanceOf(Collection::class, $this->fixture->getTraits());
+        self::assertInstanceOf(Collection::class, $this->fixture->getEnums());
+        self::assertInstanceOf(Collection::class, $this->fixture->getMarkers());
     }
 
     /**
@@ -68,7 +69,7 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testGetHash(): void
     {
-        $this->assertSame(self::EXAMPLE_HASH, $this->fixture->getHash());
+        self::assertSame(self::EXAMPLE_HASH, $this->fixture->getHash());
     }
 
     /**
@@ -77,11 +78,11 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetPath(): void
     {
-        $this->assertSame('', $this->fixture->getPath());
+        self::assertSame('', $this->fixture->getPath());
 
         $this->fixture->setPath(self::EXAMPLE_PATH);
 
-        $this->assertSame(self::EXAMPLE_PATH, $this->fixture->getPath());
+        self::assertSame(self::EXAMPLE_PATH, $this->fixture->getPath());
     }
 
     /**
@@ -90,11 +91,11 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetSource(): void
     {
-        $this->assertNull($this->fixture->getSource());
+        self::assertNull($this->fixture->getSource());
 
         $this->fixture->setSource(self::EXAMPLE_SOURCE);
 
-        $this->assertSame(self::EXAMPLE_SOURCE, $this->fixture->getSource());
+        self::assertSame(self::EXAMPLE_SOURCE, $this->fixture->getSource());
     }
 
     /**
@@ -103,14 +104,14 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetNamespaceAliases(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getNamespaceAliases());
+        self::assertInstanceOf(Collection::class, $this->fixture->getNamespaceAliases());
 
         $mockInstance = m::mock(Collection::class);
         $mock = $mockInstance;
 
         $this->fixture->setNamespaceAliases($mock);
 
-        $this->assertSame($mockInstance, $this->fixture->getNamespaceAliases());
+        self::assertSame($mockInstance, $this->fixture->getNamespaceAliases());
     }
 
     /**
@@ -119,14 +120,14 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetIncludes(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getIncludes());
+        self::assertInstanceOf(Collection::class, $this->fixture->getIncludes());
 
         $mockInstance = m::mock(Collection::class);
         $mock = $mockInstance;
 
         $this->fixture->setIncludes($mock);
 
-        $this->assertSame($mockInstance, $this->fixture->getIncludes());
+        self::assertSame($mockInstance, $this->fixture->getIncludes());
     }
 
     /**
@@ -135,14 +136,14 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetConstants(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getConstants());
+        self::assertInstanceOf(Collection::class, $this->fixture->getConstants());
 
         $mockInstance = m::mock(Collection::class);
         $mock = $mockInstance;
 
         $this->fixture->setConstants($mock);
 
-        $this->assertSame($mockInstance, $this->fixture->getConstants());
+        self::assertSame($mockInstance, $this->fixture->getConstants());
     }
 
     /**
@@ -151,14 +152,14 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetFunctions(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getFunctions());
+        self::assertInstanceOf(Collection::class, $this->fixture->getFunctions());
 
         $mockInstance = m::mock(Collection::class);
         $mock = $mockInstance;
 
         $this->fixture->setFunctions($mock);
 
-        $this->assertSame($mockInstance, $this->fixture->getFunctions());
+        self::assertSame($mockInstance, $this->fixture->getFunctions());
     }
 
     /**
@@ -167,14 +168,14 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetClasses(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getClasses());
+        self::assertInstanceOf(Collection::class, $this->fixture->getClasses());
 
         $mockInstance = m::mock(Collection::class);
         $mock = $mockInstance;
 
         $this->fixture->setClasses($mock);
 
-        $this->assertSame($mockInstance, $this->fixture->getClasses());
+        self::assertSame($mockInstance, $this->fixture->getClasses());
     }
 
     /**
@@ -183,14 +184,14 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetInterfaces(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getInterfaces());
+        self::assertInstanceOf(Collection::class, $this->fixture->getInterfaces());
 
         $mockInstance = m::mock(Collection::class);
         $mock = $mockInstance;
 
         $this->fixture->setInterfaces($mock);
 
-        $this->assertSame($mockInstance, $this->fixture->getInterfaces());
+        self::assertSame($mockInstance, $this->fixture->getInterfaces());
     }
 
     /**
@@ -199,14 +200,14 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetTraits(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getTraits());
+        self::assertInstanceOf(Collection::class, $this->fixture->getTraits());
 
         $mockInstance = m::mock(Collection::class);
         $mock = $mockInstance;
 
         $this->fixture->setTraits($mock);
 
-        $this->assertSame($mockInstance, $this->fixture->getTraits());
+        self::assertSame($mockInstance, $this->fixture->getTraits());
     }
 
     /**
@@ -215,14 +216,14 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetEnums(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getEnums());
+        self::assertInstanceOf(Collection::class, $this->fixture->getEnums());
 
         $mockInstance = m::mock(Collection::class);
         $mock = $mockInstance;
 
         $this->fixture->setEnums($mock);
 
-        $this->assertSame($mockInstance, $this->fixture->getEnums());
+        self::assertSame($mockInstance, $this->fixture->getEnums());
     }
 
     /**
@@ -231,14 +232,14 @@ final class FileDescriptorTest extends MockeryTestCase
      */
     public function testSetAndGetMarkers(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getMarkers());
+        self::assertInstanceOf(Collection::class, $this->fixture->getMarkers());
 
         $mockInstance = m::mock(Collection::class);
         $mock = $mockInstance;
 
         $this->fixture->setMarkers($mock);
 
-        $this->assertSame($mockInstance, $this->fixture->getMarkers());
+        self::assertSame($mockInstance, $this->fixture->getMarkers());
     }
 
     /**
@@ -248,18 +249,19 @@ final class FileDescriptorTest extends MockeryTestCase
     public function testIfErrorsAreInitializedToAnEmptyCollectionOnInstantiation(): void
     {
         // construct
-        $this->assertInstanceOf(Collection::class, $this->fixture->getAllErrors());
+        self::assertInstanceOf(Collection::class, $this->fixture->getAllErrors());
 
         // default returns empty array
-        $this->assertObjectHasAttribute('items', $this->fixture->getAllErrors());
+        self::assertObjectHasAttribute('items', $this->fixture->getAllErrors());
 
         $items = $this->fixture->getAllErrors()->getAll();
-        $this->assertEmpty($items);
+        self::assertEmpty($items);
     }
 
     /**
      * @covers ::__construct
      * @covers ::getAllErrors
+     * @todo Split this test into its various scenario's instead of one big lump
      */
     public function testGetAllErrors(): void
     {
@@ -279,18 +281,18 @@ final class FileDescriptorTest extends MockeryTestCase
          */
 
         // setup error list
-        $errorGlobal = ['error-global'];
-        $errorClasses = ['error-class'];
-        $errorClassMethods = ['error-class-method'];
-        $errorClassConstants = ['error-class-constant'];
-        $errorClassProperties = ['error-class-property'];
-        $errorInterfaces = ['error-interface'];
-        $errorInterfacesConstants = ['error-interface-constant'];
-        $errorInterfacesMethods = ['error-interface-method'];
-        $errorTraits = ['error-traits'];
-        $errorTraitsProperties = ['error-traits-property'];
-        $errorTraitsMethods = ['error-traits-method'];
-        $errorFunctions = ['error-functions'];
+        $errorGlobal = [new Error('error', 'error-global', 10)];
+        $errorClasses = [new Error('error', 'error-class', 10)];
+        $errorClassMethods = [new Error('error', 'error-class-method', 10)];
+        $errorClassConstants = [new Error('error', 'error-class-constant', 10)];
+        $errorClassProperties = [new Error('error', 'error-class-property', 10)];
+        $errorInterfaces = [new Error('error', 'error-interface', 10)];
+        $errorInterfacesConstants = [new Error('error', 'error-interface-constant', 10)];
+        $errorInterfacesMethods = [new Error('error', 'error-interface-method', 10)];
+        $errorTraits = [new Error('error', 'error-traits', 10)];
+        $errorTraitsProperties = [new Error('error', 'error-traits-property', 10)];
+        $errorTraitsMethods = [new Error('error', 'error-traits-method', 10)];
+        $errorFunctions = [new Error('error', 'error-functions', 10)];
 
         // setup global check
         $collection = new Collection($errorGlobal);
@@ -378,6 +380,6 @@ final class FileDescriptorTest extends MockeryTestCase
             $errorTraitsProperties
         );
 
-        $this->assertSame($expectedErrors, $this->fixture->getAllErrors()->getAll());
+        self::assertSame($expectedErrors, $this->fixture->getAllErrors()->getAll());
     }
 }


### PR DESCRIPTION
The InvalidTag does not know its line number or location and as such the
errors overview in the generated documentation shows a line number of 0.
This is not quite helpful.

To improve the situation, I have introduced that any line number of 0
will be overridden with the containing element's line number when you
retrieve the error listing.

Fixes #3057