### PR TITLE
Convert tabs to spaces when parsing ReST

### DIFF
--- a/incubator/guides-restructured-text/src/RestructuredText/Parser/LinesIterator.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Parser/LinesIterator.php
@@ -18,8 +18,11 @@ use OutOfBoundsException;
 
 use function chr;
 use function explode;
+use function preg_replace_callback;
 use function sprintf;
+use function str_repeat;
 use function str_replace;
+use function strlen;
 use function trim;
 
 /**
@@ -28,16 +31,30 @@ use function trim;
 class LinesIterator implements Iterator
 {
     /** @var string[] */
-    private $lines = [];
-
-    /** @var int */
-    private $position = 0;
+    private array $lines = [];
+    private int $position = 0;
 
     public function load(string $document): void
     {
         $document = trim($this->prepareDocument($document));
         $this->lines = explode("\n", $document);
+
+        foreach ($this->lines as $key => $line) {
+            $this->lines[$key] = $this->tabToSpaces($line);
+        }
+
         $this->rewind();
+    }
+
+    private function tabToSpaces(string $line): string
+    {
+        $tabStop = 8;
+
+        return preg_replace_callback(
+            '/^(\t*)/',
+            static fn ($matches) => str_repeat(' ', strlen($matches[1]) * $tabStop),
+            $line
+        );
     }
 
     public function getNextLine(): ?string

--- a/incubator/guides-restructured-text/src/RestructuredText/Parser/Productions/ListRule.php
+++ b/incubator/guides-restructured-text/src/RestructuredText/Parser/Productions/ListRule.php
@@ -57,8 +57,7 @@ final class ListRule implements Rule
          # (or eol, if text starts on a new line)
         /ux';
 
-    /** @var MarkupLanguageParser */
-    private $parser;
+    private MarkupLanguageParser $parser;
 
     public function __construct(MarkupLanguageParser $parser)
     {


### PR DESCRIPTION
RestructureText is a line-based indentation sensitive format. To support tabs and make this easier to parse, we need to convert tab indentation into spaces internally. This will allow for a universal bit of logic when dealing with indentation.