### PR TITLE
Fix Code Block Options

### DIFF
--- a/docs/references/phpdoc/tags/var.rst
+++ b/docs/references/phpdoc/tags/var.rst
@@ -78,8 +78,8 @@ Another example is to document the variable in a foreach explicitly; many IDEs
 use this information to help you with auto-completion:
 
 .. code-block:: php
-
    :linenos:
+
     /** @var \Sqlite3 $sqlite */
     foreach ($connections as $sqlite) {
         // There should be no docblock here.
@@ -91,8 +91,8 @@ use this information to help you with auto-completion:
 Even compound class constant and property statements may be documented:
 
 .. code-block:: php
-
    :linenos:
+
     class Foo
     {
         /**


### PR DESCRIPTION
Currently `:linenos:` shows up in the code block. I checked all other pages for the same issue but didn't see anything.
![image](https://user-images.githubusercontent.com/3212673/185199619-50bbe9a5-4c6b-4025-8505-5d6ab952fb7b.png)
