### PR TITLE
Comment use of unreleased method from ReflectionDocBlock

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/MethodAssembler.php
@@ -41,7 +41,9 @@ class MethodAssembler extends BaseTagAssembler
         $descriptor = new MethodDescriptor($data->getName());
         $descriptor->setMethodName($data->getMethodName());
         $descriptor->setStatic($data->isStatic());
-        $descriptor->setHasReturnByReference($data->returnsReference());
+
+        // TODO: Uncomment this line as soon as DocBlockReflection 5.4 is released and included
+        // $descriptor->setHasReturnByReference($data->returnsReference());
 
         $response = new ReturnDescriptor('return');
         $response->setType($data->getReturnType());


### PR DESCRIPTION
The build on master breaks on this, so let's revert it for now