### PR TITLE
GH#3307 Make readonly mutator for class available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ pre-commit-test: test phpcs phpstan psalm composer-require-checker
 
 .PHONY: composer
 composer:
-	${.DOCKER_COMPOSE_RUN} --entrypoint=/usr/bin/composer phpdoc install
+	docker run -it --rm -v${CURDIR}:/opt/project -w /opt/project composer:2 install
 
 .PHONY: composer-mirror
 composer-mirror:

--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,10 @@ shell:
 node_modules/.bin/cypress:
 	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/opt/phpdoc/var/cache/.cypress" -v ${CURDIR}:/opt/phpdoc -w /opt/phpdoc node npm install
 
-build/default/index.html: data/examples/MariosPizzeria/**/*
+build/default/index.html: data/examples/MariosPizzeria/**/* data/templates/default/**/*
 	${.DOCKER_COMPOSE_RUN} phpdoc --config=data/examples/MariosPizzeria/phpdoc.xml --template=default --target=build/default --force
 
-build/clean/index.html: data/examples/MariosPizzeria/**/*
+build/clean/index.html: data/examples/MariosPizzeria/**/* data/templates/clean/**/*
 	${.DOCKER_COMPOSE_RUN} phpdoc --config=data/examples/MariosPizzeria/phpdoc.xml --template=clean --target=build/clean --force
 
 .PHONY: docs

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "phpdocumentor/guides-markdown": "*@dev",
         "phpdocumentor/guides-restructured-text": "*@dev",
         "phpdocumentor/json-path": "*@dev",
-        "phpdocumentor/reflection": "^5.2",
+        "phpdocumentor/reflection": "^5.3",
         "phpdocumentor/reflection-common": "^2.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpdocumentor/type-resolver": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "league/tactician-bundle": "^1.2",
         "league/uri": "~6.5.0",
         "league/uri-interfaces": "^2.0",
+        "nikic/php-parser": "^4.14",
         "phpdocumentor/flyfinder": "^1.0",
         "phpdocumentor/graphviz": "^2.0",
         "phpdocumentor/guides": "*@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e26554193be3302ecc2036063b5e4e1",
+    "content-hash": "a4a7155bdd0ee75452489caf583ba72c",
     "packages": [
         {
             "name": "cypresslab/php-curry",
@@ -1467,16 +1467,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.2",
+            "version": "v4.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
+                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
                 "shasum": ""
             },
             "require": {
@@ -1517,9 +1517,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
             },
-            "time": "2021-11-30T19:35:32+00:00"
+            "time": "2022-11-12T15:38:23+00:00"
         },
         {
             "name": "parsica-php/parsica",
@@ -1709,7 +1709,7 @@
         },
         {
             "name": "phpdocumentor/guides",
-            "version": "dev-villfa-feat/method-tag-returns-reference",
+            "version": "dev-main",
             "dist": {
                 "type": "path",
                 "url": "incubator/guides",
@@ -1753,7 +1753,7 @@
         },
         {
             "name": "phpdocumentor/guides-markdown",
-            "version": "dev-villfa-feat/method-tag-returns-reference",
+            "version": "dev-main",
             "dist": {
                 "type": "path",
                 "url": "incubator/guides-markdown",
@@ -1786,7 +1786,7 @@
         },
         {
             "name": "phpdocumentor/guides-restructured-text",
-            "version": "dev-villfa-feat/method-tag-returns-reference",
+            "version": "dev-main",
             "dist": {
                 "type": "path",
                 "url": "incubator/guides-restructured-text",
@@ -1821,7 +1821,7 @@
         },
         {
             "name": "phpdocumentor/json-path",
-            "version": "dev-villfa-feat/method-tag-returns-reference",
+            "version": "dev-main",
             "dist": {
                 "type": "path",
                 "url": "incubator/json-path",
@@ -1862,35 +1862,42 @@
         },
         {
             "name": "phpdocumentor/reflection",
-            "version": "5.2.0",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/Reflection.git",
-                "reference": "936e4dde326e6ba42feb46cb7a89688a9425356f"
+                "reference": "9887ef960405afc97e0e3da48be3656fa4a81a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/936e4dde326e6ba42feb46cb7a89688a9425356f",
-                "reference": "936e4dde326e6ba42feb46cb7a89688a9425356f",
+                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/9887ef960405afc97e0e3da48be3656fa4a81a13",
+                "reference": "9887ef960405afc97e0e3da48be3656fa4a81a13",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.13",
-                "php": ">=7.2",
+                "php": "^7.4|8.0.*|8.1.*",
                 "phpdocumentor/reflection-common": "^2.1",
                 "phpdocumentor/reflection-docblock": "^5",
                 "phpdocumentor/type-resolver": "^1.2",
-                "psr/log": "~1.0",
                 "webmozart/assert": "^1.7"
             },
             "require-dev": {
                 "mikey179/vfsstream": "~1.2",
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.5.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-php-parser": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.14.5",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-4.x": "5.0.x-dev"
+                    "dev-5.x": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -1912,9 +1919,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpDocumentor/Reflection/issues",
-                "source": "https://github.com/phpDocumentor/Reflection/tree/5.2.0"
+                "source": "https://github.com/phpDocumentor/Reflection/tree/5.3.0"
             },
-            "time": "2022-04-02T19:58:37+00:00"
+            "time": "2022-10-14T08:02:22+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -43,6 +43,24 @@ describe('Classes', function() {
             .contains('This class provides an interface through which you can order pizza\'s and pasta\'s from Mario\'s Pizzeria.');
     });
 
+    it('Shows a class is readonly', function() {
+        cy.visit('build/default/classes/Marios-Pizza.html');
+        cy.get('.phpdocumentor-element.-class .phpdocumentor-label')
+            .contains('Read only');
+    });
+
+    it('Shows a class is final', function() {
+        cy.visit('build/default/classes/Marios-Pizza.html');
+        cy.get('.phpdocumentor-element.-class .phpdocumentor-label')
+            .contains('Final');
+    });
+
+    it('Shows a class is abstract', function() {
+        cy.visit('build/default/classes/Marios-Pizza-Topping.html');
+        cy.get('.phpdocumentor-element.-class .phpdocumentor-label')
+            .contains('Abstract');
+    });
+
     describe ('Shows tags', function () {
         it('Shows the tags section', function () {
             cy.get('.phpdocumentor-tag-list__heading')

--- a/data/examples/MariosPizzeria/src/Pizza.php
+++ b/data/examples/MariosPizzeria/src/Pizza.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Marios;
 
 use ArrayObject;
-use JetBrains\PhpStorm\Pure;
 
 /**
  * @package Domain
  */
-final class Pizza implements Product
+final readonly class Pizza implements Product
 {
     use SharedTrait { sayHello as private myPrivateHello; }
 

--- a/data/examples/MariosPizzeria/src/Pizza/Topping.php
+++ b/data/examples/MariosPizzeria/src/Pizza/Topping.php
@@ -2,7 +2,7 @@
 
 namespace Marios\Pizza;
 
-final class Topping
+abstract class Topping
 {
     /**
      * @api

--- a/data/examples/MariosPizzeria/src/Pizza/Toppings/Pepperoni.php
+++ b/data/examples/MariosPizzeria/src/Pizza/Toppings/Pepperoni.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Marios\Pizza\Toppings;
+
+use Marios\Pizza\Topping;
+
+final class Pepperoni extends Topping
+{
+
+}

--- a/data/templates/default/components/class-title.html.twig
+++ b/data/templates/default/components/class-title.html.twig
@@ -36,3 +36,17 @@
         </span>
     {% endif %}
 </h2>
+
+<div class="phpdocumentor-label-line">
+{% if node.isReadOnly %}
+    <div class="phpdocumentor-label phpdocumentor-label--success"><span>Read only</span><span>Yes</span></div>
+{% endif %}
+
+{% if node.isFinal %}
+    <div class="phpdocumentor-label phpdocumentor-label--success"><span>Final</span><span>Yes</span></div>
+{% endif %}
+
+{% if node.isAbstract %}
+    <div class="phpdocumentor-label phpdocumentor-label--success"><span>Abstract</span><span>Yes</span></div>
+{% endif %}
+</div>

--- a/data/templates/default/components/tags.html.twig
+++ b/data/templates/default/components/tags.html.twig
@@ -1,6 +1,6 @@
 {% set tags = node.tags|filter((v,k) => k not in ['var', 'param', 'property', 'property-read', 'property-write', 'method', 'return', 'package', 'api']) %}
 
-{% if tags|length > 0 %}
+{% if tags|length > 0 and tags|first|length > 0 %}
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
         <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>

--- a/data/templates/default/css/base.css.twig
+++ b/data/templates/default/css/base.css.twig
@@ -26,6 +26,7 @@ body {
 {% include 'objects/code.css.twig' %}
 {% include 'objects/blockquote.css.twig' %}
 {% include 'objects/tables.css.twig' %}
+{% include 'objects/labels.css.twig' %}
 
 {% include 'components/header.css.twig' %}
 {% include 'components/header-title.css.twig' %}

--- a/data/templates/default/objects/labels.css.twig
+++ b/data/templates/default/objects/labels.css.twig
@@ -1,0 +1,20 @@
+.phpdocumentor-label-line {
+    display: flex; flex-direction: row; gap: 1rem
+}
+
+.phpdocumentor-label {
+    background: #f6f6f6;
+    border-radius: .25rem;
+    font-size: 80%;
+    display: inline-block;
+    overflow: hidden
+}
+
+.phpdocumentor-label span {
+    display: inline-block;
+    padding: .125rem .5rem;
+}
+
+.phpdocumentor-label--success span:last-of-type {
+    background: #abe1ab;
+}

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/ClassAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/ClassAssembler.php
@@ -56,6 +56,7 @@ class ClassAssembler extends AssemblerAbstract
 
         $classDescriptor->setAbstract($data->isAbstract());
         $classDescriptor->setFinal($data->isFinal());
+        $classDescriptor->setReadOnly($data->isReadOnly());
         $classDescriptor->setNamespace(substr((string) $data->getFqsen(), 0, -strlen($data->getName()) - 1));
 
         $interfaces = $classDescriptor->getInterfaces();

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -49,6 +49,9 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     /** @var bool $final Whether this class is marked as final and can't be subclassed. */
     protected $final = false;
 
+    /** @var bool $readOnly Whether this class is marked as readonly. */
+    protected bool $readOnly = false;
+
     /** @var Collection<ConstantDescriptor> $constants References to constants defined in this class. */
     protected $constants;
 
@@ -109,7 +112,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     }
 
     /**
-     * @internal should not be called by any other class than the assamblers
+     * @internal should not be called by any other class than the assemblers
      */
     public function setFinal(bool $final): void
     {
@@ -119,6 +122,19 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     public function isFinal(): bool
     {
         return $this->final;
+    }
+
+    /**
+     * @internal should not be called by any other class than the assemblers
+     */
+    public function setReadOnly(bool $readOnly): void
+    {
+        $this->readOnly = $readOnly;
+    }
+
+    public function isReadOnly(): bool
+    {
+        return $this->readOnly;
     }
 
     /**

--- a/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ClassDescriptorTest.php
@@ -25,8 +25,7 @@ use stdClass;
  */
 final class ClassDescriptorTest extends MockeryTestCase
 {
-    /** @var ClassDescriptor $fixture */
-    protected $fixture;
+    protected ClassDescriptor $fixture;
     use MagicPropertyContainerTests;
     use MagicMethodContainerTests;
     use TraitUsageTests;
@@ -46,13 +45,13 @@ final class ClassDescriptorTest extends MockeryTestCase
      */
     public function testSettingAndGettingAParent(): void
     {
-        $this->assertNull($this->fixture->getParent());
+        self::assertNull($this->fixture->getParent());
 
         $mock = m::mock(ClassDescriptor::class);
 
         $this->fixture->setParent($mock);
 
-        $this->assertSame($mock, $this->fixture->getParent());
+        self::assertSame($mock, $this->fixture->getParent());
     }
 
     /**
@@ -64,7 +63,7 @@ final class ClassDescriptorTest extends MockeryTestCase
 
         $this->fixture->setParent($mock);
 
-        $this->assertSame($mock, $this->fixture->getParent());
+        self::assertSame($mock, $this->fixture->getParent());
     }
 
     /**
@@ -73,13 +72,13 @@ final class ClassDescriptorTest extends MockeryTestCase
      */
     public function testSettingAndGettingInterfaces(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getInterfaces());
+        self::assertInstanceOf(Collection::class, $this->fixture->getInterfaces());
 
         $mock = m::mock(Collection::class);
 
         $this->fixture->setInterfaces($mock);
 
-        $this->assertSame($mock, $this->fixture->getInterfaces());
+        self::assertSame($mock, $this->fixture->getInterfaces());
     }
 
     /**
@@ -88,13 +87,13 @@ final class ClassDescriptorTest extends MockeryTestCase
      */
     public function testSettingAndGettingConstants(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getConstants());
+        self::assertInstanceOf(Collection::class, $this->fixture->getConstants());
 
         $mock = m::mock(Collection::class);
 
         $this->fixture->setConstants($mock);
 
-        $this->assertSame($mock, $this->fixture->getConstants());
+        self::assertSame($mock, $this->fixture->getConstants());
     }
 
     /**
@@ -103,13 +102,13 @@ final class ClassDescriptorTest extends MockeryTestCase
      */
     public function testSettingAndGettingProperties(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getProperties());
+        self::assertInstanceOf(Collection::class, $this->fixture->getProperties());
 
         $mock = m::mock(Collection::class);
 
         $this->fixture->setProperties($mock);
 
-        $this->assertSame($mock, $this->fixture->getProperties());
+        self::assertSame($mock, $this->fixture->getProperties());
     }
 
     /**
@@ -118,13 +117,13 @@ final class ClassDescriptorTest extends MockeryTestCase
      */
     public function testSettingAndGettingMethods(): void
     {
-        $this->assertInstanceOf(Collection::class, $this->fixture->getMethods());
+        self::assertInstanceOf(Collection::class, $this->fixture->getMethods());
 
         $mock = m::mock(Collection::class);
 
         $this->fixture->setMethods($mock);
 
-        $this->assertSame($mock, $this->fixture->getMethods());
+        self::assertSame($mock, $this->fixture->getMethods());
     }
 
     /**
@@ -133,8 +132,8 @@ final class ClassDescriptorTest extends MockeryTestCase
     public function testRetrievingInheritedMethodsReturnsEmptyCollectionWithoutParent(): void
     {
         $inheritedMethods = $this->fixture->getInheritedMethods();
-        $this->assertInstanceOf(Collection::class, $inheritedMethods);
-        $this->assertCount(0, $inheritedMethods);
+        self::assertInstanceOf(Collection::class, $inheritedMethods);
+        self::assertCount(0, $inheritedMethods);
     }
 
     /**
@@ -149,10 +148,10 @@ final class ClassDescriptorTest extends MockeryTestCase
         $this->fixture->setParent($mock);
         $result = $this->fixture->getInheritedMethods();
 
-        $this->assertInstanceOf(Collection::class, $result);
+        self::assertInstanceOf(Collection::class, $result);
 
         $expected = ['methods', 'inherited'];
-        $this->assertSame($expected, $result->getAll());
+        self::assertSame($expected, $result->getAll());
     }
 
     /**
@@ -161,11 +160,11 @@ final class ClassDescriptorTest extends MockeryTestCase
      */
     public function testSettingAndGettingWhetherClassIsAbstract(): void
     {
-        $this->assertFalse($this->fixture->isAbstract());
+        self::assertFalse($this->fixture->isAbstract());
 
         $this->fixture->setAbstract(true);
 
-        $this->assertTrue($this->fixture->isAbstract());
+        self::assertTrue($this->fixture->isAbstract());
     }
 
     /**
@@ -174,11 +173,24 @@ final class ClassDescriptorTest extends MockeryTestCase
      */
     public function testSettingAndGettingWhetherClassIsFinal(): void
     {
-        $this->assertFalse($this->fixture->isFinal());
+        self::assertFalse($this->fixture->isFinal());
 
         $this->fixture->setFinal(true);
 
-        $this->assertTrue($this->fixture->isFinal());
+        self::assertTrue($this->fixture->isFinal());
+    }
+
+    /**
+     * @covers ::isReadOnly
+     * @covers ::setReadOnly
+     */
+    public function testSettingAndGettingWhetherClassIsReadOnly(): void
+    {
+        self::assertFalse($this->fixture->isReadOnly());
+
+        $this->fixture->setReadOnly(true);
+
+        self::assertTrue($this->fixture->isReadOnly());
     }
 
     /**
@@ -187,10 +199,10 @@ final class ClassDescriptorTest extends MockeryTestCase
     public function testGetInheritedConstantsNoParent(): void
     {
         $descriptor = new ClassDescriptor();
-        $this->assertInstanceOf(Collection::class, $descriptor->getInheritedConstants());
+        self::assertInstanceOf(Collection::class, $descriptor->getInheritedConstants());
 
         $descriptor->setParent(new stdClass());
-        $this->assertInstanceOf(Collection::class, $descriptor->getInheritedConstants());
+        self::assertInstanceOf(Collection::class, $descriptor->getInheritedConstants());
     }
 
     /**
@@ -207,10 +219,10 @@ final class ClassDescriptorTest extends MockeryTestCase
         $this->fixture->setParent($mock);
         $result = $this->fixture->getInheritedConstants();
 
-        $this->assertInstanceOf(Collection::class, $result);
+        self::assertInstanceOf(Collection::class, $result);
 
         $expected = ['constants', 'inherited'];
-        $this->assertSame($expected, $result->getAll());
+        self::assertSame($expected, $result->getAll());
     }
 
     /**
@@ -219,10 +231,10 @@ final class ClassDescriptorTest extends MockeryTestCase
     public function testGetInheritedPropertiesNoParent(): void
     {
         $descriptor = new ClassDescriptor();
-        $this->assertInstanceOf(Collection::class, $descriptor->getInheritedProperties());
+        self::assertInstanceOf(Collection::class, $descriptor->getInheritedProperties());
 
         $descriptor->setParent(new stdClass());
-        $this->assertInstanceOf(Collection::class, $descriptor->getInheritedProperties());
+        self::assertInstanceOf(Collection::class, $descriptor->getInheritedProperties());
     }
 
     /**
@@ -239,10 +251,10 @@ final class ClassDescriptorTest extends MockeryTestCase
         $this->fixture->setParent($mock);
         $result = $this->fixture->getInheritedProperties();
 
-        $this->assertInstanceOf(Collection::class, $result);
+        self::assertInstanceOf(Collection::class, $result);
 
         $expected = ['properties', 'inherited'];
-        $this->assertSame($expected, $result->getAll());
+        self::assertSame($expected, $result->getAll());
     }
 
     /**
@@ -260,8 +272,8 @@ final class ClassDescriptorTest extends MockeryTestCase
         $result = $this->fixture->getInheritedProperties();
 
         // Assert
-        $this->assertInstanceOf(Collection::class, $result);
-        $this->assertSame($expected, $result->getAll());
+        self::assertInstanceOf(Collection::class, $result);
+        self::assertSame($expected, $result->getAll());
     }
 
     /**
@@ -279,8 +291,8 @@ final class ClassDescriptorTest extends MockeryTestCase
         $result = $this->fixture->getInheritedProperties();
 
         // Assert
-        $this->assertInstanceOf(Collection::class, $result);
-        $this->assertSame($expected, $result->getAll());
+        self::assertInstanceOf(Collection::class, $result);
+        self::assertSame($expected, $result->getAll());
     }
 
     /**
@@ -330,7 +342,7 @@ final class ClassDescriptorTest extends MockeryTestCase
 
         $mock->setPackage($package);
 
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
     /**
@@ -340,8 +352,8 @@ final class ClassDescriptorTest extends MockeryTestCase
      */
     public function testCall(): void
     {
-        $this->assertNull($this->fixture->__call('notexisting', []));
-        $this->assertInstanceOf(Collection::class, $this->fixture->__call('getNotexisting', []));
+        self::assertNull($this->fixture->__call('notexisting', []));
+        self::assertInstanceOf(Collection::class, $this->fixture->__call('getNotexisting', []));
     }
 
     /**
@@ -359,7 +371,7 @@ final class ClassDescriptorTest extends MockeryTestCase
         $result = $this->fixture->getSummary();
 
         // Assert
-        $this->assertSame($summary, $result);
+        self::assertSame($summary, $result);
     }
 
     protected function whenFixtureHasParentClass(): ClassDescriptor


### PR DESCRIPTION
When a class has the readonly keyword, we should be able to show that in the generated documentation. These changes will ensure that the twig templates can read whether a whole class is readonly.

![image](https://user-images.githubusercontent.com/193704/202923616-8f6b15cf-5660-46d0-a1b5-68e0b455da00.png)

This is now shown as a label with the text when present, if absent: it is omitted. This will now also show that label for abstract and final classes, and there are e2e tests for this behaviour.

I am not 100% convinced of the choice for this UI, but it is an improvement over what we have now and I am looking into a slight update of the styling to clean a few things up