### PR TITLE
Move Files listing from Project to Documentation Sets

### DIFF
--- a/src/phpDocumentor/Descriptor/DocumentationSetDescriptor.php
+++ b/src/phpDocumentor/Descriptor/DocumentationSetDescriptor.php
@@ -14,23 +14,23 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use phpDocumentor\Configuration\Source;
+use phpDocumentor\Descriptor\Interfaces\FileInterface;
 
 abstract class DocumentationSetDescriptor
 {
-    /** @var string */
-    protected $name = '';
-
-    /** @var Source */
-    protected $source;
-
-    /** @var string */
-    protected $outputLocation = '.';
+    protected string $name = '';
+    protected Source $source;
+    protected string $outputLocation = '.';
 
     /** @var Collection<TocDescriptor> */
-    private $tocs;
+    private Collection $tocs;
+
+    /** @var Collection<FileInterface> $files */
+    private Collection $files;
 
     public function __construct()
     {
+        $this->files = new Collection();
         $this->tocs = Collection::fromClassString(TocDescriptor::class);
     }
 
@@ -65,5 +65,25 @@ abstract class DocumentationSetDescriptor
     public function getOutputLocation(): string
     {
         return $this->outputLocation;
+    }
+
+    /**
+     * Sets the list of files that is in this documentation set.
+     *
+     * @param Collection<FileInterface> $files
+     */
+    public function setFiles(Collection $files): void
+    {
+        $this->files = $files;
+    }
+
+    /**
+     * Returns the list of files that is in this documentation set.
+     *
+     * @return Collection<FileInterface>
+     */
+    public function getFiles(): Collection
+    {
+        return $this->files;
     }
 }

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor.php
@@ -74,6 +74,8 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
     /**
      * Sets all files on this project.
      *
+     * @deprecated Please use {@see DocumentationSetDescriptor::getFiles()}
+     *
      * @param Collection<FileInterface> $files
      */
     public function setFiles(Collection $files): void
@@ -83,6 +85,10 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
 
     /**
      * Returns all files with their sub-elements.
+     *
+     * @deprecated Please use {@see DocumentationSetDescriptor::getFiles()}
+     *
+     * @return Collection<FileInterface>
      */
     public function getFiles(): Collection
     {

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor.php
@@ -21,6 +21,7 @@ use phpDocumentor\Descriptor\Traits\HasName;
 use phpDocumentor\Descriptor\Traits\HasNamespace;
 use phpDocumentor\Descriptor\Traits\HasPackage;
 use phpDocumentor\Reflection\Fqsen;
+use Webmozart\Assert\Assert;
 
 /**
  * Represents the entire project with its files, namespaces and indexes.
@@ -34,9 +35,6 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
     use HasDescription;
     use HasPackage;
     use HasNamespace;
-
-    /** @var Collection<FileInterface> $files */
-    private Collection $files;
 
     /** @var Collection<Collection<ElementInterface>> $indexes */
     private Collection $indexes;
@@ -67,7 +65,6 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
         $package->setFullyQualifiedStructuralElementName(new Fqsen('\\'));
         $this->setPackage($package);
 
-        $this->setFiles(new Collection());
         $this->setIndexes(new Collection());
 
         $this->setPartials(new Collection());
@@ -81,7 +78,7 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
      */
     public function setFiles(Collection $files): void
     {
-        $this->files = $files;
+        $this->getApiDocumentationSet()->setFiles($files);
     }
 
     /**
@@ -89,7 +86,7 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
      */
     public function getFiles(): Collection
     {
-        return $this->files;
+        return $this->getApiDocumentationSet()->getFiles();
     }
 
     /**
@@ -172,5 +169,22 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
     public function getVersions(): Collection
     {
         return $this->versions;
+    }
+
+    /**
+     * Retrieves the first API Documentation set from the first version.
+     *
+     * @deprecated As soon as we are done migrating to multiple API Documentation sets, this method becomes invalid
+     *     and should be removed.
+     */
+    private function getApiDocumentationSet(): ApiSetDescriptor
+    {
+        $firstVersion = $this->versions->first();
+        Assert::isInstanceOf($firstVersion, VersionDescriptor::class);
+
+        $firstApiSet = $firstVersion->getDocumentationSets()->filter(ApiSetDescriptor::class)->first();
+        Assert::isInstanceOf($firstApiSet, ApiSetDescriptor::class);
+
+        return $firstApiSet;
     }
 }

--- a/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
@@ -22,6 +22,7 @@ use phpDocumentor\Descriptor\MethodDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\PropertyDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
+use phpDocumentor\Faker\Faker;
 use phpDocumentor\Reflection\Fqsen;
 use PHPUnit\Framework\TestCase;
 
@@ -35,17 +36,20 @@ use function array_values;
  */
 class ElementsIndexBuilderTest extends TestCase
 {
-    /** @var ElementsIndexBuilder $fixture */
-    protected $fixture;
+    use Faker;
 
-    /** @var ProjectDescriptor */
-    protected $project;
+    protected ElementsIndexBuilder $fixture;
+    protected ProjectDescriptor $project;
 
     protected function setUp(): void
     {
         $this->fixture = new ElementsIndexBuilder();
 
         $this->project = new ProjectDescriptor('title');
+        $set = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$set]);
+        $this->project->getVersions()->add($version);
+
         $file1 = new FileDescriptor('hash');
         $file2 = new FileDescriptor('hash2');
         $this->project->getFiles()->add($file1);

--- a/tests/unit/phpDocumentor/Compiler/Pass/NamespaceTreeBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/NamespaceTreeBuilderTest.php
@@ -21,6 +21,7 @@ use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\NamespaceDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
+use phpDocumentor\Faker\Faker;
 use phpDocumentor\Reflection\Fqsen;
 use PHPUnit\Framework\TestCase;
 
@@ -34,6 +35,8 @@ use function sort;
  */
 class NamespaceTreeBuilderTest extends TestCase
 {
+    use Faker;
+
     /** @var NamespaceTreeBuilder $fixture */
     protected $fixture;
 
@@ -45,6 +48,10 @@ class NamespaceTreeBuilderTest extends TestCase
         $this->fixture = new NamespaceTreeBuilder();
 
         $this->project = new ProjectDescriptor('title');
+        $set = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$set]);
+        $this->project->getVersions()->add($version);
+
         $this->project->getFiles()->add(new FileDescriptor('hash'));
     }
 

--- a/tests/unit/phpDocumentor/Compiler/Pass/PackageTreeBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/PackageTreeBuilderTest.php
@@ -24,6 +24,7 @@ use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TagDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
+use phpDocumentor\Faker\Faker;
 use phpDocumentor\Parser\Parser;
 use phpDocumentor\Reflection\DocBlock\Description;
 use PHPUnit\Framework\TestCase;
@@ -36,6 +37,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
  */
 final class PackageTreeBuilderTest extends TestCase
 {
+    use Faker;
     use ProphecyTrait;
 
     private const DEFAULT_PACKAGE_NAME = 'Default';
@@ -68,6 +70,9 @@ final class PackageTreeBuilderTest extends TestCase
     public function testRootPackageIsSet(): void
     {
         $project = new ProjectDescriptor('title');
+        $set = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$set]);
+        $project->getVersions()->add($version);
         $this->fixture->execute($project);
 
         $packages = $project->getIndexes()->get('packages');
@@ -417,6 +422,9 @@ final class PackageTreeBuilderTest extends TestCase
     private function givenProjectWithFile(FileDescriptor $file): ProjectDescriptor
     {
         $project = new ProjectDescriptor('title');
+        $set = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$set]);
+        $project->getVersions()->add($version);
         $project->getFiles()->add($file);
 
         return $project;
@@ -425,6 +433,10 @@ final class PackageTreeBuilderTest extends TestCase
     private function givenProjectWithFiles(array $files): ProjectDescriptor
     {
         $project = new ProjectDescriptor('title');
+        $set = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$set]);
+        $project->getVersions()->add($version);
+
         foreach ($files as $file) {
             $project->getFiles()->add($file);
         }

--- a/tests/unit/phpDocumentor/Compiler/Pass/RemoveSourcecodeTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/RemoveSourcecodeTest.php
@@ -65,18 +65,17 @@ final class RemoveSourcecodeTest extends TestCase
 
     private function giveProjectDescriptor(ApiSetDescriptor $apiDescriptor): ProjectDescriptor
     {
-        $projecDescriptor = $this->faker()->projectDescriptor();
-        $projecDescriptor->setFiles(
+        $projectDescriptor = $this->faker()->projectDescriptor();
+        $versionDesciptor = $this->faker()->versionDescriptor([$apiDescriptor]);
+        $projectDescriptor->getVersions()->add($versionDesciptor);
+        $projectDescriptor->setFiles(
             DescriptorCollection::fromClassString(
                 DocumentationSetDescriptor::class,
                 [$this->faker()->fileDescriptor()]
             )
         );
 
-        $versionDesciptor = $this->faker()->versionDescriptor([$apiDescriptor]);
-        $projecDescriptor->getVersions()->add($versionDesciptor);
-
-        return $projecDescriptor;
+        return $projectDescriptor;
     }
 
     /**

--- a/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
@@ -46,8 +46,8 @@ SOURCE
         $documentationsSets->add($apiDescriptor);
 
         $projectDescriptor = new ProjectDescriptor('test project');
-        $projectDescriptor->setFiles(new Collection([$fileDescriptor]));
         $projectDescriptor->getVersions()->add(new VersionDescriptor('latest', $documentationsSets));
+        $projectDescriptor->setFiles(new Collection([$fileDescriptor]));
 
         $fixture->execute($projectDescriptor);
 

--- a/tests/unit/phpDocumentor/Descriptor/ApiSetDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ApiSetDescriptorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Descriptor;
+
+use phpDocumentor\Configuration\ApiSpecification;
+use phpDocumentor\Faker\Faker;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Descriptor\ApiSetDescriptor
+ * @covers ::<private>
+ * @covers ::__construct
+ */
+final class ApiSetDescriptorTest extends TestCase
+{
+    use Faker;
+
+    /**
+     * @covers ::setFiles
+     * @covers ::getFiles
+     */
+    public function testContainsAListingOfFilesInThisSet(): void
+    {
+        $source = $this->faker()->source();
+        $set = new ApiSetDescriptor('api', $source, 'output', ApiSpecification::createDefault());
+        $files = new Collection([new FileDescriptor('hash')]);
+
+        self::assertEquals(new Collection(), $set->getFiles());
+
+        $set->setFiles($files);
+
+        self::assertSame($files, $set->getFiles());
+    }
+}

--- a/tests/unit/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapperTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapperTest.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Descriptor\Cache;
 
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Faker\Faker;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
@@ -31,16 +32,15 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  */
 final class ProjectDescriptorMapperTest extends TestCase
 {
-    /** @var ProjectDescriptorMapper */
-    private $mapper;
+    use Faker;
 
-    /** @var FilesystemAdapter */
-    private $cachePool;
+    private ProjectDescriptorMapper $mapper;
+    private FilesystemAdapter $cachePool;
 
     protected function setUp(): void
     {
         $this->cachePool = new FilesystemAdapter();
-        $this->mapper    = new ProjectDescriptorMapper($this->cachePool);
+        $this->mapper = new ProjectDescriptorMapper($this->cachePool);
     }
 
     /**
@@ -53,6 +53,9 @@ final class ProjectDescriptorMapperTest extends TestCase
         $fileDescriptor->setPath('./src/MyClass.php');
 
         $projectDescriptor = new ProjectDescriptor('project');
+        $set = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$set]);
+        $projectDescriptor->getVersions()->add($version);
         $projectDescriptor->getFiles()->set('./src/MyClass.php', $fileDescriptor);
 
         $this->assertFalse($projectDescriptor->getSettings()->shouldIncludeSource());
@@ -62,6 +65,9 @@ final class ProjectDescriptorMapperTest extends TestCase
         $this->mapper->save($projectDescriptor);
 
         $restoredProjectDescriptor = new ProjectDescriptor('project2');
+        $set = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$set]);
+        $restoredProjectDescriptor->getVersions()->add($version);
         $this->mapper->populate($restoredProjectDescriptor);
 
         $this->assertTrue($restoredProjectDescriptor->getSettings()->shouldIncludeSource());

--- a/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use phpDocumentor\Descriptor\ProjectDescriptor\Settings;
+use phpDocumentor\Faker\Faker;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,6 +24,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class ProjectDescriptorTest extends TestCase
 {
+    use Faker;
+
     public const EXAMPLE_NAME = 'Initial name';
 
     /** @var ProjectDescriptor */
@@ -58,12 +61,17 @@ final class ProjectDescriptorTest extends TestCase
      */
     public function testGetSetFiles(): void
     {
+        $set = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$set]);
+        $this->fixture->getVersions()->add($version);
+
         $this->assertInstanceOf(Collection::class, $this->fixture->getFiles());
 
         $filesCollection = new Collection();
         $this->fixture->setFiles($filesCollection);
 
         $this->assertSame($filesCollection, $this->fixture->getFiles());
+        $this->assertSame($set->getFiles(), $this->fixture->getFiles());
     }
 
     /**

--- a/tests/unit/phpDocumentor/Transformer/Writer/SourcecodeTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/SourcecodeTest.php
@@ -57,9 +57,9 @@ final class SourcecodeTest extends MockeryTestCase
         $transformation = $this->prophesize(Transformation::class);
         $transformation->template()->shouldNotBeCalled();
 
-        $projecDescriptor = $this->giveProjectDescriptor($this->faker()->apiSetDescriptor());
+        $projectDescriptor = $this->giveProjectDescriptor($this->faker()->apiSetDescriptor());
 
-        $this->sourceCode->transform($projecDescriptor, $transformation->reveal());
+        $this->sourceCode->transform($projectDescriptor, $transformation->reveal());
     }
 
     /**
@@ -79,17 +79,16 @@ final class SourcecodeTest extends MockeryTestCase
 
     private function giveProjectDescriptor(ApiSetDescriptor $apiDescriptor): ProjectDescriptor
     {
-        $projecDescriptor = $this->faker()->projectDescriptor();
-        $projecDescriptor->setFiles(
+        $projectDescriptor = $this->faker()->projectDescriptor();
+        $versionDesciptor = $this->faker()->versionDescriptor([$apiDescriptor]);
+        $projectDescriptor->getVersions()->add($versionDesciptor);
+        $projectDescriptor->setFiles(
             DescriptorCollection::fromClassString(
                 DocumentationSetDescriptor::class,
                 [$this->faker()->fileDescriptor()]
             )
         );
 
-        $versionDesciptor = $this->faker()->versionDescriptor([$apiDescriptor]);
-        $projecDescriptor->getVersions()->add($versionDesciptor);
-
-        return $projecDescriptor;
+        return $projectDescriptor;
     }
 }


### PR DESCRIPTION
As part of the effort to introduce support for multiple versions and components, we need to move data around to go from the project (all versions and components) to Documentation Sets (which is bound to a single version and component).

To be fair, this change does not move everything around; just where files are stored at the moment. This is done to keep the changesets small. In subsequent work, we can change the usage of the get and setFiles to start pointing to the DocumentationSet.