### PR TITLE
Tighten table of contents

### DIFF
--- a/cypress/integration/default/frontpage.spec.js
+++ b/cypress/integration/default/frontpage.spec.js
@@ -59,19 +59,23 @@ describe('Frontpage', function() {
     describe('Global constants and functions', function() {
         it('Shows a section "Table Of Contents"', function() {
             cy.get('h3#toc').should('contain', 'Table of Contents');
-            cy.get('h3#toc').next('.phpdocumentor-table-of-contents');
+            cy.get('h3#toc')
+                .siblings('.phpdocumentor-table-of-contents')
+                .should('exist');
         });
 
         it('Shows the "HIGHER_OVEN_TEMPERATURE" constant', function() {
             cy.get('h3#toc')
-                .next('.phpdocumentor-table-of-contents')
-                .find('.-constant').should('contain', 'HIGHER_OVEN_TEMPERATURE')
+                .siblings('.phpdocumentor-table-of-contents')
+                .find('.-constant')
+                .should('contain', 'HIGHER_OVEN_TEMPERATURE')
         });
 
         // TODO: Is this the outcome that we want?
         it('Opens the "HIGHER_OVEN_TEMPERATURE" constant', function() {
             cy
-                .get('h3#toc').next('.phpdocumentor-table-of-contents')
+                .get('h3#toc')
+                .siblings('.phpdocumentor-table-of-contents')
                 .find('.phpdocumentor-table-of-contents__entry.-constant')
                 .contains('HIGHER_OVEN_TEMPERATURE')
                 .click();

--- a/data/templates/default/components/table-of-contents-entry.html.twig
+++ b/data/templates/default/components/table-of-contents-entry.html.twig
@@ -1,10 +1,12 @@
 <dt class="phpdocumentor-table-of-contents__entry -{{ type }} -{{ node.visibility }}">
-    <a href="{{ link(node) }}">{{ type == 'property' ? '$' }}{{ node.name }}{{ type == 'method' or type == 'function' ? '()' }}</a>
+    <a href="{{ link(node) }}">{{ node is property ? '$' }}{{ node.name }}{{ node is method or node is function ? '()' }}</a>
     <span>
-        {% if type == 'constant' %}&nbsp;= {{ node.value }}{% endif %}
-        {% if type == 'case' %}{% if node.value %}&nbsp;= {{ node.value }}{% endif %}{% endif %}
-        {% if type == 'property' %}&nbsp;: {{ node.type ? node.type|route('class:short')|join('|')|raw : 'mixed' }}{% endif %}
-        {% if type == 'method' or type == 'function' %}&nbsp;: {{ node.response.type|route('class:short')|join('|')|raw }}{% endif %}
+        {% if node is constant %}&nbsp;= {{ node.value }}{% endif %}
+        {% if node is enumCase %}{% if node.value %}&nbsp;= {{ node.value }}{% endif %}{% endif %}
+        {% if node is property %}&nbsp;: {{ node.type ? node.type|route('class:short')|join('|')|raw : 'mixed' }}{% endif %}
+        {% if node is method or node is function %}&nbsp;: {{ node.response.type|route('class:short')|join('|')|raw }}{% endif %}
     </span>
 </dt>
+{% if node.summary %}
 <dd>{{ node.summary }}</dd>
+{% endif %}

--- a/data/templates/default/components/table-of-contents.css.twig
+++ b/data/templates/default/components/table-of-contents.css.twig
@@ -2,7 +2,7 @@
 }
 
 .phpdocumentor-table-of-contents .phpdocumentor-table-of-contents__entry {
-    padding-top: var(--spacing-xs);
+    margin-bottom: var(--spacing-xxs);
     margin-left: 2rem;
     display: flex;
 }

--- a/data/templates/default/components/table-of-contents.html.twig
+++ b/data/templates/default/components/table-of-contents.html.twig
@@ -24,7 +24,7 @@
 </dl>
 {% endif %}
 
-{% if node.interfaces is not empty or node.classes is not empty or node.traits is not empty or node.enums is not empty %}
+{% if node is element container and (node.interfaces is not empty or node.classes is not empty or node.traits is not empty or node.enums is not empty) %}
 <h3 id="interfaces_class_traits">
     Interfaces, Classes, Traits and Enums
     <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>

--- a/data/templates/default/components/table-of-contents.html.twig
+++ b/data/templates/default/components/table-of-contents.html.twig
@@ -56,27 +56,56 @@
 {% set constants = constants(node) %}
 {% set properties = properties(node) %}
 {% set methods = methods(node) %}
+{% set cases = cases(node) %}
+{% set functions = node.functions|default([]) %}
 
-{% if constants is not empty or node.functions is not empty or methods is not empty or properties is not empty %}
-<h3 id="toc">
-    Table of Contents
-    <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
-</h3>
+{% if constants is not empty or functions is not empty or methods is not empty or properties is not empty or cases is not empty %}
+    <h3 id="toc">
+        Table of Contents
+        <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
+    </h3>
+{% endif %}
 
+{% if constants is not empty %}
+<h4>Constants</h4>
 <dl class="phpdocumentor-table-of-contents">
-    {% for constant in constants(node)|sortByVisibility %}
+    {% for constant in constants|sortByVisibility %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'constant', 'node': constant}) }}
     {% endfor %}
-    {% for case in cases(node)|sortByVisibility %}
+</dl>
+{% endif %}
+
+{% if cases is not empty %}
+<h4>Cases</h4>
+<dl class="phpdocumentor-table-of-contents">
+    {% for case in cases|sortByVisibility %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'case', 'node': case}) }}
     {% endfor %}
-    {% for property in properties(node)|sortByVisibility %}
+</dl>
+{% endif %}
+
+{% if properties is not empty %}
+<h4>Properties</h4>
+<dl class="phpdocumentor-table-of-contents">
+    {% for property in properties|sortByVisibility %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'property', 'node': property}) }}
     {% endfor %}
-    {% for method in methods(node)|sortByVisibility %}
+</dl>
+{% endif %}
+
+{% if methods is not empty %}
+<h4>Methods</h4>
+<dl class="phpdocumentor-table-of-contents">
+    {% for method in methods|sortByVisibility %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'method', 'node': method}) }}
     {% endfor %}
-    {% for function in node.functions|default([]) %}
+</dl>
+{% endif %}
+
+{% if functions is not empty %}
+<h4>Functions</h4>
+<dl class="phpdocumentor-table-of-contents">
+    {% for function in functions %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'function', 'node': function}) }}
     {% endfor %}
 </dl>

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -22,6 +22,18 @@ use phpDocumentor\Descriptor\Descriptor;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\DocBlock\DescriptionDescriptor;
 use phpDocumentor\Descriptor\EnumDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ArgumentInterface;
+use phpDocumentor\Descriptor\Interfaces\ClassInterface;
+use phpDocumentor\Descriptor\Interfaces\ConstantInterface;
+use phpDocumentor\Descriptor\Interfaces\ContainerInterface;
+use phpDocumentor\Descriptor\Interfaces\FileInterface;
+use phpDocumentor\Descriptor\Interfaces\FunctionInterface;
+use phpDocumentor\Descriptor\Interfaces\InterfaceInterface;
+use phpDocumentor\Descriptor\Interfaces\MethodInterface;
+use phpDocumentor\Descriptor\Interfaces\NamespaceInterface;
+use phpDocumentor\Descriptor\Interfaces\PackageInterface;
+use phpDocumentor\Descriptor\Interfaces\PropertyInterface;
+use phpDocumentor\Descriptor\Interfaces\TraitInterface;
 use phpDocumentor\Descriptor\Interfaces\VisibilityInterface;
 use phpDocumentor\Descriptor\NamespaceDescriptor;
 use phpDocumentor\Descriptor\PackageDescriptor;
@@ -39,6 +51,7 @@ use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
+use Twig\TwigTest;
 use Webmozart\Assert\Assert;
 
 use function array_unshift;
@@ -73,11 +86,8 @@ use function vsprintf;
  */
 final class Extension extends AbstractExtension implements ExtensionInterface, GlobalsInterface
 {
-    /** @var LinkRenderer */
-    private $routeRenderer;
-
-    /** @var ConverterInterface */
-    private $markdownConverter;
+    private LinkRenderer $routeRenderer;
+    private ConverterInterface $markdownConverter;
 
     /**
      * Registers the structure and transformation with this extension.
@@ -110,6 +120,27 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
             'destinationPath' => null,
             'parameter' => [],
             'env' => null,
+        ];
+    }
+
+    /**
+     * @return list<TwigTest>
+     */
+    public function getTests(): array
+    {
+        return [
+            new TwigTest('element container', static fn (Descriptor $el) => $el instanceof ContainerInterface),
+            new TwigTest('namespace', static fn (Descriptor $el) => $el instanceof NamespaceInterface),
+            new TwigTest('package', static fn (Descriptor $el) => $el instanceof PackageInterface),
+            new TwigTest('file', static fn (Descriptor $el) => $el instanceof FileInterface),
+            new TwigTest('class', static fn (Descriptor $el) => $el instanceof ClassInterface),
+            new TwigTest('interface', static fn (Descriptor $el) => $el instanceof InterfaceInterface),
+            new TwigTest('trait', static fn (Descriptor $el) => $el instanceof TraitInterface),
+            new TwigTest('property', static fn (Descriptor $el) => $el instanceof PropertyInterface),
+            new TwigTest('method', static fn (Descriptor $el) => $el instanceof MethodInterface),
+            new TwigTest('argument', static fn (Descriptor $el) => $el instanceof ArgumentInterface),
+            new TwigTest('function', static fn (Descriptor $el) => $el instanceof FunctionInterface),
+            new TwigTest('constant', static fn (Descriptor $el) => $el instanceof ConstantInterface),
         ];
     }
 

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -26,6 +26,8 @@ use phpDocumentor\Descriptor\Interfaces\ArgumentInterface;
 use phpDocumentor\Descriptor\Interfaces\ClassInterface;
 use phpDocumentor\Descriptor\Interfaces\ConstantInterface;
 use phpDocumentor\Descriptor\Interfaces\ContainerInterface;
+use phpDocumentor\Descriptor\Interfaces\EnumCaseInterface;
+use phpDocumentor\Descriptor\Interfaces\EnumInterface;
 use phpDocumentor\Descriptor\Interfaces\FileInterface;
 use phpDocumentor\Descriptor\Interfaces\FunctionInterface;
 use phpDocumentor\Descriptor\Interfaces\InterfaceInterface;
@@ -135,6 +137,8 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
             new TwigTest('file', static fn (Descriptor $el) => $el instanceof FileInterface),
             new TwigTest('class', static fn (Descriptor $el) => $el instanceof ClassInterface),
             new TwigTest('interface', static fn (Descriptor $el) => $el instanceof InterfaceInterface),
+            new TwigTest('enum', static fn (Descriptor $el) => $el instanceof EnumInterface),
+            new TwigTest('enumCase', static fn (Descriptor $el) => $el instanceof EnumCaseInterface),
             new TwigTest('trait', static fn (Descriptor $el) => $el instanceof TraitInterface),
             new TwigTest('property', static fn (Descriptor $el) => $el instanceof PropertyInterface),
             new TwigTest('method', static fn (Descriptor $el) => $el instanceof MethodInterface),


### PR DESCRIPTION
_Warning, this PR is based on the branch from PR https://github.com/phpDocumentor/phpDocumentor/pull/3380 because I needed the new tests. The other PR should be merged first_

The table of contents section could have used some love and this is the
first step into it. In this change I have fixes a bug where the Table of
Contents header was not shown for enums that only had cases, I have
re-used the new twig tests for rendering the table of contents entries,
and I have redone the whitespacing between the entries in the table of
contents for more readability

**Old**
![image](https://user-images.githubusercontent.com/193704/204079748-11863f15-0ce3-4b4d-adbd-6310f9375118.png)

**New**
![image](https://user-images.githubusercontent.com/193704/204079724-a1c5b708-e38c-4538-b580-8df57772c7dc.png)
