### PR TITLE
Fix issue with minimal directory

### DIFF
--- a/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
+++ b/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
@@ -76,7 +76,7 @@ final class PathNormalizingMiddleware implements MiddlewareInterface
             $version->setApi($apiConfigs);
 
             foreach ($version->getGuides() ?? [] as $key => $guide) {
-                $version->guides[$key]->withSource(
+                $version->guides[$key] = $version->guides[$key]->withSource(
                     $guide->source()->withDsn(
                         $guide->source()->dsn()->resolve($configDsn)
                     )
@@ -148,12 +148,22 @@ final class PathNormalizingMiddleware implements MiddlewareInterface
             $path = '/' . $path;
         }
 
-        return rtrim($path, '/');
+        $path = rtrim($path, '/');
+
+        if ($path === '') {
+            return '.';
+        }
+
+        return $path;
     }
 
     private function pathToGlobPattern(string $path): string
     {
         $path = $this->normalizePath($path);
+
+        if ($path === '.') {
+            return '/**/*';
+        }
 
         if (substr($path, -1) !== '*' && strpos($path, '.') === false) {
             $path .= '/**/*';

--- a/tests/integration/phpDocumentor/Configuration/data/phpDocumentor3XMLWithoutApi.xml
+++ b/tests/integration/phpDocumentor/Configuration/data/phpDocumentor3XMLWithoutApi.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ This file is part of phpDocumentor.
+  ~
+  ~  For the full copyright and license information, please view the LICENSE
+  ~  file that was distributed with this source code.
+  ~
+  ~  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+  ~  @link      https://phpdoc.org
+  -->
+
+<phpdocumentor
+        configVersion="3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://www.phpdoc.org"
+        xsi:noNamespaceSchemaLocation="phpdoc.xsd"
+>
+    <paths>
+        <output>file://build/docs</output>
+        <cache>/tmp/phpdoc-doc-cache</cache>
+    </paths>
+    <version number="1.0.0">
+        <folder>latest</folder>
+        <guide format="rst">
+            <source dsn=".">
+                <path>.</path>
+            </source>
+        </guide>
+    </version>
+    <template name="clean"/>
+</phpdocumentor>


### PR DESCRIPTION
The `.` directory should process the current directory. This didn't work for guides as they do not work with glob paths.