### PR TITLE
GH Actions: bust the cache semi-regularly

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,6 +49,8 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --optimize-autoloader
+          # Bust the cache at least once a month - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       - name: composer-require-checker
         run: composer-require-checker check --config-file $GITHUB_WORKSPACE/composer-require-config.json composer.json
@@ -89,6 +91,8 @@ jobs:
       uses: "ramsey/composer-install@v2"
       with:
         composer-options: --optimize-autoloader
+        # Bust the cache at least once a month - output format: YYYY-MM-DD.
+        custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
     - name: Install PHPUnit extensions
       run: mkdir -p tools/phpunit.d && curl -sL https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar
@@ -156,6 +160,8 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --optimize-autoloader
+          # Bust the cache at least once a month - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       - name: PHPStan
         uses: phpDocumentor/phpstan-ga@1.8
@@ -200,6 +206,8 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --optimize-autoloader
+          # Bust the cache at least once a month - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       - name: Psalm
         run: php bin/psalm.phar --output-format=github
@@ -243,6 +251,8 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --optimize-autoloader
+          # Bust the cache at least once a month - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       - name: warm cache
         uses: phpDocumentor/phar-ga@latest
@@ -327,6 +337,8 @@ jobs:
       uses: "ramsey/composer-install@v2"
       with:
         composer-options: --optimize-autoloader
+        # Bust the cache at least once a month - output format: YYYY-MM-DD.
+        custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
     - name: Install PHPUnit extensions
       run: mkdir -p tools/phpunit.d && curl -sL https://github.com/jaapio/prophecy-phpunit/releases/download/v2.2.0/prophecy-phpunit.phar --output tools/phpunit.d/prophecy-phpunit.phar
@@ -377,6 +389,8 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --optimize-autoloader
+          # Bust the cache at least once a month - output format: YYYY-MM-DD.
+          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       - name: Build example project template
         run: ./bin/phpdoc --template=${{ matrix.template }} -vvv --config=data/examples/MariosPizzeria/phpdoc.xml --target=build/${{ matrix.template }} --setting="guides.enabled=false"


### PR DESCRIPTION
Caches used in GH Actions do not get updated, they can only be replaced by a different cache with a different cache key.

Now the predefined Composer install action this repo is using already creates a pretty comprehensive cache key:

> `ramsey/composer-install` will auto-generate a cache key which is composed of
the following elements:
> * The OS image name, like `ubuntu-latest`.
> * The exact PHP version, like `8.1.11`.
> * The options passed via `composer-options`.
> * The dependency version setting as per `dependency-versions`.
> * The working directory as per `working-directory`.
> * A hash of the `composer.json` and/or `composer.lock` files.

This means that aside from other factors, the cache will always be busted when changes are made to the (committed) `composer.json` or the `composer.lock` file (if the latter exists in the repo).

For packages running on recent versions of PHP, it also means that the cache will automatically be busted once a month when a new PHP version comes out.

### The problem

For runs on older PHP versions which don't receive updates anymore, the cache will not be busted via new PHP version releases, so effectively, the cache will only be busted when a change is made to the `composer.json`/`composer.lock` file - which may not happen that frequently on low-traffic repos.

But... packages _in use_ on those older PHP versions - especially dependencies of declared dependencies - may still release new versions and those new versions will not exist in the cache and will need to be downloaded each time the action is run and over time the cache gets less and less relevant as more and more packages will need to be downloaded for each run.

### The solution

To combat this issue, a new `custom-cache-suffix` option has been added to the Composer install action in version 2.2.0. This new option allows for providing some extra information to add to the cache key, which allows for busting the cache based on your own additional criteria.

This commit implements the use of this `custom-cache-suffix` option for all relevant workflows in this repo.

Refs:
* https://github.com/ramsey/composer-install/#custom-cache-suffix
* https://github.com/ramsey/composer-install/releases/tag/2.2.0