### PR TITLE
Fix aggregated types sometimes rendered wrong; closes 3323

### DIFF
--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -25,6 +25,7 @@ use phpDocumentor\Reflection\DocBlock\Tags\Reference;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\AbstractList;
+use phpDocumentor\Reflection\Types\AggregatedType;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Collection;
 use phpDocumentor\Reflection\Types\Iterable_;
@@ -273,6 +274,10 @@ final class LinkRenderer
 
         if ($node instanceof AbstractList) {
             return $this->renderAbstractListLinks($node, $presentation);
+        }
+
+        if ($node instanceof AggregatedType) {
+            return implode($node->getToken(), $this->renderASeriesOfLinks($node, $presentation));
         }
 
         // With an unlinked object, we don't know if the page for it exists; so we don't render a link to it.


### PR DESCRIPTION
Fixes the rendering of aggregated types being rendered wrong when using them for example as value type in an array.

Needs a patch for phpdocumentor-typeresolver ([see here](https://github.com/phpDocumentor/TypeResolver/pull/179)) to add a method `getToken()` to actually get the token (seperator) from the aggregated type.