### PR TITLE
Show whether a method is tagged as 'api'

### DIFF
--- a/data/templates/default/components/class-title.html.twig
+++ b/data/templates/default/components/class-title.html.twig
@@ -39,14 +39,14 @@
 
 <div class="phpdocumentor-label-line">
 {% if node.isReadOnly %}
-    <div class="phpdocumentor-label phpdocumentor-label--success"><span>Read only</span><span>Yes</span></div>
+    {{ include('components/label.html.twig', {name: 'Read only', value: 'Yes'}, with_context = false) }}
 {% endif %}
 
 {% if node.isFinal %}
-    <div class="phpdocumentor-label phpdocumentor-label--success"><span>Final</span><span>Yes</span></div>
+    {{ include('components/label.html.twig', {name: 'Final', value: 'Yes'}, with_context = false) }}
 {% endif %}
 
 {% if node.isAbstract %}
-    <div class="phpdocumentor-label phpdocumentor-label--success"><span>Abstract</span><span>Yes</span></div>
+    {{ include('components/label.html.twig', {name: 'Abstract', value: 'Yes'}, with_context = false) }}
 {% endif %}
 </div>

--- a/data/templates/default/components/label.html.twig
+++ b/data/templates/default/components/label.html.twig
@@ -1,0 +1,1 @@
+<div class="phpdocumentor-label phpdocumentor-label--{{ type|default('success') }}"><span>{{ name }}</span><span>{{ value }}</span></div>

--- a/data/templates/default/components/method-response.html.twig
+++ b/data/templates/default/components/method-response.html.twig
@@ -1,8 +1,10 @@
-{% if (node.response.type and node.response.type != 'void') or node.response.description %}
-    <h5 class="phpdocumentor-return-value__heading">Return values</h5>
-    <span class="phpdocumentor-signature__response_type">{{ node.response.type|route('class:short')|join('|')|raw }}</span>
-    {% if node.response %}
-        &mdash;
-        {{ include('components/description.html.twig', {'node': node.response}) }}
-    {% endif %}
+{% if (node.response.type and node.response.type != 'void' and node.response.type != 'mixed') or not node.response.description.empty %}
+        <section>
+        <h5 class="phpdocumentor-return-value__heading">Return values</h5>
+        <span class="phpdocumentor-signature__response_type">{{ node.response.type|route('class:short')|join('|')|raw }}</span>
+        {% if not node.response.description.empty %}
+            &mdash;
+            {{ include('components/description.html.twig', {'node': node.response}) }}
+        {% endif %}
+    </section>
 {% endif %}

--- a/data/templates/default/components/method.html.twig
+++ b/data/templates/default/components/method.html.twig
@@ -15,6 +15,11 @@
     {{ include('components/element-found-in.html.twig', {'node': method}) }}
     {{ include('components/summary.html.twig', {'node': method}) }}
     {{ include('components/method-signature.html.twig', {'node': method}) }}
+    <div class="phpdocumentor-label-line">
+    {% if method.tags.api %}
+        {{ include('components/label.html.twig', {name: 'API', value: 'Yes'}, with_context = false) }}
+    {% endif %}
+    </div>
     {{ include('components/description.html.twig', {'node': method}) }}
     {{ include('components/method-arguments.html.twig', {'node': method}) }}
     {{ include('components/tags.html.twig', {'node': method }) }}

--- a/data/templates/default/objects/forms.css.twig
+++ b/data/templates/default/objects/forms.css.twig
@@ -38,7 +38,7 @@ textarea {
     outline: 0;
 }
 
-.phpdocumentor-label {
+label.phpdocumentor-label {
     display: block;
     margin-bottom: var(--spacing-xs);
 }

--- a/data/templates/default/objects/labels.css.twig
+++ b/data/templates/default/objects/labels.css.twig
@@ -1,5 +1,7 @@
 .phpdocumentor-label-line {
-    display: flex; flex-direction: row; gap: 1rem
+    display: flex;
+    flex-direction: row;
+    gap: 1rem
 }
 
 .phpdocumentor-label {
@@ -8,6 +10,14 @@
     font-size: 80%;
     display: inline-block;
     overflow: hidden
+}
+
+/*
+It would be better if the phpdocumentor-element class were to become a flex element with a gap, but for #3337 that
+is too big a fix and needs to be done in a new design iteration.
+*/
+.phpdocumentor-signature + .phpdocumentor-label-line .phpdocumentor-label {
+    margin-top: var(--spacing-sm);
 }
 
 .phpdocumentor-label span {


### PR DESCRIPTION
In the default template, there is no indication whether an element is tagged with the `api` tag, this change fixes that for methods at least.

Another change included in this commit is that we now properly do not render response descriptions, including the em-dash, when there is none to render, and when it is of type mixed without a description we also omit rendering of the result because it doesn't add anything.

Example rendering:

![image](https://user-images.githubusercontent.com/193704/205489611-1b9655ad-b2db-40a8-9d36-546296b72469.png)

Fixes #3337 