### PR TITLE
feat: preserve newlines in XML attributes

### DIFF
--- a/data/templates/xml/docblock.xml.twig
+++ b/data/templates/xml/docblock.xml.twig
@@ -7,7 +7,7 @@
         {% apply spaceless %}
         <tag
                 name="{{ tag.name }}"
-                description="{{ tag.description }}"
+                description="{{ tag.description|e|replace({"\n": "&#10;"})|raw }}"
                 {% if tag.link %} link="{{ tag.link }}"{% endif %}
                 {% if tag.version %} version="{{ tag.version }}"{% endif %}
                 {% if tag.reference %} link="{{ tag.reference }}"{% endif %}


### PR DESCRIPTION
I was able to test this via https://twigfiddle.com/s65ia4 and with my local checkout of `phpdoc`.

Essentially, this ensures that newlines are preserved in the XML attributes for `structure.xml`. Otherwise, the newline characters are lost.

Eg:

```xml
<method>
    <name>__construct</name>
    <docblock>
        <tag
            name="param"
            description="{
    Optional. Data for populating the Message object.

    @type string $name
          supply a name for this object
}"
            variable="options"
            type="array"
        />
    </docblock>
</method>
```

When usng `SimpleXMLElement`, this will be rendered without any newlines. E.g. `{    Optional. Data for populating the Message object.    @type string $name          supply a name for this object}`. 

By using the `replace` filter in twig, the result will instead be:

```xml
<method>
    <name>__construct</name>
    <docblock>
        <tag
            name="param"
            description="{&#10;    Optional. Data for populating the Message object.&#10;    @type string $name&#10;          supply a name for this object&#10;}"
            variable="options"
            type="array"
        />
    </docblock>
</method>
```