### PR TITLE
Warn when multiple versions and/or sets of each type is given

### DIFF
--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use InvalidArgumentException;
+use OutOfRangeException;
 use phpDocumentor\Configuration\ApiSpecification;
 use phpDocumentor\Descriptor\Builder\AssemblerFactory;
 use phpDocumentor\Descriptor\Builder\AssemblerInterface;
@@ -239,6 +240,12 @@ class ProjectDescriptorBuilder
 
     public function addVersion(VersionDescriptor $version): void
     {
+        if ($this->project->getVersions()->count() >= 1) {
+            throw new OutOfRangeException(
+                'phpDocumentor only supports 1 version at the moment, support for multiple versions is being worked on'
+            );
+        }
+
         $this->project->getVersions()->add($version);
     }
 }

--- a/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
+++ b/src/phpDocumentor/Pipeline/Stage/InitializeBuilderFromConfig.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Pipeline\Stage;
 
+use OutOfRangeException;
 use phpDocumentor\Configuration\VersionSpecification;
 use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\Collection;
@@ -21,6 +22,7 @@ use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\GuideSetDescriptor;
 use phpDocumentor\Descriptor\VersionDescriptor;
 
+use function count;
 use function md5;
 
 final class InitializeBuilderFromConfig
@@ -56,6 +58,9 @@ final class InitializeBuilderFromConfig
     private function buildVersion(VersionSpecification $version): VersionDescriptor
     {
         $collection = Collection::fromClassString(DocumentationSetDescriptor::class);
+
+        $this->guardAgainstMultipleSetsOfTheSameType($version);
+
         foreach ($version->getGuides() as $guide) {
             $collection->add(
                 new GuideSetDescriptor(md5($guide['output']), $guide['source'], $guide['output'], $guide['format'])
@@ -77,5 +82,29 @@ final class InitializeBuilderFromConfig
             $version->getNumber(),
             $collection
         );
+    }
+
+    /**
+     * Until official support is added for versions, check whether there is 1 and fail when multiple is
+     * given.
+     *
+     * By adding this restriction, it should prevent confusion with users when they were to add multiple
+     * in the configuration.
+     */
+    private function guardAgainstMultipleSetsOfTheSameType(VersionSpecification $version): void
+    {
+        if (count($version->getGuides()) > 1) {
+            throw new OutOfRangeException(
+                'phpDocumentor supports 1 set of guides at the moment, '
+                . 'support for multiple sets is being worked on'
+            );
+        }
+
+        if (count($version->getApi()) > 1) {
+            throw new OutOfRangeException(
+                'phpDocumentor supports 1 set of API documentation at the moment, '
+                . 'support for multiple sets is being worked on'
+            );
+        }
     }
 }


### PR DESCRIPTION
As part of the effort to support multiple versions and sets of documentation we first need to make sure there can only be one version and one set of documentation per type.

This sounds counter-intuitive, but adding this restriction will help the user experience, and it will allow us to make assumptions on the number of versions and sets while proxying data from one side of the application to another. Specifically the 'indexes' in ProjectDescriptor can be proxied to the first version's first Api Set