### PR TITLE
Extend timeout for UML generation to 20mins

### DIFF
--- a/src/phpDocumentor/Transformer/Writer/Graph/PlantumlRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph/PlantumlRenderer.php
@@ -51,7 +51,7 @@ PUML;
             $this->plantUmlBinaryPath = 'plantuml';
         }
 
-        $process = new Process([$this->plantUmlBinaryPath, '-tsvg', $pumlFileLocation], __DIR__, null, null, 600.0);
+        $process = new Process([$this->plantUmlBinaryPath, '-tsvg', $pumlFileLocation], __DIR__, null, null, 1200.0);
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
Hello, we have a larger codebase with ~800 files (according to the parse process of phpdocumentor) and while executing this in the docker image on our CI system, we regularly run into timeouts from the UML process. After 10 minutes it simply aborts and the rendering process never finishes. This change here is the attempt to fix that.