### PR TITLE
Fix OutputHello Example Param Wording

### DIFF
--- a/docs/references/phpdoc/types.rst
+++ b/docs/references/phpdoc/types.rst
@@ -119,7 +119,7 @@ The following keywords are recognized:
        :linenos:
 
         /**
-         * @param boolean $quiet when true 'Hello world' is echo-ed.
+         * @param boolean $quiet when true 'Hello world' is not echo-ed.
          *
          * @return void
          */


### PR DESCRIPTION
Just a tiny one: fixed wording of `outputHello` example param description... it suggested that when `$quiet` was true it _would_ echo 'Hello World' when in actual fact, that's the opposite of what the example code does.