### PR TITLE
Back to top doesn't work in Guides

### DIFF
--- a/data/templates/default/components/back-to-top.html.twig
+++ b/data/templates/default/components/back-to-top.html.twig
@@ -1,1 +1,1 @@
-<a href="{{ target_path }}#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>
+<a href="{{ target_path ?: env.currentFileDestination }}#top" class="phpdocumentor-back-to-top"><i class="fas fa-chevron-circle-up"></i></a>


### PR DESCRIPTION
Guides doesn't provide the target_path global that points to the current file's path relative to the BASE tag. This means that it was left empty when rendering guides, and that top always pointed to the BASE.

Although it would probably be better to make a fix that can universally support both render pipelines, the current guides implementation is in flux and I am solving it by taking the current path from the RenderContext

Fixes #3350 