### PR TITLE
Move headerlinks to component

### DIFF
--- a/data/templates/default/components/constant.html.twig
+++ b/data/templates/default/components/constant.html.twig
@@ -1,7 +1,7 @@
 <article class="phpdocumentor-element -constant -{{ constant.visibility }} {% if constant.deprecated %}-deprecated{% endif %}">
     <h4 class="phpdocumentor-element__name" id="constant_{{ constant.name }}">
         {{ constant.name }}
-        <a href="{{ link(constant) }}" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': constant}, with_context = false) }}
     </h4>
 
     {{ include('components/element-found-in.html.twig', {'node': constant}) }}

--- a/data/templates/default/components/constants.html.twig
+++ b/data/templates/default/components/constants.html.twig
@@ -4,7 +4,7 @@
     <section class="phpdocumentor-constants">
         <h3 class="phpdocumentor-elements__header" id="constants">
             Constants
-            <a href="{{ link(node) }}#constants" class="headerlink"><i class="fas fa-link"></i></a>
+            {{ include('components/headerlink.html.twig', {'on': node, 'at': 'constants'}, with_context = false) }}
         </h3>
         {% for constant in constants %}
             {% include 'components/constant.html.twig' %}

--- a/data/templates/default/components/enum-case.html.twig
+++ b/data/templates/default/components/enum-case.html.twig
@@ -6,7 +6,7 @@
 >
     <h4 class="phpdocumentor-element__name" id="enumcase_{{ case.name }}">
         {{ case.name }}
-        <a href="{{ link(case) }}" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': case}, with_context = false) }}
     </h4>
     {{ include('components/element-found-in.html.twig', {'node': case}) }}
     {{ include('components/summary.html.twig', {'node': case}) }}

--- a/data/templates/default/components/enum-cases.html.twig
+++ b/data/templates/default/components/enum-cases.html.twig
@@ -3,7 +3,7 @@
     <section class="phpdocumentor-cases">
         <h3 class="phpdocumentor-elements__header" id="cases">
             Cases
-            <a href="{{ link(node) }}#cases" class="headerlink"><i class="fas fa-link"></i></a>
+            {{ include('components/headerlink.html.twig', {'on': node, 'at': 'cases'}, with_context = false) }}
         </h3>
         {% for case in cases %}
             {% include 'components/enum-case.html.twig' %}

--- a/data/templates/default/components/function.html.twig
+++ b/data/templates/default/components/function.html.twig
@@ -1,7 +1,7 @@
 <article class="phpdocumentor-element -function -{{ function.visibility }} {% if function.deprecated %}-deprecated{% endif %}">
     <h4 class="phpdocumentor-element__name" id="function_{{ function.name }}">
         {{ function.name }}()
-        <a href="{{ link(function) }}" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': function}, with_context = false) }}
     </h4>
     {{ include('components/element-found-in.html.twig', {'node': function}) }}
     {{ include('components/summary.html.twig', {'node': function}) }}

--- a/data/templates/default/components/functions.html.twig
+++ b/data/templates/default/components/functions.html.twig
@@ -2,7 +2,7 @@
     <section class="phpdocumentor-functions">
         <h3 class="phpdocumentor-elements__header" id="functions">
             Functions
-            <a href="{{ link(node) }}#functions" class="headerlink"><i class="fas fa-link"></i></a>
+            {{ include('components/headerlink.html.twig', {'on': node, 'at': 'functions'}, with_context = false) }}
         </h3>
         {% for function in node.functions %}
             {% include 'components/function.html.twig' %}

--- a/data/templates/default/components/headerlink.css.twig
+++ b/data/templates/default/components/headerlink.css.twig
@@ -1,0 +1,34 @@
+.phpdocumentor h1 .headerlink,
+.phpdocumentor h2 .headerlink,
+.phpdocumentor h3 .headerlink,
+.phpdocumentor h4 .headerlink,
+.phpdocumentor h5 .headerlink,
+.phpdocumentor h6 .headerlink
+{
+    display: none;
+}
+
+@media (min-width: {{ breakpoints['md'] }}) {
+    .phpdocumentor h1 .headerlink,
+    .phpdocumentor h2 .headerlink,
+    .phpdocumentor h3 .headerlink,
+    .phpdocumentor h4 .headerlink,
+    .phpdocumentor h5 .headerlink,
+    .phpdocumentor h6 .headerlink {
+        display: inline;
+        transition: all .3s ease-in-out;
+        opacity: 0;
+        text-decoration: none;
+        color: silver;
+        font-size: 80%;
+    }
+
+    .phpdocumentor h1:hover .headerlink,
+    .phpdocumentor h2:hover .headerlink,
+    .phpdocumentor h3:hover .headerlink,
+    .phpdocumentor h4:hover .headerlink,
+    .phpdocumentor h5:hover .headerlink,
+    .phpdocumentor h6:hover .headerlink {
+        opacity: 1;
+    }
+}

--- a/data/templates/default/components/headerlink.html.twig
+++ b/data/templates/default/components/headerlink.html.twig
@@ -1,0 +1,1 @@
+<a href="{{ link(on) ~ (at ? ('#' ~ at)) }}" class="headerlink"><i class="fas fa-link"></i></a>

--- a/data/templates/default/components/method.html.twig
+++ b/data/templates/default/components/method.html.twig
@@ -10,7 +10,7 @@
 >
     <h4 class="phpdocumentor-element__name" id="method_{{ method.name }}">
         {{ method.name }}()
-        <a href="{{ link(method) }}" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': method}, with_context = false) }}
     </h4>
     {{ include('components/element-found-in.html.twig', {'node': method}) }}
     {{ include('components/summary.html.twig', {'node': method}) }}

--- a/data/templates/default/components/methods.html.twig
+++ b/data/templates/default/components/methods.html.twig
@@ -3,7 +3,7 @@
     <section class="phpdocumentor-methods">
         <h3 class="phpdocumentor-elements__header" id="methods">
             Methods
-            <a href="{{ link(node) }}#methods" class="headerlink"><i class="fas fa-link"></i></a>
+            {{ include('components/headerlink.html.twig', {'on': node, 'at': 'methods'}, with_context = false) }}
         </h3>
         {% for method in methods %}
             {% include 'components/method.html.twig' %}

--- a/data/templates/default/components/properties.html.twig
+++ b/data/templates/default/components/properties.html.twig
@@ -4,7 +4,7 @@
     <section class="phpdocumentor-properties">
         <h3 class="phpdocumentor-elements__header" id="properties">
             Properties
-            <a href="{{ link(node) }}#properties" class="headerlink"><i class="fas fa-link"></i></a>
+            {{ include('components/headerlink.html.twig', {'on': node, 'at': 'properties'}, with_context = false) }}
         </h3>
         {% for property in properties %}
             {% include 'components/property.html.twig' %}

--- a/data/templates/default/components/property.html.twig
+++ b/data/templates/default/components/property.html.twig
@@ -11,7 +11,7 @@
 >
     <h4 class="phpdocumentor-element__name" id="property_{{ property.name }}">
         ${{ property.name }}
-        <a href="{{ link(property) }}" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': property}, with_context = false) }}
         <span class="phpdocumentor-element__modifiers">
             {% if property.writeOnly %}<small class="phpdocumentor-element__modifier">write-only</small>{% endif %}
             {% if property.readOnly %}<small class="phpdocumentor-element__modifier">read-only</small>{% endif %}

--- a/data/templates/default/components/table-of-contents.html.twig
+++ b/data/templates/default/components/table-of-contents.html.twig
@@ -6,13 +6,13 @@
 
 <h3 id="toc">
     Table of Contents
-    <a href="{{ link(node) }}#toc" class="headerlink"><i class="fas fa-link"></i></a>
+    {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc'}, with_context = false) }}
 </h3>
 
 {% if packages|default([]) is not empty %}
 <h4 id="packages">
     Packages
-    <a href="{{ link(node) }}#packages" class="headerlink"><i class="fas fa-link"></i></a>
+    {{ include('components/headerlink.html.twig', {'on': node, 'at': 'packages'}, with_context = false) }}
 </h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for package in packages %}
@@ -24,7 +24,7 @@
 {% if namespaces|default([]) is not empty %}
 <h4 id="namespaces">
     Namespaces
-    <a href="{{ link(node) }}#namespaces" class="headerlink"><i class="fas fa-link"></i></a>
+    {{ include('components/headerlink.html.twig', {'on': node, 'at': 'namespaces'}, with_context = false) }}
 </h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for namespace in namespaces %}
@@ -36,7 +36,7 @@
 {% if node.interfaces is not empty %}
     <h4 id="toc-interfaces">
         Interfaces
-        <a href="{{ link(node) }}#toc-interfaces" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc-interfaces'}, with_context = false) }}
     </h4>
     <dl class="phpdocumentor-table-of-contents">
         {% for interface in node.interfaces %}
@@ -51,7 +51,7 @@
 {% if node.classes is not empty %}
     <h4 id="toc-classes">
         Classes
-        <a href="{{ link(node) }}#toc-classes" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc-classes'}, with_context = false) }}
     </h4>
     <dl class="phpdocumentor-table-of-contents">
         {% for class in node.classes %}
@@ -66,7 +66,7 @@
 {% if node.traits is not empty %}
     <h4 id="toc-traits">
         Traits
-        <a href="{{ link(node) }}#toc-traits" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc-traits'}, with_context = false) }}
     </h4>
     <dl class="phpdocumentor-table-of-contents">
     {% for trait in node.traits %}
@@ -81,7 +81,7 @@
 {% if node.enums is not empty %}
     <h4 id="toc-enums">
         Enums
-        <a href="{{ link(node) }}#toc-enums" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc-enums'}, with_context = false) }}
     </h4>
     <dl class="phpdocumentor-table-of-contents">
     {% for enum in node.enums %}
@@ -96,7 +96,7 @@
 {% if constants is not empty %}
 <h4 id="toc-constants">
     Constants
-    <a href="{{ link(node) }}#toc-constants" class="headerlink"><i class="fas fa-link"></i></a>
+    {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc-constants'}, with_context = false) }}
 </h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for constant in constants|sortByVisibility %}
@@ -108,7 +108,7 @@
 {% if cases is not empty %}
 <h4 id="toc-cases">
     Cases
-    <a href="{{ link(node) }}#toc-cases" class="headerlink"><i class="fas fa-link"></i></a>
+    {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc-cases'}, with_context = false) }}
 </h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for case in cases|sortByVisibility %}
@@ -120,7 +120,7 @@
 {% if properties is not empty %}
 <h4 id="toc-properties">
     Properties
-    <a href="{{ link(node) }}#toc-properties" class="headerlink"><i class="fas fa-link"></i></a>
+    {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc-properties'}, with_context = false) }}
 </h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for property in properties|sortByVisibility %}
@@ -132,7 +132,7 @@
 {% if methods is not empty %}
 <h4 id="toc-methods">
     Methods
-    <a href="{{ link(node) }}#toc-methods" class="headerlink"><i class="fas fa-link"></i></a>
+    {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc-methods'}, with_context = false) }}
 </h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for method in methods|sortByVisibility %}
@@ -144,7 +144,7 @@
 {% if functions is not empty %}
 <h4 id="toc-functions">
     Functions
-    <a href="{{ link(node) }}#toc-functions" class="headerlink"><i class="fas fa-link"></i></a>
+    {{ include('components/headerlink.html.twig', {'on': node, 'at': 'toc-functions'}, with_context = false) }}
 </h4>
 <dl class="phpdocumentor-table-of-contents">
     {% for function in functions %}

--- a/data/templates/default/components/tags.html.twig
+++ b/data/templates/default/components/tags.html.twig
@@ -3,7 +3,7 @@
 {% if tags|length > 0 and tags|first|length > 0 %}
     <h5 class="phpdocumentor-tag-list__heading" id="tags">
         Tags
-        <a href="#tags" class="headerlink"><i class="fas fa-link"></i></a>
+        {{ include('components/headerlink.html.twig', {'on': node, 'at': 'tags'}, with_context = false) }}
     </h5>
     <dl class="phpdocumentor-tag-list">
         {% for name,seriesOfTag in tags %}

--- a/data/templates/default/css/base.css.twig
+++ b/data/templates/default/css/base.css.twig
@@ -21,6 +21,7 @@ body {
 }
 
 {% include 'objects/headings.css.twig' %}
+{% include 'components/headerlink.css.twig' %}
 {% include 'objects/paragraph.css.twig' %}
 {% include 'objects/images.css.twig' %}
 {% include 'objects/line.css.twig' %}

--- a/data/templates/default/objects/headings.css.twig
+++ b/data/templates/default/objects/headings.css.twig
@@ -50,38 +50,3 @@
     margin-bottom: var(--spacing-md);
     margin-top: var(--spacing-md);
 }
-
-.phpdocumentor h1 .headerlink,
-.phpdocumentor h2 .headerlink,
-.phpdocumentor h3 .headerlink,
-.phpdocumentor h4 .headerlink,
-.phpdocumentor h5 .headerlink,
-.phpdocumentor h6 .headerlink
-{
-    display: none;
-}
-
-@media (min-width: {{ breakpoints['md'] }}) {
-    .phpdocumentor h1 .headerlink,
-    .phpdocumentor h2 .headerlink,
-    .phpdocumentor h3 .headerlink,
-    .phpdocumentor h4 .headerlink,
-    .phpdocumentor h5 .headerlink,
-    .phpdocumentor h6 .headerlink {
-        display: inline;
-        transition: all .3s ease-in-out;
-        opacity: 0;
-        text-decoration: none;
-        color: silver;
-        font-size: 80%;
-    }
-
-    .phpdocumentor h1:hover .headerlink,
-    .phpdocumentor h2:hover .headerlink,
-    .phpdocumentor h3:hover .headerlink,
-    .phpdocumentor h4:hover .headerlink,
-    .phpdocumentor h5:hover .headerlink,
-    .phpdocumentor h6:hover .headerlink {
-        opacity: 1;
-    }
-}


### PR DESCRIPTION
To fix #3042 and embrace components in the default template, I have moved the deep link anchors (headerlinks) onto a component and as such fix all locations where they were used. Apparently I missed the tags headerlink in the previous fix

Fixes #3042 