### PR TITLE
Introduce the first value objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,10 @@ shell:
 node_modules/.bin/cypress:
 	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/opt/phpdoc/var/cache/.cypress" -v ${CURDIR}:/opt/phpdoc -w /opt/phpdoc node npm install
 
-build/default/index.html: data/examples/MariosPizzeria/**/* data/templates/default/**/*
+build/default/index.html: data/examples/MariosPizzeria/**/* data/templates/default/**/* src/**/*
 	${.DOCKER_COMPOSE_RUN} phpdoc --config=data/examples/MariosPizzeria/phpdoc.xml --template=default --target=build/default --force
 
-build/clean/index.html: data/examples/MariosPizzeria/**/* data/templates/clean/**/*
+build/clean/index.html: data/examples/MariosPizzeria/**/* data/templates/clean/**/* src/**/*
 	${.DOCKER_COMPOSE_RUN} phpdoc --config=data/examples/MariosPizzeria/phpdoc.xml --template=clean --target=build/clean --force
 
 .PHONY: docs

--- a/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ArgumentDescriptor.php
@@ -28,12 +28,8 @@ class ArgumentDescriptor extends DescriptorAbstract implements Interfaces\Argume
     use Traits\BelongsToMethod;
     use Traits\CanHaveAType;
     use Traits\CanHaveADefaultValue;
-
-    /** @var bool $byReference whether the argument passes the parameter by reference instead of by value */
-    protected bool $byReference = false;
-
-    /** @var bool Determines if this Argument represents a variadic argument */
-    protected bool $isVariadic = false;
+    use Traits\CanBeByReference;
+    use Traits\CanBeVariadic;
 
     public function getInheritedElement(): ?ArgumentInterface
     {
@@ -58,31 +54,5 @@ class ArgumentDescriptor extends DescriptorAbstract implements Interfaces\Argume
         }
 
         return null;
-    }
-
-    public function setByReference(bool $byReference): void
-    {
-        $this->byReference = $byReference;
-    }
-
-    public function isByReference(): bool
-    {
-        return $this->byReference;
-    }
-
-    /**
-     * Sets whether this argument represents a variadic argument.
-     */
-    public function setVariadic(bool $isVariadic): void
-    {
-        $this->isVariadic = $isVariadic;
-    }
-
-    /**
-     * Returns whether this argument represents a variadic argument.
-     */
-    public function isVariadic(): bool
-    {
-        return $this->isVariadic;
     }
 }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/ArgumentAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/ArgumentAssembler.php
@@ -17,6 +17,7 @@ use phpDocumentor\Descriptor\ArgumentDescriptor;
 use phpDocumentor\Descriptor\Builder\AssemblerAbstract as BaseAssembler;
 use phpDocumentor\Descriptor\Interfaces\ArgumentInterface;
 use phpDocumentor\Descriptor\Tag\ParamDescriptor;
+use phpDocumentor\Descriptor\ValueObjects\IsApplicable;
 use phpDocumentor\Reflection\Php\Argument;
 
 use function stripcslashes;
@@ -45,8 +46,8 @@ class ArgumentAssembler extends BaseAssembler
         }
 
         $argumentDescriptor->setDefault($this->prettifyValue($data->getDefault()));
-        $argumentDescriptor->setByReference($data->isByReference());
-        $argumentDescriptor->setVariadic($data->isVariadic());
+        $argumentDescriptor->setByReference(IsApplicable::fromBoolean($data->isByReference()));
+        $argumentDescriptor->setVariadic(IsApplicable::fromBoolean($data->isVariadic()));
 
         return $argumentDescriptor;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/MethodAssembler.php
@@ -19,6 +19,7 @@ use phpDocumentor\Descriptor\DocBlock\DescriptionDescriptor;
 use phpDocumentor\Descriptor\Interfaces\MethodInterface;
 use phpDocumentor\Descriptor\MethodDescriptor;
 use phpDocumentor\Descriptor\Tag\ParamDescriptor;
+use phpDocumentor\Descriptor\ValueObjects\IsApplicable;
 use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\Php\Argument;
@@ -151,7 +152,7 @@ class MethodAssembler extends AssemblerAbstract
         $argument->setDescription(new DescriptionDescriptor($lastParamTag->getDescription(), []));
         $argument->setStartLocation($methodDescriptor->getStartLocation());
         $argument->setEndLocation($methodDescriptor->getEndLocation());
-        $argument->setVariadic(true);
+        $argument->setVariadic(IsApplicable::true());
 
         $methodDescriptor->getArguments()->set($argument->getName(), $argument);
     }

--- a/src/phpDocumentor/Descriptor/Interfaces/ArgumentInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/ArgumentInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor\Interfaces;
 
 use phpDocumentor\Descriptor\IsTyped;
+use phpDocumentor\Descriptor\ValueObjects\IsApplicable;
 
 /**
  * Describes the public interface for a descriptor of an Argument.
@@ -44,21 +45,21 @@ interface ArgumentInterface extends ElementInterface, IsTyped
     /**
      * Sets whether this argument passes its parameter by reference or by value.
      *
-     * @param bool $byReference True if the parameter is passed by reference, otherwise it is by value.
+     * @param IsApplicable $byReference True if the parameter is passed by reference, otherwise it is by value.
      */
-    public function setByReference(bool $byReference): void;
+    public function setByReference(IsApplicable $byReference): void;
 
     /**
      * Returns whether the parameter is passed by reference or by value.
      *
-     * @return bool True if the parameter is passed by reference, otherwise it is by value.
+     * @return bool if the parameter is passed by reference, otherwise it is by value.
      */
     public function isByReference(): bool;
 
     /**
      * Sets whether this argument represents a variadic argument.
      */
-    public function setVariadic(bool $isVariadic): void;
+    public function setVariadic(IsApplicable $isVariadic): void;
 
     /**
      * Returns whether this argument represents a variadic argument.

--- a/src/phpDocumentor/Descriptor/Traits/CanBeByReference.php
+++ b/src/phpDocumentor/Descriptor/Traits/CanBeByReference.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Descriptor\Traits;
+
+use phpDocumentor\Descriptor\ValueObjects\IsApplicable;
+
+trait CanBeByReference
+{
+    /** @var IsApplicable $byReference whether the argument passes the parameter by reference instead of by value */
+    protected IsApplicable $byReference;
+
+    public function setByReference(IsApplicable $byReference): void
+    {
+        $this->byReference = $byReference;
+    }
+
+    public function isByReference(): bool
+    {
+        if (!isset($this->byReference)) {
+            $this->byReference = IsApplicable::false();
+        }
+
+        return $this->byReference->equals(IsApplicable::true());
+    }
+}

--- a/src/phpDocumentor/Descriptor/Traits/CanBeVariadic.php
+++ b/src/phpDocumentor/Descriptor/Traits/CanBeVariadic.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Descriptor\Traits;
+
+use phpDocumentor\Descriptor\ValueObjects\IsApplicable;
+
+trait CanBeVariadic
+{
+    /** @var IsApplicable Determines if this Argument represents a variadic argument */
+    protected IsApplicable $isVariadic;
+
+    /**
+     * Sets whether this argument represents a variadic argument.
+     */
+    public function setVariadic(IsApplicable $isVariadic): void
+    {
+        $this->isVariadic = $isVariadic;
+    }
+
+    /**
+     * Returns whether this argument represents a variadic argument.
+     */
+    public function isVariadic(): bool
+    {
+        if (!isset($this->isVariadic)) {
+            $this->isVariadic = IsApplicable::false();
+        }
+
+        return $this->isVariadic->equals(IsApplicable::true());
+    }
+}

--- a/src/phpDocumentor/Descriptor/ValueObjects/Equals.php
+++ b/src/phpDocumentor/Descriptor/ValueObjects/Equals.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Descriptor\ValueObjects;
+
+/**
+ * @template T as Equals
+ */
+interface Equals
+{
+    /**
+     * @param T $other
+     */
+    public function equals(Equals $other): bool;
+}

--- a/src/phpDocumentor/Descriptor/ValueObjects/IsApplicable.php
+++ b/src/phpDocumentor/Descriptor/ValueObjects/IsApplicable.php
@@ -48,7 +48,7 @@ final class IsApplicable implements Equals
 
     public function isFalse(): bool
     {
-        return $this->value === true;
+        return $this->value === false;
     }
 
     public function inverse(): self
@@ -58,6 +58,7 @@ final class IsApplicable implements Equals
 
     public function equals(Equals $other): bool
     {
-        return $this->value === $other->value;
+        return $other instanceof self
+            && $this->value === $other->value;
     }
 }

--- a/src/phpDocumentor/Descriptor/ValueObjects/IsApplicable.php
+++ b/src/phpDocumentor/Descriptor/ValueObjects/IsApplicable.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Descriptor\ValueObjects;
+
+/**
+ * @implements Equals<IsApplicable>
+ * @immutable
+ */
+final class IsApplicable implements Equals
+{
+    private bool $value;
+
+    private function __construct(bool $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function true(): self
+    {
+        return new self(true);
+    }
+
+    public static function false(): self
+    {
+        return new self(false);
+    }
+
+    public static function fromBoolean(bool $boolean): self
+    {
+        return new self($boolean);
+    }
+
+    public function isTrue(): bool
+    {
+        return $this->value === true;
+    }
+
+    public function isFalse(): bool
+    {
+        return $this->value === true;
+    }
+
+    public function inverse(): self
+    {
+        return new self(!$this->value);
+    }
+
+    public function equals(Equals $other): bool
+    {
+        return $this->value === $other->value;
+    }
+}

--- a/tests/unit/phpDocumentor/Descriptor/ArgumentDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ArgumentDescriptorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use phpDocumentor\Descriptor\DocBlock\DescriptionDescriptor;
+use phpDocumentor\Descriptor\ValueObjects\IsApplicable;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Type;
@@ -145,7 +146,7 @@ final class ArgumentDescriptorTest extends TestCase
         $argument = new ArgumentDescriptor();
         self::assertFalse($argument->isByReference());
 
-        $argument->setByReference(true);
+        $argument->setByReference(IsApplicable::true());
 
         self::assertTrue($argument->isByReference());
     }
@@ -159,7 +160,7 @@ final class ArgumentDescriptorTest extends TestCase
         $argument = new ArgumentDescriptor();
         self::assertFalse($argument->isVariadic());
 
-        $argument->setVariadic(true);
+        $argument->setVariadic(IsApplicable::true());
 
         self::assertTrue($argument->isVariadic());
     }

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/ArgumentAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/ArgumentAssemblerTest.php
@@ -94,11 +94,11 @@ class ArgumentAssemblerTest extends TestCase
 
         // Assert
         $this->assertSame($name, $descriptor->getName());
+        $this->assertSame($description, $descriptor->getDescription());
         $this->assertSame($type, $descriptor->getType());
         $this->assertNull($descriptor->getDefault());
         $this->assertFalse($descriptor->isByReference());
         $this->assertFalse($descriptor->isVariadic());
-        $this->assertSame($description, $descriptor->getDescription());
     }
 
     /**

--- a/tests/unit/phpDocumentor/Descriptor/ValueObjects/IsApplicableTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ValueObjects/IsApplicableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**

--- a/tests/unit/phpDocumentor/Descriptor/ValueObjects/IsApplicableTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ValueObjects/IsApplicableTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Descriptor\ValueObjects;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass IsApplicable
+ * @covers ::__construct
+ * @covers ::<private>
+ */
+final class IsApplicableTest extends TestCase
+{
+    /**
+     * @covers ::true()
+     * @covers ::isTrue()
+     * @covers ::isFalse()
+     */
+    public function testIndicatingPresenceOfFeature(): void
+    {
+        $featureToggle = IsApplicable::true();
+        self::assertTrue($featureToggle->isTrue());
+        self::assertFalse($featureToggle->isFalse());
+    }
+
+    /**
+     * @covers ::false()
+     * @covers ::isTrue()
+     * @covers ::isFalse()
+     */
+    public function testIndicatingAbsenceOfFeature(): void
+    {
+        $featureToggle = IsApplicable::false();
+        self::assertFalse($featureToggle->isTrue());
+        self::assertTrue($featureToggle->isFalse());
+    }
+
+    /**
+     * @covers ::inverse()
+     * @covers ::isTrue()
+     * @covers ::isFalse()
+     */
+    public function testValueCanBeInvertedAndIsImmutable(): void
+    {
+        $original = IsApplicable::false();
+        $changed = $original->inverse();
+
+        self::assertNotSame($original, $changed);
+        self::assertFalse($changed->isFalse());
+        self::assertTrue($changed->isTrue());
+    }
+
+    /**
+     * @covers ::fromBoolean
+     */
+    public function testCanBeInstantiatedFromBoolean(): void
+    {
+        self::assertTrue(IsApplicable::fromBoolean(true)->isTrue());
+        self::assertTrue(IsApplicable::fromBoolean(false)->isFalse());
+    }
+
+    /**
+     * @covers ::equals
+     */
+    public function testCanBeComparedToAnother(): void
+    {
+        self::assertTrue(IsApplicable::true()->equals(IsApplicable::true()));
+        self::assertFalse(IsApplicable::true()->equals(IsApplicable::false()));
+        self::assertTrue(IsApplicable::false()->equals(IsApplicable::false()));
+        self::assertFalse(IsApplicable::false()->equals(IsApplicable::true()));
+    }
+}


### PR DESCRIPTION
During a recent call, Jaap and I talked about using imposters to be able to have objects that represent references. This can replace the use of multiples types in the linker and descriptors by having a Reference object instead of a FQSEN directly injected.

The value objects allow us to be more flexible in our design, and to return an 'undefined' state when using these imposter objects.