### PR TITLE
Show 'On this page' for classes and namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,10 +142,10 @@ shell:
 node_modules/.bin/cypress:
 	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/opt/phpdoc/var/cache/.cypress" -v ${CURDIR}:/opt/phpdoc -w /opt/phpdoc node npm install
 
-build/default/index.html: data/examples/MariosPizzeria/**/* data/templates/default/**/*
+build/default/index.html: data/examples/MariosPizzeria/**/* data/templates/default/**/* .RUN_ALWAYS
 	${.DOCKER_COMPOSE_RUN} phpdoc --config=data/examples/MariosPizzeria/phpdoc.xml --template=default --target=build/default --force
 
-build/clean/index.html: data/examples/MariosPizzeria/**/* data/templates/clean/**/*
+build/clean/index.html: data/examples/MariosPizzeria/**/* data/templates/clean/**/* .RUN_ALWAYS
 	${.DOCKER_COMPOSE_RUN} phpdoc --config=data/examples/MariosPizzeria/phpdoc.xml --template=clean --target=build/clean --force
 
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,12 @@ help:
 	@echo "unit-test        - runs unit tests";
 	@echo "integration-test - runs integration tests";
 	@echo "functional-test  - runs functional tests";
-	@echo "e2e-test         - runs phpDocumentor and verifies the output using Cypress";
 	@echo "composer-require-checker - checks for any missing composer packages";
+	@echo "";
+	@echo "e2e-test         - runs phpDocumentor and verifies the output using Cypress";
+	@echo "build/default/index.html - builds the 'default' template's example project";
+	@echo "build/clean/index.html - builds the 'clean' template's example project";
+	@echo "cypress/integration/*.spec.js - runs e2e tests on a specific specification";
 	@echo "";
 	@echo "== Code Quality ==";
 	@echo "lint             - performs all linting on the code";
@@ -41,7 +45,7 @@ help:
 	@echo "== Release tools ==";
 	@echo "composer-mirror  - Runs a production-version of composer install for, i.e., the phar building";
 	@echo "phar             - Creates the PHAR file";
-	@echo "docs			    - Creates local docs docker image";
+	@echo "docs             - Creates local docs docker image";
 	@echo "";
 
 .PHONY: phar
@@ -109,6 +113,12 @@ unit-test integration-test functional-test:
 e2e-test: node_modules/.bin/cypress build/default/index.html build/clean/index.html
 	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:10.3.0
 
+cypress/integration/default/%.spec.js: node_modules/.bin/cypress build/default/index.html .RUN_ALWAYS
+	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:10.3.0 -s $@
+
+cypress/integration/clean/%.spec.js: node_modules/.bin/cypress build/clean/index.html .RUN_ALWAYS
+	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:10.3.0 -s $@
+
 .PHONY: composer-require-checker
 composer-require-checker:
 	${.DOCKER_COMPOSE_RUN} --entrypoint=./tools/composer-require-checker phpdoc  check --config-file /opt/phpdoc/composer-require-config.json composer.json
@@ -152,3 +162,6 @@ build-website: demo docs
 demo:
 	${.DOCKER_COMPOSE_RUN} phpdoc --template=default -t ./build/website/demo/default
 	${.DOCKER_COMPOSE_RUN} phpdoc --template=clean -t ./build/website/demo/clean
+
+.PHONY: .RUN_ALWAYS
+.RUN_ALWAYS:

--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -97,6 +97,8 @@ describe('Classes', function() {
     describe('On This Page', function() {
         it('renders links to the summary items', function() {
             getSummaryEntry('Methods').should('exist');
+        });
+        it('renders references to methods on this page', function() {
             getEntryIn('Methods', 'jsonSerialize()').should('exist');
             getEntryIn('Methods', 'order()').should('exist');
             getEntryIn('Methods', 'doOrder()').should('exist');

--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -1,5 +1,6 @@
-import sidebar from "./sidebar.inc";
-import search from "./search.inc";
+import sidebar from './sidebar.inc';
+import search from './search.inc';
+import {getToc, getTocEntry} from './helpers/tableOfContents.lib';
 
 describe('Classes', function() {
     beforeEach(function(){
@@ -23,70 +24,75 @@ describe('Classes', function() {
         });
     });
 
-    it('Has "Pizzeria" as title', function() {
-        cy.get('.phpdocumentor-content__title').contains('Pizzeria');
-    });
-
-    it('Shows a single implemented interface; which is not clickable because it is external', function() {
-        cy.get('.phpdocumentor-element__implements').contains("JsonSerializable");
-        cy.get('.phpdocumentor-element__implements abbr')
-            .should("have.attr", 'title', '\\JsonSerializable');
-    });
-
-    it('Has a summary', function() {
-        cy.get('.phpdocumentor-element.-class > .phpdocumentor-summary')
-            .contains("Entrypoint for this pizza ordering application.");
-    });
-
-    it('Has a description', function() {
-        cy.get('.phpdocumentor-element.-class > .phpdocumentor-description')
-            .contains('This class provides an interface through which you can order pizza\'s and pasta\'s from Mario\'s Pizzeria.');
-    });
-
-    it('Shows a class is readonly', function() {
-        cy.visit('build/default/classes/Marios-Pizza.html');
-        cy.get('.phpdocumentor-element.-class .phpdocumentor-label')
-            .contains('Read only');
-    });
-
-    it('Shows a class is final', function() {
-        cy.visit('build/default/classes/Marios-Pizza.html');
-        cy.get('.phpdocumentor-element.-class .phpdocumentor-label')
-            .contains('Final');
-    });
-
-    it('Shows a class is abstract', function() {
-        cy.visit('build/default/classes/Marios-Pizza-Topping.html');
-        cy.get('.phpdocumentor-element.-class .phpdocumentor-label')
-            .contains('Abstract');
-    });
-
-    describe ('Shows tags', function () {
-        it('Shows the tags section', function () {
-            cy.get('.phpdocumentor-tag-list__heading')
-                .contains("Tags")
-        })
-
-        it('Shows link without description', function() {
-            cy.get('.phpdocumentor-element.-class  > .phpdocumentor-tag-list >.phpdocumentor-tag-list__definition > a')
-                .contains('https://wwww.phpdoc.org')
-                .should('have.attr', 'href', 'https://wwww.phpdoc.org')
+    describe('Synopsis', function() {
+        it('Has "Pizzeria" as title', function () {
+            cy.get('.phpdocumentor-content__title').contains('Pizzeria');
         });
 
-        it('Shows link with description', function() {
-            cy.get('.phpdocumentor-element.-class  > .phpdocumentor-tag-list >.phpdocumentor-tag-list__definition > a')
-                .contains('docs')
-                .parent()
-                .should('have.attr', 'href', 'https://docs.phpdoc.org')
+        it('Shows a single implemented interface; which is not clickable because it is external', function () {
+            cy.get('.phpdocumentor-element__implements').contains("JsonSerializable");
+            cy.get('.phpdocumentor-element__implements abbr')
+                .should("have.attr", 'title', '\\JsonSerializable');
+        });
+
+        it('Has a summary', function () {
+            cy.get('.phpdocumentor-element.-class > .phpdocumentor-summary')
+                .contains("Entrypoint for this pizza ordering application.");
+        });
+
+        it('Has a description', function () {
+            cy.get('.phpdocumentor-element.-class > .phpdocumentor-description')
+                .contains('This class provides an interface through which you can order pizza\'s and pasta\'s from Mario\'s Pizzeria.');
+        });
+
+        it('Shows a class is readonly', function () {
+            cy.visit('build/default/classes/Marios-Pizza.html');
+            cy.get('.phpdocumentor-element.-class .phpdocumentor-label')
+                .contains('Read only');
+        });
+
+        it('Shows a class is final', function () {
+            cy.visit('build/default/classes/Marios-Pizza.html');
+            cy.get('.phpdocumentor-element.-class .phpdocumentor-label')
+                .contains('Final');
+        });
+
+        it('Shows a class is abstract', function () {
+            cy.visit('build/default/classes/Marios-Pizza-Topping.html');
+            cy.get('.phpdocumentor-element.-class .phpdocumentor-label')
+                .contains('Abstract');
+        });
+
+        describe('Shows tags', function () {
+            it('Shows the tags section', function () {
+                cy.get('.phpdocumentor-tag-list__heading')
+                    .contains("Tags")
+            })
+
+            it('Shows link without description', function () {
+                cy.get('.phpdocumentor-element.-class  > .phpdocumentor-tag-list >.phpdocumentor-tag-list__definition > a')
+                    .contains('https://wwww.phpdoc.org')
+                    .should('have.attr', 'href', 'https://wwww.phpdoc.org')
+            });
+
+            it('Shows link with description', function () {
+                cy.get('.phpdocumentor-element.-class  > .phpdocumentor-tag-list >.phpdocumentor-tag-list__definition > a')
+                    .contains('docs')
+                    .parent()
+                    .should('have.attr', 'href', 'https://docs.phpdoc.org')
+            });
         });
     });
 
-    describe('Table of Contents', function(){
-        it('Show methods', function() {
-            cy.get('.phpdocumentor-table-of-contents__entry')
-                .contains("jsonSerialize()")
-                .parent()
-                .contains(': array'); // type
+    describe('Table of Contents', function() {
+        it('Shows methods with their return type and visibility', function() {
+            const toc = getToc('methods', 'Methods');
+            const entry = getTocEntry(toc, 'jsonSerialize()');
+
+            entry
+                .should('have.class', '-method')
+                .and('have.class', '-public')
+                .and('contain', ': array<string|int, mixed>'); // type including generic arguments
         });
     });
 

--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -24,7 +24,7 @@ describe('Classes', function() {
     });
 
     it('Has "Pizzeria" as title', function() {
-        cy.get('.phpdocumentor-content__title').contains("Pizzeria");
+        cy.get('.phpdocumentor-content__title').contains('Pizzeria');
     });
 
     it('Shows a single implemented interface; which is not clickable because it is external', function() {

--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -1,6 +1,7 @@
 import sidebar from './sidebar.inc';
 import search from './search.inc';
 import {getToc, getTocEntry} from './helpers/tableOfContents.lib';
+import {getEntryIn, getSummaryEntry} from './helpers/onThisPage.lib';
 
 describe('Classes', function() {
     beforeEach(function(){
@@ -86,13 +87,19 @@ describe('Classes', function() {
 
     describe('Table of Contents', function() {
         it('Shows methods with their return type and visibility', function() {
-            const toc = getToc('methods', 'Methods');
-            const entry = getTocEntry(toc, 'jsonSerialize()');
-
-            entry
+            getTocEntry(getToc('methods', 'Methods'), 'jsonSerialize()')
                 .should('have.class', '-method')
                 .and('have.class', '-public')
                 .and('contain', ': array<string|int, mixed>'); // type including generic arguments
+        });
+    });
+
+    describe('On This Page', function() {
+        it('renders links to the summary items', function() {
+            getSummaryEntry('Methods').should('exist');
+            getEntryIn('Methods', 'jsonSerialize()').should('exist');
+            getEntryIn('Methods', 'order()').should('exist');
+            getEntryIn('Methods', 'doOrder()').should('exist');
         });
     });
 

--- a/cypress/integration/default/constants.spec.js
+++ b/cypress/integration/default/constants.spec.js
@@ -5,7 +5,12 @@ describe('Showing constants for a class', function() {
         cy.visit('build/default/classes/Marios-Pizza.html');
     });
 
-    describe('Meta-data', function() {
+    describe('Synopsis', function() {
+        it('Show the name', function() {
+            getElementWithName('constant', 'TYPE_ITALIAN')
+                .should('be.visible');
+        });
+
         it('Can be marked "public" (visibility) to influence styling', function () {
             getElementWithName('constant', 'TYPE_ITALIAN')
                 .should('have.class', '-public')
@@ -25,13 +30,6 @@ describe('Showing constants for a class', function() {
                 .should('not.have.class', '-public')
                 .and('not.have.class', '-protected')
                 .and('have.class', '-private');
-        });
-    });
-
-    describe('Synopsis', function() {
-        it('Show the name', function() {
-            getElementWithName('constant', 'TYPE_ITALIAN')
-                .should('be.visible');
         });
 
         it('Show the file name where the constant is located in the project', function() {
@@ -108,7 +106,20 @@ describe('Showing constants for an interface', function() {
         cy.visit('build/default/classes/Marios-Product.html');
     });
 
-    describe('Meta-data', function() {
+    describe('Synopsis', function() {
+        it('Show the name', function() {
+            getElementWithName('constant', 'PUBLIC_CONSTANT')
+                .should('be.visible');
+        });
+
+        it('Show the file name where the constant is located in the project', function() {
+            getElementWithName('constant', 'PUBLIC_CONSTANT')
+                .find('.phpdocumentor-element-found-in__file')
+                .contains('a', 'Product.php')
+                .find('abbr')
+                .should('have.attr', 'title', 'src/Product.php');
+        });
+
         it('Can be marked "public" (visibility) to influence styling', function () {
             getElementWithName('constant', 'PUBLIC_CONSTANT')
                 .should('have.class', '-public')
@@ -128,21 +139,6 @@ describe('Showing constants for an interface', function() {
                 .should('not.have.class', '-public')
                 .and('not.have.class', '-protected')
                 .and('have.class', '-private');
-        });
-    });
-
-    describe('Synopsis', function() {
-        it('Show the name', function() {
-            getElementWithName('constant', 'PUBLIC_CONSTANT')
-                .should('be.visible');
-        });
-
-        it('Show the file name where the constant is located in the project', function() {
-            getElementWithName('constant', 'PUBLIC_CONSTANT')
-                .find('.phpdocumentor-element-found-in__file')
-                .contains('a', 'Product.php')
-                .find('abbr')
-                .should('have.attr', 'title', 'src/Product.php');
         });
 
         it('Links to the file documentation wherein the constant is', function() {

--- a/cypress/integration/default/frontpage.spec.js
+++ b/cypress/integration/default/frontpage.spec.js
@@ -10,53 +10,7 @@ describe('Frontpage', function() {
     describe('Search', search);
     describe('In the sidebar', sidebar);
 
-    describe('Packages', function() {
-        it('Shows a section "Packages" with a table of contents', function() {
-            cy.get('h3#packages').should('contain', 'Packages');
-            cy.get('h3#packages').next('.phpdocumentor-table-of-contents');
-        });
-
-        it('Shows the "Marios" package', function() {
-            cy.get('h3#packages')
-                .next('.phpdocumentor-table-of-contents')
-                .find('.-package').should('contain', 'Marios')
-        });
-
-        it('Opens the "Marios" package', function() {
-            cy
-                .get('h3#packages').next('.phpdocumentor-table-of-contents')
-                .find('.phpdocumentor-table-of-contents__entry.-package')
-                .contains("Marios")
-                .click();
-
-            shouldVisitPageWithTitle('/packages/Marios.html', 'Marios');
-        });
-    });
-
-    describe('Namespaces', function() {
-        it('Shows a section "Namespaces" with a table of contents', function() {
-            cy.get('h3#namespaces').should('contain', 'Namespaces');
-            cy.get('h3#namespaces').next('.phpdocumentor-table-of-contents');
-        });
-
-        it('Shows the "Marios" namespace', function() {
-            cy.get('h3#namespaces')
-                .next('.phpdocumentor-table-of-contents')
-                .find('.-namespace').should('contain', 'Marios')
-        });
-
-        it('Opens the "Marios" namespace', function() {
-            cy
-                .get('h3#namespaces').next('.phpdocumentor-table-of-contents')
-                .find('.phpdocumentor-table-of-contents__entry.-namespace')
-                .contains("Marios")
-                .click();
-
-            shouldVisitPageWithTitle('/namespaces/marios.html', 'Marios');
-        });
-    });
-
-    describe('Global constants and functions', function() {
+    describe('Table Of Contents', function() {
         it('Shows a section "Table Of Contents"', function() {
             cy.get('h3#toc').should('contain', 'Table of Contents');
             cy.get('h3#toc')
@@ -64,23 +18,71 @@ describe('Frontpage', function() {
                 .should('exist');
         });
 
-        it('Shows the "HIGHER_OVEN_TEMPERATURE" constant', function() {
-            cy.get('h3#toc')
-                .siblings('.phpdocumentor-table-of-contents')
-                .find('.-constant')
-                .should('contain', 'HIGHER_OVEN_TEMPERATURE')
+        describe('Packages', function() {
+            it('Shows a section "Packages" with a table of contents', function() {
+                cy.get('h4#packages').should('contain', 'Packages');
+                cy.get('h4#packages').next('.phpdocumentor-table-of-contents');
+            });
+
+            it('Shows the "Marios" package', function() {
+                cy.get('h4#packages')
+                    .next('.phpdocumentor-table-of-contents')
+                    .find('.-package').should('contain', 'Marios')
+            });
+
+            it('Opens the "Marios" package', function() {
+                cy
+                    .get('h4#packages').next('.phpdocumentor-table-of-contents')
+                    .find('.phpdocumentor-table-of-contents__entry.-package')
+                    .contains("Marios")
+                    .click();
+
+                shouldVisitPageWithTitle('/packages/Marios.html', 'Marios');
+            });
         });
 
-        // TODO: Is this the outcome that we want?
-        it('Opens the "HIGHER_OVEN_TEMPERATURE" constant', function() {
-            cy
-                .get('h3#toc')
-                .siblings('.phpdocumentor-table-of-contents')
-                .find('.phpdocumentor-table-of-contents__entry.-constant')
-                .contains('HIGHER_OVEN_TEMPERATURE')
-                .click();
+        describe('Namespaces', function() {
+            it('Shows a section "Namespaces" with a table of contents', function() {
+                cy.get('h4#namespaces').should('contain', 'Namespaces');
+                cy.get('h4#namespaces').next('.phpdocumentor-table-of-contents');
+            });
 
-            shouldVisitPageWithTitle('/namespaces/default.html', 'API Documentation');
+            it('Shows the "Marios" namespace', function() {
+                cy.get('h4#namespaces')
+                    .next('.phpdocumentor-table-of-contents')
+                    .find('.-namespace').should('contain', 'Marios')
+            });
+
+            it('Opens the "Marios" namespace', function() {
+                cy
+                    .get('h4#namespaces').next('.phpdocumentor-table-of-contents')
+                    .find('.phpdocumentor-table-of-contents__entry.-namespace')
+                    .contains("Marios")
+                    .click();
+
+                shouldVisitPageWithTitle('/namespaces/marios.html', 'Marios');
+            });
+        });
+
+        describe('Global constants and functions', function() {
+            it('Shows the "HIGHER_OVEN_TEMPERATURE" constant', function() {
+                cy.get('h3#toc')
+                    .siblings('.phpdocumentor-table-of-contents')
+                    .find('.-constant')
+                    .should('contain', 'HIGHER_OVEN_TEMPERATURE')
+            });
+
+            // TODO: Is this the outcome that we want?
+            it('Opens the "HIGHER_OVEN_TEMPERATURE" constant', function() {
+                cy
+                    .get('h3#toc')
+                    .siblings('.phpdocumentor-table-of-contents')
+                    .find('.phpdocumentor-table-of-contents__entry.-constant')
+                    .contains('HIGHER_OVEN_TEMPERATURE')
+                    .click();
+
+                shouldVisitPageWithTitle('/namespaces/default.html', 'API Documentation');
+            });
         });
     });
 });

--- a/cypress/integration/default/helpers/onThisPage.lib.js
+++ b/cypress/integration/default/helpers/onThisPage.lib.js
@@ -1,0 +1,21 @@
+export function getOnThisPage() {
+    return cy.get('.phpdocumentor-on-this-page__content');
+}
+
+export function getSection(name) {
+    return getOnThisPage()
+        .find('.phpdocumentor-on-this-page-section__title')
+        .contains(name)
+        .next('li');
+}
+
+export function getSummaryEntry(name) {
+    return getSection('Table Of Contents')
+        .find('li').contains(name);
+}
+
+export function getEntryIn(section, name) {
+    return getSection(section)
+        .find('li').contains(name);
+}
+

--- a/cypress/integration/default/helpers/tableOfContents.lib.js
+++ b/cypress/integration/default/helpers/tableOfContents.lib.js
@@ -1,0 +1,10 @@
+export function getToc(tocType, tocName) {
+    return cy.get('h4#toc-' + tocType).contains(tocName).next('.phpdocumentor-table-of-contents');
+}
+
+export function getTocEntry(toc, name) {
+    return toc.find('.phpdocumentor-table-of-contents__entry')
+        .contains(name)
+        .parents('.phpdocumentor-table-of-contents__entry');
+}
+

--- a/cypress/integration/default/interfaces.spec.js
+++ b/cypress/integration/default/interfaces.spec.js
@@ -1,0 +1,78 @@
+import sidebar from './sidebar.inc';
+import search from './search.inc';
+import {getToc, getTocEntry} from './helpers/tableOfContents.lib';
+import {getEntryIn, getSummaryEntry} from './helpers/onThisPage.lib';
+
+describe('Interfaces', function() {
+    beforeEach(function(){
+        cy.visit('build/default/classes/Marios-Product.html');
+    });
+
+    describe('Search', search);
+    describe('In the sidebar', sidebar);
+
+    describe('Breadcrumb', function() {
+        it('Has a breadcrumb featuring "Marios"', function() {
+            cy.get('.phpdocumentor-breadcrumb').should('have.length', 1);
+            cy.get('.phpdocumentor-breadcrumb').contains('Marios');
+        });
+
+        it('will send you to the namespace page when clicking on "Marios" in the breadcrumb', function() {
+            cy.get('.phpdocumentor-breadcrumb')
+                .contains('Marios')
+                .click();
+            cy.url().should('include', '/namespaces/marios.html');
+        });
+    });
+
+    describe('Synopsis', function() {
+        it('Has "Product" as title', function () {
+            cy.get('.phpdocumentor-content__title').contains('Product');
+        });
+
+        it('Has a summary', function () {
+            cy.get('.phpdocumentor-element.-interface > .phpdocumentor-summary')
+                .contains('Contract between products.');
+        });
+
+        it('Has a description', function () {
+            cy.get('.phpdocumentor-element.-interface > .phpdocumentor-description')
+                .contains('This is a description on an interface.');
+        });
+    });
+
+    describe('Table of Contents', function() {
+        it('Shows methods with their return type and visibility', function() {
+            getTocEntry(getToc('methods', 'Methods'), 'getName()')
+                .should('have.class', '-method')
+                .and('have.class', '-public')
+                .and('contain', ': string');
+        });
+        it('Shows constants with their visibility', function() {
+            getTocEntry(getToc('constants', 'Constants'), 'PUBLIC_CONSTANT')
+                .should('have.class', '-constant')
+                .and('have.class', '-public');
+            getTocEntry(getToc('constants', 'Constants'), 'PROTECTED_CONSTANT')
+                .should('have.class', '-constant')
+                .and('have.class', '-protected');
+            getTocEntry(getToc('constants', 'Constants'), 'PRIVATE_CONSTANT')
+                .should('have.class', '-constant')
+                .and('have.class', '-private');
+        });
+    });
+
+    describe('On This Page', function() {
+        it('renders links to the summary items', function() {
+            getSummaryEntry('Constants').should('exist');
+            getSummaryEntry('Methods').should('exist');
+        });
+        it('renders references to constants on this page', function() {
+            getEntryIn('Constants', 'PUBLIC_CONSTANT').should('exist');
+            getEntryIn('Constants', 'PROTECTED_CONSTANT').should('exist');
+            getEntryIn('Constants', 'PRIVATE_CONSTANT').should('exist');
+        });
+        it('renders references to methods on this page', function() {
+            getEntryIn('Methods', 'getName()').should('exist');
+        });
+    });
+});

--- a/cypress/integration/default/namespaces.spec.js
+++ b/cypress/integration/default/namespaces.spec.js
@@ -1,15 +1,12 @@
 import {shouldVisitPageWithTitle} from "./helpers/pages.lib";
 import sidebar from "./sidebar.inc";
 import search from "./search.inc";
+import {getToc, getTocEntry} from "./helpers/tableOfContents.lib";
+import {getEntryIn, getSummaryEntry} from "./helpers/onThisPage.lib";
 
 describe('Namespaces', function() {
     beforeEach(function(){
         cy.visit('build/default/namespaces/marios.html');
-    });
-
-    it('Has "Marios" as title', function() {
-        cy.get('.phpdocumentor-content__title')
-            .contains("Marios");
     });
 
     describe('Search', search);
@@ -24,6 +21,12 @@ describe('Namespaces', function() {
         });
     });
 
+    describe('Synopsis', function() {
+        it('Has "Marios" as title', function() {
+            cy.get('.phpdocumentor-content__title').contains("Marios");
+        });
+    });
+
     describe('Table of Contents', function() {
         describe('Child namespaces', function () {
             it('Has a section "Namespaces" featuring the "Pizza" sub-namespace', function () {
@@ -35,7 +38,7 @@ describe('Namespaces', function() {
 
             it('Goes to the "Pizza" sub-namespace when you click on it', function () {
                 cy.get('h4#namespaces')
-                    .contains("Namespaces")
+                    .contains('Namespaces')
                     .next('.phpdocumentor-table-of-contents')
                     .find('.phpdocumentor-table-of-contents__entry')
                     .contains('Pizza')
@@ -43,55 +46,57 @@ describe('Namespaces', function() {
 
                 shouldVisitPageWithTitle('/namespaces/marios-pizza.html', 'Pizza');
             });
-        })
+        });
 
-        describe('Interfaces, Classes, Traits and Enums', function () {
-            it('Features the "Product" interface', function () {
-                const name = 'Product';
+        it('Features the "Product" interface', function () {
+            getTocEntry(getToc('interfaces', 'Interfaces'), 'Product')
+                .should('have.class', '-interface');
+        });
 
-                cy.get('h4#toc-interfaces')
-                    .contains('Interfaces')
-                    .next('.phpdocumentor-table-of-contents')
-                    .contains('.phpdocumentor-table-of-contents__entry', name)
-                    .should('have.class', '-interface');
-            });
+        it('Features the "Pizzeria" class and its description', function () {
+            const title = 'Pizzeria';
+            const description = 'Entrypoint for this pizza ordering application.';
 
-            it('Features the "Pizzeria" class and its description', function () {
-                const title = 'Pizzeria';
-                const description = 'Entrypoint for this pizza ordering application.';
+            getTocEntry(getToc('classes', 'Classes'), title)
+                .should('have.class', '-class')
+                .next('dd')
+                .should('have.text', description)
+        });
 
-                cy.get('h4#toc-classes')
-                    .contains('Classes')
-                    .next('.phpdocumentor-table-of-contents')
-                    .contains('.phpdocumentor-table-of-contents__entry', title)
-                    .should('have.class', '-class')
-                    .next('dd')
-                    .should('have.text', description)
-            });
+        it('Goes to "Pizzeria" its detail page when you click on it', function () {
+            const title = 'Pizzeria';
 
-            it('Goes to "Pizzeria" its detail page when you click on it', function () {
-                const title = 'Pizzeria';
+            getTocEntry(getToc('classes', 'Classes'), title)
+                .find('a').click();
 
-                cy.get('h4#toc-classes')
-                    .contains('Classes')
-                    .next('.phpdocumentor-table-of-contents')
-                    .contains('.phpdocumentor-table-of-contents__entry a', title)
-                    .click();
+            shouldVisitPageWithTitle('/classes/Marios-Pizzeria.html', title);
+        });
 
-                shouldVisitPageWithTitle('/classes/Marios-Pizzeria.html', title);
-            });
+        it('Features the "SharedTrait" trait with its description', function () {
+            const title = 'SharedTrait';
 
-            it('Features the "SharedTrait" trait with its description', function () {
-                const name = 'SharedTrait';
+            getTocEntry(getToc('traits', 'Traits'), title)
+                .should('have.class', '-trait')
+                .next('dd')
+                .should('have.text', 'Trait that all pizza\'s could share.');
+        });
+    });
 
-                cy.get('h4#toc-traits')
-                    .contains('Traits')
-                    .next('.phpdocumentor-table-of-contents')
-                    .contains('.phpdocumentor-table-of-contents__entry', name)
-                    .should('have.class', '-trait')
-                    .next('dd')
-                    .should('have.text', 'Trait that all pizza\'s could share.');
-            });
+    describe('On This Page', function() {
+        it('renders links to the summary items', function() {
+            getSummaryEntry('Interfaces').should('exist');
+            getSummaryEntry('Classes').should('exist');
+            getSummaryEntry('Traits').should('exist');
+            getSummaryEntry('Enums').should('exist');
+            getSummaryEntry('Constants').should('exist');
+            getSummaryEntry('Functions').should('exist');
+        });
+        it('renders references to constants on this page', function() {
+            getEntryIn('Constants', 'OVEN_TEMPERATURE').should('exist');
+        });
+        it('renders references to functions on this page', function() {
+            getEntryIn('Functions', 'coolOven').should('exist');
+            getEntryIn('Functions', 'heatOven').should('exist');
         });
     });
 
@@ -133,3 +138,4 @@ describe('Namespaces', function() {
         });
     });
 });
+

--- a/cypress/integration/default/namespaces.spec.js
+++ b/cypress/integration/default/namespaces.spec.js
@@ -27,18 +27,18 @@ describe('Namespaces', function() {
     describe('Table of Contents', function() {
         describe('Child namespaces', function () {
             it('Has a section "Namespaces" featuring the "Pizza" sub-namespace', function () {
-                cy.get('h3#namespaces').contains("Namespaces")
+                cy.get('h4#namespaces').contains("Namespaces")
                     .next('.phpdocumentor-table-of-contents')
                     .find('.phpdocumentor-table-of-contents__entry')
                     .should('contain', 'Pizza');
             });
 
             it('Goes to the "Pizza" sub-namespace when you click on it', function () {
-                cy.get('h3#namespaces')
+                cy.get('h4#namespaces')
                     .contains("Namespaces")
                     .next('.phpdocumentor-table-of-contents')
                     .find('.phpdocumentor-table-of-contents__entry')
-                    .contains("Pizza")
+                    .contains('Pizza')
                     .click();
 
                 shouldVisitPageWithTitle('/namespaces/marios-pizza.html', 'Pizza');
@@ -46,19 +46,11 @@ describe('Namespaces', function() {
         })
 
         describe('Interfaces, Classes, Traits and Enums', function () {
-            const sectionTitle = 'Interfaces, Classes, Traits and Enums';
-
-            it('Has a section "Interfaces, Classes, Traits and Enums" with a table of contents', function () {
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
-                    .next('.phpdocumentor-table-of-contents');
-            });
-
             it('Features the "Product" interface', function () {
                 const name = 'Product';
 
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
+                cy.get('h4#toc-interfaces')
+                    .contains('Interfaces')
                     .next('.phpdocumentor-table-of-contents')
                     .contains('.phpdocumentor-table-of-contents__entry', name)
                     .should('have.class', '-interface');
@@ -68,8 +60,8 @@ describe('Namespaces', function() {
                 const title = 'Pizzeria';
                 const description = 'Entrypoint for this pizza ordering application.';
 
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
+                cy.get('h4#toc-classes')
+                    .contains('Classes')
                     .next('.phpdocumentor-table-of-contents')
                     .contains('.phpdocumentor-table-of-contents__entry', title)
                     .should('have.class', '-class')
@@ -80,8 +72,8 @@ describe('Namespaces', function() {
             it('Goes to "Pizzeria" its detail page when you click on it', function () {
                 const title = 'Pizzeria';
 
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
+                cy.get('h4#toc-classes')
+                    .contains('Classes')
                     .next('.phpdocumentor-table-of-contents')
                     .contains('.phpdocumentor-table-of-contents__entry a', title)
                     .click();
@@ -92,8 +84,8 @@ describe('Namespaces', function() {
             it('Features the "SharedTrait" trait with its description', function () {
                 const name = 'SharedTrait';
 
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
+                cy.get('h4#toc-traits')
+                    .contains('Traits')
                     .next('.phpdocumentor-table-of-contents')
                     .contains('.phpdocumentor-table-of-contents__entry', name)
                     .should('have.class', '-trait')
@@ -103,7 +95,7 @@ describe('Namespaces', function() {
         });
     });
 
-    describe('Constants section', function() {
+    describe('Shows details on constants', function() {
         let sectionTitle = 'Constants';
 
         it('Shows the title "Constants"', function () {
@@ -122,7 +114,7 @@ describe('Namespaces', function() {
         });
     });
 
-    describe('Functions section', function() {
+    describe('Shows details on functions', function() {
         let sectionTitle = 'Functions';
 
         it('Shows the title "Functions"', function () {

--- a/cypress/integration/default/packages.spec.js
+++ b/cypress/integration/default/packages.spec.js
@@ -17,19 +17,11 @@ describe('Packages', function() {
 
     describe('Table of Contents', function() {
         describe('Interfaces, Classes, Traits and Enums', function () {
-            const sectionTitle = 'Interfaces, Classes, Traits and Enums';
-
-            it('Has a section "Interfaces, Classes, Traits and Enums" with a table of contents', function () {
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
-                    .next('.phpdocumentor-table-of-contents');
-            });
-
             it('Features the "Product" interface', function () {
                 const name = 'Product';
 
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
+                cy.get('h4#toc-interfaces')
+                    .contains('Interfaces')
                     .next('.phpdocumentor-table-of-contents')
                     .contains('.phpdocumentor-table-of-contents__entry', name)
                     .should('have.class', '-interface');
@@ -39,8 +31,8 @@ describe('Packages', function() {
                 const title = 'Pizzeria';
                 const description = 'Entrypoint for this pizza ordering application.';
 
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
+                cy.get('h4#toc-classes')
+                    .contains('Classes')
                     .next('.phpdocumentor-table-of-contents')
                     .contains('.phpdocumentor-table-of-contents__entry', title)
                     .should('have.class', '-class')
@@ -51,8 +43,8 @@ describe('Packages', function() {
             it('Goes to "Pizzeria" its detail page when you click on it', function () {
                 const title = 'Pizzeria';
 
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
+                cy.get('h4#toc-classes')
+                    .contains('Classes')
                     .next('.phpdocumentor-table-of-contents')
                     .contains('.phpdocumentor-table-of-contents__entry a', title)
                     .click();
@@ -63,8 +55,8 @@ describe('Packages', function() {
             it('Features the "SharedTrait" trait with its description', function () {
                 const name = 'SharedTrait';
 
-                cy.get('h3#interfaces_class_traits')
-                    .contains(sectionTitle)
+                cy.get('h4#toc-traits')
+                    .contains('Traits')
                     .next('.phpdocumentor-table-of-contents')
                     .contains('.phpdocumentor-table-of-contents__entry', name)
                     .should('have.class', '-trait')
@@ -74,7 +66,7 @@ describe('Packages', function() {
         });
     });
 
-    describe('Constants section', function() {
+    describe('Shows details on constants', function() {
         let sectionTitle = 'Constants';
 
         it('Shows the title "Constants"', function () {
@@ -93,7 +85,7 @@ describe('Packages', function() {
         });
     });
 
-    describe('Functions section', function() {
+    describe('Show details on functions', function() {
         let sectionTitle = 'Functions';
 
         it('Shows the title "Functions"', function () {

--- a/cypress/integration/default/packages.spec.js
+++ b/cypress/integration/default/packages.spec.js
@@ -1,68 +1,74 @@
 import {shouldVisitPageWithTitle} from "./helpers/pages.lib";
 import sidebar from "./sidebar.inc";
 import search from "./search.inc";
+import {getEntryIn, getSummaryEntry} from "./helpers/onThisPage.lib";
+import {getToc, getTocEntry} from "./helpers/tableOfContents.lib";
 
 describe('Packages', function() {
-    beforeEach(function(){
+    beforeEach(function() {
         cy.visit('build/default/packages/Marios.html');
-    });
-
-    it('Has a title', function() {
-        cy.get('.phpdocumentor-content__title')
-            .contains("Marios");
     });
 
     describe('Search', search);
     describe('In the sidebar', sidebar);
 
+    describe('Synopsis', function() {
+        it('Has a title', function() {
+            cy.get('.phpdocumentor-content__title')
+                .contains("Marios");
+        });
+    });
+
     describe('Table of Contents', function() {
-        describe('Interfaces, Classes, Traits and Enums', function () {
-            it('Features the "Product" interface', function () {
-                const name = 'Product';
+        it('Features the "Product" interface', function () {
+            getTocEntry(getToc('interfaces', 'Interfaces'), 'Product')
+                .should('have.class', '-interface');
+        });
 
-                cy.get('h4#toc-interfaces')
-                    .contains('Interfaces')
-                    .next('.phpdocumentor-table-of-contents')
-                    .contains('.phpdocumentor-table-of-contents__entry', name)
-                    .should('have.class', '-interface');
-            });
+        it('Features the "Pizzeria" class and its description', function () {
+            const title = 'Pizzeria';
+            const description = 'Entrypoint for this pizza ordering application.';
 
-            it('Features the "Pizzeria" class and its description', function () {
-                const title = 'Pizzeria';
-                const description = 'Entrypoint for this pizza ordering application.';
+            getTocEntry(getToc('classes', 'Classes'), title)
+                .should('have.class', '-class')
+                .next('dd')
+                .should('have.text', description)
+        });
 
-                cy.get('h4#toc-classes')
-                    .contains('Classes')
-                    .next('.phpdocumentor-table-of-contents')
-                    .contains('.phpdocumentor-table-of-contents__entry', title)
-                    .should('have.class', '-class')
-                    .next('dd')
-                    .should('have.text', description)
-            });
+        it('Goes to "Pizzeria" its detail page when you click on it', function () {
+            const title = 'Pizzeria';
 
-            it('Goes to "Pizzeria" its detail page when you click on it', function () {
-                const title = 'Pizzeria';
+            getTocEntry(getToc('classes', 'Classes'), title)
+                .find('a').click();
 
-                cy.get('h4#toc-classes')
-                    .contains('Classes')
-                    .next('.phpdocumentor-table-of-contents')
-                    .contains('.phpdocumentor-table-of-contents__entry a', title)
-                    .click();
+            shouldVisitPageWithTitle('/classes/Marios-Pizzeria.html', title);
+        });
 
-                shouldVisitPageWithTitle('/classes/Marios-Pizzeria.html', title);
-            });
+        it('Features the "SharedTrait" trait with its description', function () {
+            const title = 'SharedTrait';
 
-            it('Features the "SharedTrait" trait with its description', function () {
-                const name = 'SharedTrait';
+            getTocEntry(getToc('traits', 'Traits'), title)
+                .should('have.class', '-trait')
+                .next('dd')
+                .should('have.text', 'Trait that all pizza\'s could share.');
+        });
+    });
 
-                cy.get('h4#toc-traits')
-                    .contains('Traits')
-                    .next('.phpdocumentor-table-of-contents')
-                    .contains('.phpdocumentor-table-of-contents__entry', name)
-                    .should('have.class', '-trait')
-                    .next('dd')
-                    .should('have.text', 'Trait that all pizza\'s could share.');
-            });
+    describe('On This Page', function() {
+        it('renders links to the summary items', function() {
+            getSummaryEntry('Interfaces').should('exist');
+            getSummaryEntry('Classes').should('exist');
+            getSummaryEntry('Traits').should('exist');
+            getSummaryEntry('Enums').should('exist');
+            getSummaryEntry('Constants').should('exist');
+            getSummaryEntry('Functions').should('exist');
+        });
+        it('renders references to constants on this page', function() {
+            getEntryIn('Constants', 'OVEN_TEMPERATURE').should('exist');
+        });
+        it('renders references to functions on this page', function() {
+            getEntryIn('Functions', 'coolOven').should('exist');
+            getEntryIn('Functions', 'heatOven').should('exist');
         });
     });
 

--- a/cypress/integration/default/traits.spec.js
+++ b/cypress/integration/default/traits.spec.js
@@ -1,0 +1,61 @@
+import sidebar from './sidebar.inc';
+import search from './search.inc';
+import {getToc, getTocEntry} from './helpers/tableOfContents.lib';
+import {getEntryIn, getSummaryEntry} from './helpers/onThisPage.lib';
+
+describe('Interfaces', function() {
+    beforeEach(function(){
+        cy.visit('build/default/classes/Marios-SharedTrait.html');
+    });
+
+    describe('Search', search);
+    describe('In the sidebar', sidebar);
+
+    describe('Breadcrumb', function() {
+        it('Has a breadcrumb featuring "Marios"', function() {
+            cy.get('.phpdocumentor-breadcrumb').should('have.length', 1);
+            cy.get('.phpdocumentor-breadcrumb').contains('Marios');
+        });
+
+        it('will send you to the namespace page when clicking on "Marios" in the breadcrumb', function() {
+            cy.get('.phpdocumentor-breadcrumb')
+                .contains('Marios')
+                .click();
+            cy.url().should('include', '/namespaces/marios.html');
+        });
+    });
+
+    describe('Synopsis', function() {
+        it('Has "SharedTrait" as title', function () {
+            cy.get('.phpdocumentor-content__title').contains('SharedTrait');
+        });
+
+        it('Has a summary', function () {
+            cy.get('.phpdocumentor-element.-trait > .phpdocumentor-summary')
+                .contains('Trait that all pizza\'s could share.');
+        });
+
+        it('Has a description', function () {
+            cy.get('.phpdocumentor-element.-trait > .phpdocumentor-description')
+                .contains('Okay, so I couldn\'t think of something that fits the theme .. If you have a cool idea: please issue a PR :)');
+        });
+    });
+
+    describe('Table of Contents', function() {
+        it('Shows methods with their return type and visibility', function() {
+            getTocEntry(getToc('methods', 'Methods'), 'sayHello()')
+                .should('have.class', '-method')
+                .and('have.class', '-public')
+                .and('contain', 'Base');
+        });
+    });
+
+    describe('On This Page', function() {
+        it('renders links to the summary items', function() {
+            getSummaryEntry('Methods').should('exist');
+        });
+        it('renders references to methods on this page', function() {
+            getEntryIn('Methods', 'sayHello()').should('exist');
+        });
+    });
+});

--- a/data/examples/MariosPizzeria/src/Product.php
+++ b/data/examples/MariosPizzeria/src/Product.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Marios;
 
+/**
+ * Contract between products.
+ *
+ * This is a description on an interface.
+ */
 interface Product
 {
     public const PUBLIC_CONSTANT = 1;

--- a/data/templates/default/class.html.twig
+++ b/data/templates/default/class.html.twig
@@ -24,7 +24,7 @@
         <strong class="phpdocumentor-on-this-page__title">On this page</strong>
 
         <ul class="phpdocumentor-list -clean">
-            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li class="phpdocumentor-on-this-page-section__title">Table Of Contents</li>
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% if constants is not empty %}
@@ -39,7 +39,7 @@
                 </ul>
             </li>
             {% if constants is not empty %}
-                <li>Constants</li>
+                <li class="phpdocumentor-on-this-page-section__title">Constants</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
@@ -50,7 +50,7 @@
             {% endif %}
 
             {% if properties is not empty %}
-                <li>Properties</li>
+                <li class="phpdocumentor-on-this-page-section__title">Properties</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for property in properties|sortByVisibility %}
@@ -61,7 +61,7 @@
             {% endif %}
 
             {% if methods is not empty %}
-            <li>Methods</li>
+            <li class="phpdocumentor-on-this-page-section__title">Methods</li>
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for method in methods|sortByVisibility %}

--- a/data/templates/default/class.html.twig
+++ b/data/templates/default/class.html.twig
@@ -20,8 +20,9 @@
     {% set properties = properties(node) %}
     {% set methods = methods(node) %}
 
-    <div class="phpdocumentor-on-this-page__content">
-        <strong>On this page</strong>
+    <section class="phpdocumentor-on-this-page__content">
+        <strong class="phpdocumentor-on-this-page__title">On this page</strong>
+
         <ul class="phpdocumentor-list -clean">
             <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
             <li>
@@ -70,5 +71,5 @@
             </li>
             {% endif %}
         </ul>
-    </div>
+    </section>
 {% endblock %}

--- a/data/templates/default/class.html.twig
+++ b/data/templates/default/class.html.twig
@@ -14,3 +14,61 @@
         {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}
+
+{% block on_this_page %}
+    {% set constants = constants(node) %}
+    {% set properties = properties(node) %}
+    {% set methods = methods(node) %}
+
+    <div class="phpdocumentor-on-this-page__content">
+        <strong>On this page</strong>
+        <ul class="phpdocumentor-list -clean">
+            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li>
+                <ul class="phpdocumentor-list -clean">
+                    {% if constants is not empty %}
+                    <li><a href="{{ link(node) }}#toc-constants">Constants</a></li>
+                    {% endif %}
+                    {% if properties is not empty %}
+                    <li><a href="{{ link(node) }}#toc-properties">Properties</a></li>
+                    {% endif %}
+                    {% if methods is not empty %}
+                    <li><a href="{{ link(node) }}#toc-methods">Methods</a></li>
+                    {% endif %}
+                </ul>
+            </li>
+            {% if constants is not empty %}
+                <li>Constants</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for constant in constants|sortByVisibility %}
+                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+
+            {% if properties is not empty %}
+                <li>Properties</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for property in properties|sortByVisibility %}
+                            <li><a href="{{ link(property) }}">${{ property.name }}<a href="{{ link(node) }}"></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+
+            {% if methods is not empty %}
+            <li>Methods</li>
+            <li>
+                <ul class="phpdocumentor-list -clean">
+                    {% for method in methods|sortByVisibility %}
+                        <li><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                    {% endfor %}
+                </ul>
+            </li>
+            {% endif %}
+        </ul>
+    </div>
+{% endblock %}

--- a/data/templates/default/components/header-title.css.twig
+++ b/data/templates/default/components/header-title.css.twig
@@ -32,7 +32,7 @@
 
 @media (min-width: {{ breakpoints['menu'] }}) {
     .phpdocumentor-title {
-        width: 30.6666666667%;
+        width: 22%;
         border-right: var(--sidebar-border-color) solid 1px;
     }
 

--- a/data/templates/default/components/on-this-page.css.twig
+++ b/data/templates/default/components/on-this-page.css.twig
@@ -2,20 +2,44 @@
     display: none;
 }
 
+.phpdocumentor-on-this-page__title {
+    display: block;
+    font-weight: bold;
+    margin-bottom: var(--spacing-sm);
+    color: var(--link-color-primary);
+}
+
 @media (min-width: {{ breakpoints['menu'] }}) {
     .phpdocumentor-on-this-page__sidebar {
         display: block;
         position: relative;
     }
 
+    .phpdocumentor-on-this-page__content::-webkit-scrollbar,
+    [scrollbars]::-webkit-scrollbar {
+        height: 8px;
+        width: 8px;
+    }
+
+    .phpdocumentor-on-this-page__content::-webkit-scrollbar-corner,
+    [scrollbars]::-webkit-scrollbar-corner {
+        background: 0;
+    }
+
+    .phpdocumentor-on-this-page__content::-webkit-scrollbar-thumb,
+    [scrollbars]::-webkit-scrollbar-thumb {
+        background: rgba(128,134,139,0.26);
+        border-radius: 8px;
+    }
+
     .phpdocumentor-on-this-page__content {
         position: fixed;
-        max-height: calc(100vh - var(--header-height));
+        height: calc(100vh - var(--header-height));
         overflow-y: auto;
-        border-left: 1px solid silver;
+        border-left: 1px solid var(--sidebar-border-color);
         padding-left: var(--spacing-lg);
         font-size: 90%;
-        width: 18%; /* This magic number probably indicates a problem, revisit this */
-        right: 0;
+        width: calc(18% - var(--spacing-xs) - var(--spacing-xs)); /* This magic number probably indicates a problem, revisit this */
+        right: var(--spacing-xs);
     }
 }

--- a/data/templates/default/components/on-this-page.css.twig
+++ b/data/templates/default/components/on-this-page.css.twig
@@ -1,0 +1,19 @@
+.phpdocumentor-on-this-page__sidebar {
+    display: none;
+}
+
+@media (min-width: {{ breakpoints['menu'] }}) {
+    .phpdocumentor-on-this-page__sidebar {
+        display: block;
+        position: relative;
+    }
+
+    .phpdocumentor-on-this-page__content {
+        position: fixed;
+        max-height: calc(100vh - var(--header-height));
+        overflow-y: auto;
+        border-left: 1px solid silver;
+        padding-left: var(--spacing-lg);
+        font-size: 90%
+    }
+}

--- a/data/templates/default/components/on-this-page.css.twig
+++ b/data/templates/default/components/on-this-page.css.twig
@@ -14,6 +14,8 @@
         overflow-y: auto;
         border-left: 1px solid silver;
         padding-left: var(--spacing-lg);
-        font-size: 90%
+        font-size: 90%;
+        width: 18%; /* This magic number probably indicates a problem, revisit this */
+        right: 0;
     }
 }

--- a/data/templates/default/components/on-this-page.css.twig
+++ b/data/templates/default/components/on-this-page.css.twig
@@ -45,5 +45,6 @@
 
     .phpdocumentor-on-this-page__content li {
         word-break: break-all;
+        line-height: normal;
     }
 }

--- a/data/templates/default/components/on-this-page.css.twig
+++ b/data/templates/default/components/on-this-page.css.twig
@@ -42,4 +42,8 @@
         width: calc(18% - var(--spacing-xs) - var(--spacing-xs)); /* This magic number probably indicates a problem, revisit this */
         right: var(--spacing-xs);
     }
+
+    .phpdocumentor-on-this-page__content li {
+        word-break: break-all;
+    }
 }

--- a/data/templates/default/components/sidebar.html.twig
+++ b/data/templates/default/components/sidebar.html.twig
@@ -2,7 +2,7 @@
 <label class="phpdocumentor-sidebar__menu-icon" for="sidebar-button">
     Menu
 </label>
-<aside class="phpdocumentor-column -four phpdocumentor-sidebar">
+<aside class="phpdocumentor-column -three phpdocumentor-sidebar">
     {% for version in project.versions %}
         {% for toc in version.tableOfContents %}
         <section class="phpdocumentor-sidebar__category">

--- a/data/templates/default/components/table-of-contents.html.twig
+++ b/data/templates/default/components/table-of-contents.html.twig
@@ -1,9 +1,19 @@
-{% if packages|default([]) is not empty %}
-<h3 id="packages">
-    Packages
-    <a href="#packages" class="headerlink"><i class="fas fa-link"></i></a>
+{% set constants = constants(node) %}
+{% set properties = properties(node) %}
+{% set methods = methods(node) %}
+{% set cases = cases(node) %}
+{% set functions = node.functions|default([]) %}
+
+<h3 id="toc">
+    Table of Contents
+    <a href="{{ link(node) }}#toc" class="headerlink"><i class="fas fa-link"></i></a>
 </h3>
 
+{% if packages|default([]) is not empty %}
+<h4 id="packages">
+    Packages
+    <a href="{{ link(node) }}#packages" class="headerlink"><i class="fas fa-link"></i></a>
+</h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for package in packages %}
         <dt class="phpdocumentor-table-of-contents__entry -package">{{ package|route('class:short') }}</dt>
@@ -12,11 +22,10 @@
 {% endif %}
 
 {% if namespaces|default([]) is not empty %}
-<h3 id="namespaces">
+<h4 id="namespaces">
     Namespaces
-    <a href="#namespaces" class="headerlink"><i class="fas fa-link"></i></a>
-</h3>
-
+    <a href="{{ link(node) }}#namespaces" class="headerlink"><i class="fas fa-link"></i></a>
+</h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for namespace in namespaces %}
         <dt class="phpdocumentor-table-of-contents__entry -namespace">{{ namespace|route('class:short') }}</dt>
@@ -24,28 +33,49 @@
 </dl>
 {% endif %}
 
-{% if node is element container and (node.interfaces is not empty or node.classes is not empty or node.traits is not empty or node.enums is not empty) %}
-<h3 id="interfaces_class_traits">
-    Interfaces, Classes, Traits and Enums
-    <a href="#interfaces_class_traits" class="headerlink"><i class="fas fa-link"></i></a>
-</h3>
+{% if node.interfaces is not empty %}
+    <h4 id="toc-interfaces">
+        Interfaces
+        <a href="{{ link(node) }}#toc-interfaces" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <dl class="phpdocumentor-table-of-contents">
+        {% for interface in node.interfaces %}
+            <dt class="phpdocumentor-table-of-contents__entry -interface">{{ interface|route('class:short') }}</dt>
+            <dd>{{ interface.summary }}</dd>
+        {% endfor %}
+    </dl>
+{% endif %}
 
-<dl class="phpdocumentor-table-of-contents">
-    {% for interface in node.interfaces %}
-        <dt class="phpdocumentor-table-of-contents__entry -interface">{{ interface|route('class:short') }}</dt>
-        <dd>{{ interface.summary }}</dd>
-    {% endfor %}
-
-    {% for class in node.classes %}
-        <dt class="phpdocumentor-table-of-contents__entry -class">{{ class|route('class:short') }}</dt>
-        <dd>{{ class.summary }}</dd>
-    {% endfor %}
-
+{% if node.classes is not empty %}
+    <h4 id="toc-classes">
+        Classes
+        <a href="{{ link(node) }}#toc-classes" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <dl class="phpdocumentor-table-of-contents">
+        {% for class in node.classes %}
+            <dt class="phpdocumentor-table-of-contents__entry -class">{{ class|route('class:short') }}</dt>
+            <dd>{{ class.summary }}</dd>
+        {% endfor %}
+    </dl>
+{% endif %}
+{% if node.traits is not empty %}
+    <h4 id="toc-traits">
+        Traits
+        <a href="{{ link(node) }}#toc-traits" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <dl class="phpdocumentor-table-of-contents">
     {% for trait in node.traits %}
         <dt class="phpdocumentor-table-of-contents__entry -trait">{{ trait|route('class:short') }}</dt>
         <dd>{{ trait.summary }}</dd>
     {% endfor %}
-
+    </dl>
+{% endif %}
+{% if node.enums is not empty %}
+    <h4 id="toc-enums">
+        Enums
+        <a href="{{ link(node) }}#toc-enums" class="headerlink"><i class="fas fa-link"></i></a>
+    </h4>
+    <dl class="phpdocumentor-table-of-contents">
     {% for enum in node.enums %}
         <dt class="phpdocumentor-table-of-contents__entry -enum">{{ enum|route('class:short') }}</dt>
         <dd>{{ enum.summary }}</dd>
@@ -53,21 +83,11 @@
 </dl>
 {% endif %}
 
-{% set constants = constants(node) %}
-{% set properties = properties(node) %}
-{% set methods = methods(node) %}
-{% set cases = cases(node) %}
-{% set functions = node.functions|default([]) %}
-
-{% if constants is not empty or functions is not empty or methods is not empty or properties is not empty or cases is not empty %}
-    <h3 id="toc">
-        Table of Contents
-        <a href="#toc" class="headerlink"><i class="fas fa-link"></i></a>
-    </h3>
-{% endif %}
-
 {% if constants is not empty %}
-<h4>Constants</h4>
+<h4 id="toc-constants">
+    Constants
+    <a href="{{ link(node) }}#toc-constants" class="headerlink"><i class="fas fa-link"></i></a>
+</h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for constant in constants|sortByVisibility %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'constant', 'node': constant}) }}
@@ -76,7 +96,10 @@
 {% endif %}
 
 {% if cases is not empty %}
-<h4>Cases</h4>
+<h4 id="toc-cases">
+    Cases
+    <a href="{{ link(node) }}#toc-cases" class="headerlink"><i class="fas fa-link"></i></a>
+</h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for case in cases|sortByVisibility %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'case', 'node': case}) }}
@@ -85,7 +108,10 @@
 {% endif %}
 
 {% if properties is not empty %}
-<h4>Properties</h4>
+<h4 id="toc-properties">
+    Properties
+    <a href="{{ link(node) }}#toc-properties" class="headerlink"><i class="fas fa-link"></i></a>
+</h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for property in properties|sortByVisibility %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'property', 'node': property}) }}
@@ -94,7 +120,10 @@
 {% endif %}
 
 {% if methods is not empty %}
-<h4>Methods</h4>
+<h4 id="toc-methods">
+    Methods
+    <a href="{{ link(node) }}#toc-methods" class="headerlink"><i class="fas fa-link"></i></a>
+</h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for method in methods|sortByVisibility %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'method', 'node': method}) }}
@@ -103,7 +132,10 @@
 {% endif %}
 
 {% if functions is not empty %}
-<h4>Functions</h4>
+<h4 id="toc-functions">
+    Functions
+    <a href="{{ link(node) }}#toc-functions" class="headerlink"><i class="fas fa-link"></i></a>
+</h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for function in functions %}
         {{ include('components/table-of-contents-entry.html.twig', {'type': 'function', 'node': function}) }}

--- a/data/templates/default/css/base.css.twig
+++ b/data/templates/default/css/base.css.twig
@@ -38,5 +38,6 @@ body {
 {% include 'components/search.css.twig' %}
 {% include 'components/search-results.css.twig' %}
 {% include 'components/source-modal.css.twig' %}
+{% include 'components/on-this-page.css.twig' %}
 
 {% include 'css/utilities.css.twig' %}

--- a/data/templates/default/css/variables.css.twig
+++ b/data/templates/default/css/variables.css.twig
@@ -24,7 +24,7 @@
     --primary-color-saturation: 57%;
     --primary-color: hsl(var(--primary-color-hue), var(--primary-color-saturation), 60%);
     --primary-color-darken: hsl(var(--primary-color-hue), var(--primary-color-saturation), 40%);
-    --primary-color-darker: hsl(var(--primary-color-hue), var(--primary-color-saturation), 20%);
+    --primary-color-darker: hsl(var(--primary-color-hue), var(--primary-color-saturation), 25%);
     --primary-color-darkest: hsl(var(--primary-color-hue), var(--primary-color-saturation), 10%);
     --primary-color-lighten: hsl(var(--primary-color-hue), var(--primary-color-saturation), 80%);
     --primary-color-lighter: hsl(var(--primary-color-hue), var(--primary-color-saturation), 99%);
@@ -43,8 +43,8 @@
     --button-text-color: #555;
     --button-text-color-primary: white;
     --popover-background-color: rgba(255, 255, 255, 0.75);
-    --link-color-primary: var(--primary-color-darken);
-    --link-hover-color-primary: var(--primary-color-darker);
+    --link-color-primary: var(--primary-color-darker);
+    --link-hover-color-primary: var(--primary-color-darkest);
     --form-field-border-color: var(--dark-gray);
     --form-field-color: #fff;
     --admonition-success-color: var(--primary-color);

--- a/data/templates/default/enum.html.twig
+++ b/data/templates/default/enum.html.twig
@@ -18,8 +18,9 @@
     {% set cases = cases(node) %}
     {% set methods = methods(node) %}
 
-    <div class="phpdocumentor-on-this-page__content">
-        <strong>On this page</strong>
+    <section class="phpdocumentor-on-this-page__content">
+        <strong class="phpdocumentor-on-this-page__title">On this page</strong>
+
         <ul class="phpdocumentor-list -clean">
             <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
             <li>
@@ -54,5 +55,5 @@
                 </li>
             {% endif %}
         </ul>
-    </div>
+    </section>
 {% endblock %}

--- a/data/templates/default/enum.html.twig
+++ b/data/templates/default/enum.html.twig
@@ -22,7 +22,7 @@
         <strong class="phpdocumentor-on-this-page__title">On this page</strong>
 
         <ul class="phpdocumentor-list -clean">
-            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li class="phpdocumentor-on-this-page-section__title">Table Of Contents</li>
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% if cases is not empty %}
@@ -34,7 +34,7 @@
                 </ul>
             </li>
             {% if cases is not empty %}
-                <li>Cases</li>
+                <li class="phpdocumentor-on-this-page-section__title">Cases</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for case in cases %}
@@ -45,7 +45,7 @@
             {% endif %}
 
             {% if methods is not empty %}
-                <li>Methods</li>
+                <li class="phpdocumentor-on-this-page-section__title">Methods</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for method in methods|sortByVisibility %}

--- a/data/templates/default/enum.html.twig
+++ b/data/templates/default/enum.html.twig
@@ -13,3 +13,46 @@
         {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}
+
+{% block on_this_page %}
+    {% set cases = cases(node) %}
+    {% set methods = methods(node) %}
+
+    <div class="phpdocumentor-on-this-page__content">
+        <strong>On this page</strong>
+        <ul class="phpdocumentor-list -clean">
+            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li>
+                <ul class="phpdocumentor-list -clean">
+                    {% if cases is not empty %}
+                        <li><a href="{{ link(node) }}#toc-cases">Cases</a></li>
+                    {% endif %}
+                    {% if methods is not empty %}
+                        <li><a href="{{ link(node) }}#toc-methods">Methods</a></li>
+                    {% endif %}
+                </ul>
+            </li>
+            {% if cases is not empty %}
+                <li>Cases</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for case in cases %}
+                            <li><a href="{{ link(case) }}">{{ case.name }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+
+            {% if methods is not empty %}
+                <li>Methods</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for method in methods|sortByVisibility %}
+                            <li><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+        </ul>
+    </div>
+{% endblock %}

--- a/data/templates/default/file.html.twig
+++ b/data/templates/default/file.html.twig
@@ -17,8 +17,9 @@
     {% set constants = constants(node) %}
     {% set functions = node.functions|default([]) %}
 
-    <div class="phpdocumentor-on-this-page__content">
-        <strong>On this page</strong>
+    <section class="phpdocumentor-on-this-page__content">
+        <strong class="phpdocumentor-on-this-page__title">On this page</strong>
+
         <ul class="phpdocumentor-list -clean">
             <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
             <li>
@@ -72,5 +73,5 @@
                 </li>
             {% endif %}
         </ul>
-    </div>
+    </section>
 {% endblock %}

--- a/data/templates/default/file.html.twig
+++ b/data/templates/default/file.html.twig
@@ -12,3 +12,65 @@
         {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}
+
+{% block on_this_page %}
+    {% set constants = constants(node) %}
+    {% set functions = node.functions|default([]) %}
+
+    <div class="phpdocumentor-on-this-page__content">
+        <strong>On this page</strong>
+        <ul class="phpdocumentor-list -clean">
+            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li>
+                <ul class="phpdocumentor-list -clean">
+                    {% if node.packages is not empty %}
+                        <li><a href="{{ link(node) }}#packages">Packages</a></li>
+                    {% endif %}
+                    {% if node.namespaces is not empty %}
+                        <li><a href="{{ link(node) }}#namespaces">Namespaces</a></li>
+                    {% endif %}
+                    {% if node.interfaces is not empty %}
+                        <li><a href="{{ link(node) }}#toc-interfaces">Interfaces</a></li>
+                    {% endif %}
+                    {% if node.classes is not empty %}
+                        <li><a href="{{ link(node) }}#toc-classes">Classes</a></li>
+                    {% endif %}
+                    {% if node.traits is not empty %}
+                        <li><a href="{{ link(node) }}#toc-traits">Traits</a></li>
+                    {% endif %}
+                    {% if node.enums is not empty %}
+                        <li><a href="{{ link(node) }}#toc-enums">Enums</a></li>
+                    {% endif %}
+                    {% if node.constants is not empty %}
+                        <li><a href="{{ link(node) }}#toc-constants">Constants</a></li>
+                    {% endif %}
+                    {% if node.functions is not empty %}
+                        <li><a href="{{ link(node) }}#toc-functions">Functions</a></li>
+                    {% endif %}
+                </ul>
+            </li>
+
+            {% if constants is not empty %}
+                <li>Constants</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for constant in constants|sortByVisibility %}
+                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+
+            {% if functions is not empty %}
+                <li>Functions</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for function in functions|sortByVisibility %}
+                            <li><a href="{{ link(function) }}">{{ function.name }}()</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+        </ul>
+    </div>
+{% endblock %}

--- a/data/templates/default/file.html.twig
+++ b/data/templates/default/file.html.twig
@@ -21,7 +21,7 @@
         <strong class="phpdocumentor-on-this-page__title">On this page</strong>
 
         <ul class="phpdocumentor-list -clean">
-            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li class="phpdocumentor-on-this-page-section__title">Table Of Contents</li>
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% if node.packages is not empty %}
@@ -52,7 +52,7 @@
             </li>
 
             {% if constants is not empty %}
-                <li>Constants</li>
+                <li class="phpdocumentor-on-this-page-section__title">Constants</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
@@ -63,7 +63,7 @@
             {% endif %}
 
             {% if functions is not empty %}
-                <li>Functions</li>
+                <li class="phpdocumentor-on-this-page-section__title">Functions</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for function in functions|sortByVisibility %}

--- a/data/templates/default/interface.html.twig
+++ b/data/templates/default/interface.html.twig
@@ -13,3 +13,42 @@
         {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}
+
+{% block on_this_page %}
+    {% set constants = constants(node) %}
+    {% set methods = methods(node) %}
+
+    <div class="phpdocumentor-on-this-page__content">
+        <strong>On this page</strong>
+        <ul class="phpdocumentor-list -clean">
+            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li>
+                <ul class="phpdocumentor-list -clean">
+                    <li><a href="{{ link(node) }}#toc-constants">Constants</a></li>
+                    <li><a href="{{ link(node) }}#toc-methods">Methods</a></li>
+                </ul>
+            </li>
+            {% if methods is not empty %}
+                <li>Methods</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for method in methods|sortByVisibility %}
+                            <li><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+
+            {% if constants is not empty %}
+                <li>Constants</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for constant in constants|sortByVisibility %}
+                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+        </ul>
+    </div>
+{% endblock %}

--- a/data/templates/default/interface.html.twig
+++ b/data/templates/default/interface.html.twig
@@ -22,7 +22,7 @@
         <strong class="phpdocumentor-on-this-page__title">On this page</strong>
 
         <ul class="phpdocumentor-list -clean">
-            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li class="phpdocumentor-on-this-page-section__title">Table Of Contents</li>
             <li>
                 <ul class="phpdocumentor-list -clean">
                     <li><a href="{{ link(node) }}#toc-constants">Constants</a></li>
@@ -30,7 +30,7 @@
                 </ul>
             </li>
             {% if methods is not empty %}
-                <li>Methods</li>
+                <li class="phpdocumentor-on-this-page-section__title">Methods</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for method in methods|sortByVisibility %}
@@ -41,7 +41,7 @@
             {% endif %}
 
             {% if constants is not empty %}
-                <li>Constants</li>
+                <li class="phpdocumentor-on-this-page-section__title">Constants</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}

--- a/data/templates/default/interface.html.twig
+++ b/data/templates/default/interface.html.twig
@@ -18,8 +18,9 @@
     {% set constants = constants(node) %}
     {% set methods = methods(node) %}
 
-    <div class="phpdocumentor-on-this-page__content">
-        <strong>On this page</strong>
+    <section class="phpdocumentor-on-this-page__content">
+        <strong class="phpdocumentor-on-this-page__title">On this page</strong>
+
         <ul class="phpdocumentor-list -clean">
             <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
             <li>
@@ -50,5 +51,5 @@
                 </li>
             {% endif %}
         </ul>
-    </div>
+    </section>
 {% endblock %}

--- a/data/templates/default/layout.html.twig
+++ b/data/templates/default/layout.html.twig
@@ -35,8 +35,17 @@
         <div class="phpdocumentor-section">
             {% include 'components/sidebar.html.twig' %}
 
-            <div class="phpdocumentor-column -eight phpdocumentor-content">
-                {% block content %}{% endblock %}
+            <div class="phpdocumentor-column -nine phpdocumentor-content">
+                {% if block('on_this_page') is defined %}
+                <section class="phpdocumentor-column -nine">
+                {% endif %}
+                    {% block content %}{% endblock %}
+                {% if block('on_this_page') is defined %}
+                </section>
+                <section class="phpdocumentor-column -three phpdocumentor-on-this-page__sidebar">
+                    {{ block('on_this_page') }}
+                </section>
+                {% endif %}
                 {% include 'components/search-results.html.twig' %}
             </div>
         </div>

--- a/data/templates/default/namespace.html.twig
+++ b/data/templates/default/namespace.html.twig
@@ -48,16 +48,6 @@
                     {% endif %}
                 </ul>
             </li>
-            {% if functions is not empty %}
-                <li>Functions</li>
-                <li>
-                    <ul class="phpdocumentor-list -clean">
-                        {% for function in functions|sortByVisibility %}
-                            <li><a href="{{ link(function) }}">{{ function.name }}()</a></li>
-                        {% endfor %}
-                    </ul>
-                </li>
-            {% endif %}
 
             {% if constants is not empty %}
                 <li>Constants</li>
@@ -65,6 +55,17 @@
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
                             <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+
+            {% if functions is not empty %}
+                <li>Functions</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for function in functions|sortByVisibility %}
+                            <li><a href="{{ link(function) }}">{{ function.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/namespace.html.twig
+++ b/data/templates/default/namespace.html.twig
@@ -20,7 +20,7 @@
         <strong class="phpdocumentor-on-this-page__title">On this page</strong>
 
         <ul class="phpdocumentor-list -clean">
-            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li class="phpdocumentor-on-this-page-section__title">Table Of Contents</li>
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% if node.packages is not empty %}
@@ -51,7 +51,7 @@
             </li>
 
             {% if constants is not empty %}
-                <li>Constants</li>
+                <li class="phpdocumentor-on-this-page-section__title">Constants</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
@@ -62,7 +62,7 @@
             {% endif %}
 
             {% if functions is not empty %}
-                <li>Functions</li>
+                <li class="phpdocumentor-on-this-page-section__title">Functions</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for function in functions|sortByVisibility %}

--- a/data/templates/default/namespace.html.twig
+++ b/data/templates/default/namespace.html.twig
@@ -16,8 +16,9 @@
     {% set constants = constants(node) %}
     {% set functions = node.functions|default([]) %}
 
-    <div class="phpdocumentor-on-this-page__content">
-        <strong>On this page</strong>
+    <section class="phpdocumentor-on-this-page__content">
+        <strong class="phpdocumentor-on-this-page__title">On this page</strong>
+
         <ul class="phpdocumentor-list -clean">
             <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
             <li>
@@ -71,5 +72,5 @@
                 </li>
             {% endif %}
         </ul>
-    </div>
+    </section>
 {% endblock %}

--- a/data/templates/default/namespace.html.twig
+++ b/data/templates/default/namespace.html.twig
@@ -11,3 +11,64 @@
         {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}
+
+{% block on_this_page %}
+    {% set constants = constants(node) %}
+    {% set functions = node.functions|default([]) %}
+
+    <div class="phpdocumentor-on-this-page__content">
+        <strong>On this page</strong>
+        <ul class="phpdocumentor-list -clean">
+            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li>
+                <ul class="phpdocumentor-list -clean">
+                    {% if node.packages is not empty %}
+                    <li><a href="{{ link(node) }}#packages">Packages</a></li>
+                    {% endif %}
+                    {% if node.namespaces is not empty %}
+                    <li><a href="{{ link(node) }}#namespaces">Namespaces</a></li>
+                    {% endif %}
+                    {% if node.interfaces is not empty %}
+                    <li><a href="{{ link(node) }}#toc-interfaces">Interfaces</a></li>
+                    {% endif %}
+                    {% if node.classes is not empty %}
+                    <li><a href="{{ link(node) }}#toc-classes">Classes</a></li>
+                    {% endif %}
+                    {% if node.traits is not empty %}
+                    <li><a href="{{ link(node) }}#toc-traits">Traits</a></li>
+                    {% endif %}
+                    {% if node.enums is not empty %}
+                    <li><a href="{{ link(node) }}#toc-enums">Enums</a></li>
+                    {% endif %}
+                    {% if node.constants is not empty %}
+                    <li><a href="{{ link(node) }}#toc-constants">Constants</a></li>
+                    {% endif %}
+                    {% if node.functions is not empty %}
+                    <li><a href="{{ link(node) }}#toc-functions">Functions</a></li>
+                    {% endif %}
+                </ul>
+            </li>
+            {% if functions is not empty %}
+                <li>Functions</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for function in functions|sortByVisibility %}
+                            <li><a href="{{ link(function) }}">{{ function.name }}()</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+
+            {% if constants is not empty %}
+                <li>Constants</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for constant in constants|sortByVisibility %}
+                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+        </ul>
+    </div>
+{% endblock %}

--- a/data/templates/default/objects/lists.css.twig
+++ b/data/templates/default/objects/lists.css.twig
@@ -16,8 +16,15 @@ div.phpdocumentor-list > ul,
 ol.phpdocumentor-list,
 ul.phpdocumentor-list {
     margin-top: 0;
-    padding-left: 1rem;
-    margin-bottom: var(--spacing-md);
+    padding-left: var(--spacing-md);
+    margin-bottom: var(--spacing-sm);
+}
+
+.phpdocumentor-column ul.-clean,
+div.phpdocumentor-list > ul.-clean,
+ul.phpdocumentor-list.-clean {
+    list-style: none;
+    padding-left: 0;
 }
 
 dl {
@@ -31,7 +38,7 @@ ul.phpdocumentor-list ol.phpdocumentor-list,
 ol.phpdocumentor-list ol.phpdocumentor-list,
 ol.phpdocumentor-list ul.phpdocumentor-list {
     font-size: var(--text-sm);
-    margin: var(--spacing-xs) 0 var(--spacing-xs) calc(var(--spacing-xs) * 2);
+    margin: 0 0 0 calc(var(--spacing-xs) * 2);
 }
 
 .phpdocumentor-column ul li,

--- a/data/templates/default/package.html.twig
+++ b/data/templates/default/package.html.twig
@@ -20,7 +20,7 @@
         <strong class="phpdocumentor-on-this-page__title">On this page</strong>
 
         <ul class="phpdocumentor-list -clean">
-            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li class="phpdocumentor-on-this-page-section__title">Table Of Contents</li>
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% if node.packages is not empty %}
@@ -51,7 +51,7 @@
             </li>
 
             {% if constants is not empty %}
-                <li>Constants</li>
+                <li class="phpdocumentor-on-this-page-section__title">Constants</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
@@ -62,7 +62,7 @@
             {% endif %}
 
             {% if functions is not empty %}
-                <li>Functions</li>
+                <li class="phpdocumentor-on-this-page-section__title">Functions</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for function in functions|sortByVisibility %}

--- a/data/templates/default/package.html.twig
+++ b/data/templates/default/package.html.twig
@@ -16,8 +16,9 @@
     {% set constants = constants(node) %}
     {% set functions = node.functions|default([]) %}
 
-    <div class="phpdocumentor-on-this-page__content">
-        <strong>On this page</strong>
+    <section class="phpdocumentor-on-this-page__content">
+        <strong class="phpdocumentor-on-this-page__title">On this page</strong>
+
         <ul class="phpdocumentor-list -clean">
             <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
             <li>
@@ -71,5 +72,5 @@
                 </li>
             {% endif %}
         </ul>
-    </div>
+    </section>
 {% endblock %}

--- a/data/templates/default/package.html.twig
+++ b/data/templates/default/package.html.twig
@@ -11,3 +11,65 @@
         {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}
+
+{% block on_this_page %}
+    {% set constants = constants(node) %}
+    {% set functions = node.functions|default([]) %}
+
+    <div class="phpdocumentor-on-this-page__content">
+        <strong>On this page</strong>
+        <ul class="phpdocumentor-list -clean">
+            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li>
+                <ul class="phpdocumentor-list -clean">
+                    {% if node.packages is not empty %}
+                        <li><a href="{{ link(node) }}#packages">Packages</a></li>
+                    {% endif %}
+                    {% if node.namespaces is not empty %}
+                        <li><a href="{{ link(node) }}#namespaces">Namespaces</a></li>
+                    {% endif %}
+                    {% if node.interfaces is not empty %}
+                        <li><a href="{{ link(node) }}#toc-interfaces">Interfaces</a></li>
+                    {% endif %}
+                    {% if node.classes is not empty %}
+                        <li><a href="{{ link(node) }}#toc-classes">Classes</a></li>
+                    {% endif %}
+                    {% if node.traits is not empty %}
+                        <li><a href="{{ link(node) }}#toc-traits">Traits</a></li>
+                    {% endif %}
+                    {% if node.enums is not empty %}
+                        <li><a href="{{ link(node) }}#toc-enums">Enums</a></li>
+                    {% endif %}
+                    {% if node.constants is not empty %}
+                        <li><a href="{{ link(node) }}#toc-constants">Constants</a></li>
+                    {% endif %}
+                    {% if node.functions is not empty %}
+                        <li><a href="{{ link(node) }}#toc-functions">Functions</a></li>
+                    {% endif %}
+                </ul>
+            </li>
+
+            {% if constants is not empty %}
+                <li>Constants</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for constant in constants|sortByVisibility %}
+                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+
+            {% if functions is not empty %}
+                <li>Functions</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for function in functions|sortByVisibility %}
+                            <li><a href="{{ link(function) }}">{{ function.name }}()</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+        </ul>
+    </div>
+{% endblock %}

--- a/data/templates/default/trait.html.twig
+++ b/data/templates/default/trait.html.twig
@@ -18,8 +18,9 @@
     {% set properties = properties(node) %}
     {% set methods = methods(node) %}
 
-    <div class="phpdocumentor-on-this-page__content">
-        <strong>On this page</strong>
+    <section class="phpdocumentor-on-this-page__content">
+        <strong class="phpdocumentor-on-this-page__title">On this page</strong>
+
         <ul class="phpdocumentor-list -clean">
             <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
             <li>
@@ -50,5 +51,5 @@
                 </li>
             {% endif %}
         </ul>
-    </div>
+    </section>
 {% endblock %}

--- a/data/templates/default/trait.html.twig
+++ b/data/templates/default/trait.html.twig
@@ -13,3 +13,42 @@
         {{ include('components/source-modal.html.twig') }}
     </article>
 {% endblock %}
+
+{% block on_this_page %}
+    {% set properties = properties(node) %}
+    {% set methods = methods(node) %}
+
+    <div class="phpdocumentor-on-this-page__content">
+        <strong>On this page</strong>
+        <ul class="phpdocumentor-list -clean">
+            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li>
+                <ul class="phpdocumentor-list -clean">
+                    <li><a href="{{ link(node) }}#toc-properties">Properties</a></li>
+                    <li><a href="{{ link(node) }}#toc-methods">Methods</a></li>
+                </ul>
+            </li>
+            {% if methods is not empty %}
+                <li>Methods</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for method in methods|sortByVisibility %}
+                            <li><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+
+            {% if properties is not empty %}
+                <li>Properties</li>
+                <li>
+                    <ul class="phpdocumentor-list -clean">
+                        {% for property in properties|sortByVisibility %}
+                            <li><a href="{{ link(property) }}">${{ property.name }}<a href="{{ link(node) }}"></li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            {% endif %}
+        </ul>
+    </div>
+{% endblock %}

--- a/data/templates/default/trait.html.twig
+++ b/data/templates/default/trait.html.twig
@@ -22,7 +22,7 @@
         <strong class="phpdocumentor-on-this-page__title">On this page</strong>
 
         <ul class="phpdocumentor-list -clean">
-            <li><a href="{{ link(node) }}#toc">Table Of Contents</a></li>
+            <li class="phpdocumentor-on-this-page-section__title">Table Of Contents</li>
             <li>
                 <ul class="phpdocumentor-list -clean">
                     <li><a href="{{ link(node) }}#toc-properties">Properties</a></li>
@@ -30,7 +30,7 @@
                 </ul>
             </li>
             {% if methods is not empty %}
-                <li>Methods</li>
+                <li class="phpdocumentor-on-this-page-section__title">Methods</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for method in methods|sortByVisibility %}
@@ -41,7 +41,7 @@
             {% endif %}
 
             {% if properties is not empty %}
-                <li>Properties</li>
+                <li class="phpdocumentor-on-this-page-section__title">Properties</li>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for property in properties|sortByVisibility %}


### PR DESCRIPTION
New 'on this page' summary in a sidebar, including fixes on the deeplinks (they are pointing to the wrong location) and some styling and spacing adjustments

<hr></hr>

![image](https://user-images.githubusercontent.com/193704/204129451-4f5b3593-bd88-4935-ba41-9772fe97180e.png)
