### PR TITLE
Windows tests keep failing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -91,7 +91,7 @@ jobs:
         composer-options: --optimize-autoloader
 
     - name: Install PHPUnit extensions
-      run: mkdir -p tools/phpunit.d && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
+      run: mkdir -p tools/phpunit.d && curl https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar
 
     - name: PHPUnit
       run: phpunit --testsuite=unit
@@ -329,7 +329,7 @@ jobs:
         composer-options: --optimize-autoloader
 
     - name: Install PHPUnit extensions
-      run: mkdir -p tools/phpunit.d && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
+      run: mkdir -p tools/phpunit.d && curl https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar
 
     - name: Run PHPUnit
       run: phpunit --testsuite=unit,integration

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,12 +6,12 @@ on:
 # Allow manually triggering the workflow.
   workflow_dispatch:
 name: Qa workflow
+
 env:
   extensions: mbstring, intl, iconv, libxml, dom, json, simplexml, zlib, fileinfo
   key: cache-v1 # can be any string, change to clear the extension cache.
   defaultPHPVersion: '7.4'
-  phiveGPGKeys: 4AA394086372C20A,D2CCAC42F6295E7D,E82B2FB314E9906E,8A03EA3B385DBAA1,12CE0F1D262429A5,033E5F8D801A2F8D
-  phiveHome: $GITHUB_WORKSPACE/.phive
+
 jobs:
 
   setup:
@@ -79,29 +79,21 @@ jobs:
         php-version: ${{ env.defaultPHPVersion }}
         extensions: ${{ env.extensions }}
         ini-values: memory_limit=2G, display_errors=On, error_reporting=-1
-        tools: pecl, phive
+        tools: pecl, phpunit:9.5
 
     - name: Install Composer dependencies & cache dependencies
       uses: "ramsey/composer-install@v2"
       with:
         composer-options: --optimize-autoloader
 
-    - name: Restore/cache phive folder
-      uses: actions/cache@v3
-      with:
-        path: tools
-        key: all-build-phive-${{ hashFiles('phive.xml') }}
-        restore-keys: |
-          all-build-phive-${{ hashFiles('phive.xml') }}
-          all-build-phive-
-
-    - name: Install PHAR dependencies
+    - name: Install PHPUnit extensions
       env:
         GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: phive --no-progress install --copy --trust-gpg-keys ${{ env.phiveGPGKeys }} --force-accept-unsigned phpunit jaapio/prophecy-phpunit && mkdir -p tools/phpunit.d && mv tools/prophecy-phpunit tools/phpunit.d/prophecy-phpunit.phar
+      run: mkdir -p tools/phpunit.d \
+        && wget -O tools/phpunit.d/prophecy-phpunit https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
 
     - name: PHPUnit
-      run: php tools/phpunit --testsuite=unit
+      run: phpunit --testsuite=unit
 
     - name: Quick check code coverage level
       run: php tests/coverage-checker.php 65
@@ -318,25 +310,21 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: ${{ env.extensions }}
         ini-values: memory_limit=2G, display_errors=On, error_reporting=-1
-        tools: pecl, phive
+        tools: pecl, phpunit:9.5
+
     - name: Install Composer dependencies & cache dependencies
       uses: "ramsey/composer-install@v2"
       with:
         composer-options: --optimize-autoloader
-    - name: Restore/cache phive folder
-      uses: actions/cache@v3
-      with:
-        path: tools
-        key: all-build-phive-${{ hashFiles('phive.xml') }}
-        restore-keys: |
-          all-build-phive-${{ hashFiles('phive.xml') }}
-          all-build-phive-
-    - name: Install PHAR dependencies
+
+    - name: Install PHPUnit extensions
       env:
         GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: phive --no-progress install --copy --trust-gpg-keys ${{ env.phiveGPGKeys }} --force-accept-unsigned phpunit jaapio/prophecy-phpunit  && mkdir -p tools/phpunit.d && mv tools/prophecy-phpunit tools/phpunit.d/prophecy-phpunit.phar
+      run: mkdir -p tools/phpunit.d \
+           && wget -O tools/phpunit.d/prophecy-phpunit https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
+
     - name: Run PHPUnit
-      run: php tools/phpunit --testsuite=unit,integration
+      run: phpunit --testsuite=unit,integration
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -91,7 +91,7 @@ jobs:
         composer-options: --optimize-autoloader
 
     - name: Install PHPUnit extensions
-      run: mkdir -p tools/phpunit.d && curl https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar
+      run: mkdir -p tools/phpunit.d && curl https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar && ls tools/phpunit.d
 
     - name: PHPUnit
       run: phpunit --testsuite=unit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -90,7 +90,7 @@ jobs:
       env:
         GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: mkdir -p tools/phpunit.d \
-        && wget -O tools/phpunit.d/prophecy-phpunit https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
+        && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
 
     - name: PHPUnit
       run: phpunit --testsuite=unit
@@ -321,7 +321,7 @@ jobs:
       env:
         GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: mkdir -p tools/phpunit.d \
-           && wget -O tools/phpunit.d/prophecy-phpunit https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
+           && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
 
     - name: Run PHPUnit
       run: phpunit --testsuite=unit,integration

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -329,7 +329,7 @@ jobs:
         composer-options: --optimize-autoloader
 
     - name: Install PHPUnit extensions
-      run: mkdir -p tools/phpunit.d && curl https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar
+      run: mkdir -p tools/phpunit.d && curl https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar && ls tools/phpunit.d
 
     - name: Run PHPUnit
       run: phpunit --testsuite=unit,integration

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -89,8 +89,7 @@ jobs:
     - name: Install PHPUnit extensions
       env:
         GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: mkdir -p tools/phpunit.d \
-        && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
+      run: mkdir -p tools/phpunit.d && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
 
     - name: PHPUnit
       run: phpunit --testsuite=unit
@@ -320,8 +319,7 @@ jobs:
     - name: Install PHPUnit extensions
       env:
         GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: mkdir -p tools/phpunit.d \
-           && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
+      run: mkdir -p tools/phpunit.d && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
 
     - name: Run PHPUnit
       run: phpunit --testsuite=unit,integration

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -91,7 +91,7 @@ jobs:
         composer-options: --optimize-autoloader
 
     - name: Install PHPUnit extensions
-      run: mkdir -p tools/phpunit.d && curl https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar && ls tools/phpunit.d
+      run: mkdir -p tools/phpunit.d && curl -sL https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar
 
     - name: PHPUnit
       run: phpunit --testsuite=unit
@@ -329,7 +329,7 @@ jobs:
         composer-options: --optimize-autoloader
 
     - name: Install PHPUnit extensions
-      run: mkdir -p tools/phpunit.d && curl https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar && ls tools/phpunit.d
+      run: mkdir -p tools/phpunit.d && curl -sL https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar
 
     - name: Run PHPUnit
       run: phpunit --testsuite=unit,integration

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: ${{ env.defaultPHPVersion }}
           extensions: ${{ env.extensions }}
@@ -75,6 +77,8 @@ jobs:
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         php-version: ${{ env.defaultPHPVersion }}
         extensions: ${{ env.extensions }}
@@ -87,8 +91,6 @@ jobs:
         composer-options: --optimize-autoloader
 
     - name: Install PHPUnit extensions
-      env:
-        GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: mkdir -p tools/phpunit.d && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
 
     - name: PHPUnit
@@ -142,6 +144,8 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: ${{ env.defaultPHPVersion }}
           extensions: ${{ env.extensions }}
@@ -184,6 +188,8 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: ${{ env.defaultPHPVersion }}
           extensions: ${{ env.extensions }}
@@ -223,6 +229,8 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: ${{ env.defaultPHPVersion }}
           extensions: ${{ env.extensions }}
@@ -297,14 +305,18 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: ${{ env.extensions }}
         key: ${{ env.key }}
+
     - name: Cache extensions
       uses: actions/cache@v3
       with:
         path: ${{ steps.cache-env.outputs.dir }}
         key: ${{ steps.cache-env.outputs.key }}
         restore-keys: ${{ steps.cache-env.outputs.key }}
+
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: ${{ env.extensions }}
@@ -317,8 +329,6 @@ jobs:
         composer-options: --optimize-autoloader
 
     - name: Install PHPUnit extensions
-      env:
-        GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: mkdir -p tools/phpunit.d && wget -O tools/phpunit.d/prophecy-phpunit.phar https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar
 
     - name: Run PHPUnit
@@ -355,6 +365,8 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: ${{ env.defaultPHPVersion }}
           extensions: ${{ env.extensions }}
@@ -415,6 +427,8 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: ${{ env.extensions }}
@@ -473,6 +487,8 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: ${{ env.extensions }}


### PR DESCRIPTION
I have removed phive from the build pipeline because it keeps giving
timeouts when running the windows tests. This is a combination of phive
having too strict a timeout apparently and the Windows runners of Github
Action being slow.

Even though it would be nice to keep Phive in the pipeline, I just
cannot keep the windows tests failing much longer and the only surefire
fix is to replace phive with oldschool tooling