### PR TITLE
Remove file and index getters and setters from project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ composer-require-checker:
 	${.DOCKER_COMPOSE_RUN} --entrypoint=./tools/composer-require-checker phpdoc  check --config-file /opt/phpdoc/composer-require-config.json composer.json
 
 .PHONY: pre-commit-test
-pre-commit-test: test phpcs phpstan psalm composer-require-checker
+pre-commit-test: test integration-test phpcs phpstan psalm composer-require-checker
 
 .PHONY: composer
 composer:

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor.php
@@ -67,18 +67,6 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
     }
 
     /**
-     * Sets all files on this project.
-     *
-     * @deprecated Please use {@see DocumentationSetDescriptor::getFiles()}
-     *
-     * @param Collection<FileInterface> $files
-     */
-    public function setFiles(Collection $files): void
-    {
-        $this->getApiDocumentationSet()->setFiles($files);
-    }
-
-    /**
      * Returns all files with their sub-elements.
      *
      * @deprecated Please use {@see DocumentationSetDescriptor::getFiles()}
@@ -88,18 +76,6 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
     public function getFiles(): Collection
     {
         return $this->getApiDocumentationSet()->getFiles();
-    }
-
-    /**
-     * Sets all indexes for this project.
-     *
-     * @deprecated Please use {@see DocumentationSetDescriptor::setIndexes()}
-     *
-     * @param Collection<Collection<ElementInterface>> $indexes
-     */
-    public function setIndexes(Collection $indexes): void
-    {
-        $this->getApiDocumentationSet()->setIndexes($indexes);
     }
 
     /**

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor;
 
-use phpDocumentor\Descriptor\Interfaces\ElementInterface;
 use phpDocumentor\Descriptor\Interfaces\FileInterface;
 use phpDocumentor\Descriptor\ProjectDescriptor\Settings;
 use phpDocumentor\Descriptor\Traits\HasDescription;

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor.php
@@ -130,14 +130,6 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
     }
 
     /**
-     * @deprecated Please use {@see ApiSetDescriptor::findElement()}
-     */
-    public function findElement(Fqsen $fqsen): ?ElementInterface
-    {
-        return $this->getApiDocumentationSet()->findElement($fqsen);
-    }
-
-    /**
      * @return Collection<VersionDescriptor>
      */
     public function getVersions(): Collection

--- a/src/phpDocumentor/Transformer/Transformer.php
+++ b/src/phpDocumentor/Transformer/Transformer.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer;
 
 use League\Flysystem\FilesystemInterface;
-use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Dsn;

--- a/src/phpDocumentor/Transformer/Transformer.php
+++ b/src/phpDocumentor/Transformer/Transformer.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer;
 
 use League\Flysystem\FilesystemInterface;
+use phpDocumentor\Descriptor\ApiSetDescriptor;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Dsn;
 use phpDocumentor\Event\Dispatcher;
@@ -127,9 +129,12 @@ class Transformer
      *
      * @param Transformation[] $transformations
      */
-    public function execute(ProjectDescriptor $project, array $transformations): void
-    {
-        $this->initializeWriters($project, $transformations);
+    public function execute(
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
+        array $transformations
+    ): void {
+        $this->initializeWriters($project, $documentationSet, $transformations);
         $this->transformProject($project, $transformations);
 
         $this->logger->log(LogLevel::NOTICE, 'Finished transformation process');
@@ -140,8 +145,11 @@ class Transformer
      *
      * @param Transformation[] $transformations
      */
-    private function initializeWriters(ProjectDescriptor $project, array $transformations): void
-    {
+    private function initializeWriters(
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
+        array $transformations
+    ): void {
         $isInitialized = [];
         foreach ($transformations as $transformation) {
             $writerName = $transformation->getWriter();
@@ -152,7 +160,7 @@ class Transformer
 
             $isInitialized[] = $writerName;
             $writer = $this->writers->get($writerName);
-            $this->initializeWriter($writer, $project, $transformation->template());
+            $this->initializeWriter($writer, $project, $documentationSet, $transformation->template());
         }
     }
 
@@ -172,15 +180,19 @@ class Transformer
      *
      * @uses Dispatcher to emit the events surrounding an initialization.
      */
-    private function initializeWriter(WriterAbstract $writer, ProjectDescriptor $project, Template $template): void
-    {
+    private function initializeWriter(
+        WriterAbstract $writer,
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
+        Template $template
+    ): void {
         /** @var WriterInitializationEvent $instance */
         $instance = WriterInitializationEvent::createInstance($this);
         $event = $instance->setWriter($writer);
         $this->eventDispatcher->dispatch($event, self::EVENT_PRE_INITIALIZATION);
 
         if ($writer instanceof Initializable) {
-            $writer->initialize($project, $template);
+            $writer->initialize($project, $documentationSet, $template);
         }
 
         $this->eventDispatcher->dispatch($event, self::EVENT_POST_INITIALIZATION);

--- a/src/phpDocumentor/Transformer/Writer/Initializable.php
+++ b/src/phpDocumentor/Transformer/Writer/Initializable.php
@@ -13,10 +13,15 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer;
 
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Transformer\Template;
 
 interface Initializable
 {
-    public function initialize(ProjectDescriptor $project, Template $template): void;
+    public function initialize(
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
+        Template $template
+    ): void;
 }

--- a/src/phpDocumentor/Transformer/Writer/RenderGuide.php
+++ b/src/phpDocumentor/Transformer/Writer/RenderGuide.php
@@ -87,11 +87,9 @@ final class RenderGuide extends WriterAbstract implements ProjectDescriptor\With
                 //TODO Extract this, as this code is duplicated
                 $this->environmentBuilder->setEnvironmentFactory(
                     function () use ($transformation, $project, $documentationSet) {
-                        $twig = $this->environmentFactory->create($project, $transformation->template());
-                        $twig->addGlobal('project', $project);
+                        $twig = $this->environmentFactory->create($project, $documentationSet, $transformation->template());
                         $twig->addGlobal('usesNamespaces', count($project->getNamespace()->getChildren()) > 0);
                         $twig->addGlobal('usesPackages', count($project->getPackage()->getChildren()) > 0);
-                        $twig->addGlobal('documentationSet', $documentationSet);
                         $twig->addGlobal('destinationPath', null);
 
                         return $twig;

--- a/src/phpDocumentor/Transformer/Writer/RenderGuide.php
+++ b/src/phpDocumentor/Transformer/Writer/RenderGuide.php
@@ -87,7 +87,11 @@ final class RenderGuide extends WriterAbstract implements ProjectDescriptor\With
                 //TODO Extract this, as this code is duplicated
                 $this->environmentBuilder->setEnvironmentFactory(
                     function () use ($transformation, $project, $documentationSet) {
-                        $twig = $this->environmentFactory->create($project, $documentationSet, $transformation->template());
+                        $twig = $this->environmentFactory->create(
+                            $project,
+                            $documentationSet,
+                            $transformation->template()
+                        );
                         $twig->addGlobal('usesNamespaces', count($project->getNamespace()->getChildren()) > 0);
                         $twig->addGlobal('usesPackages', count($project->getPackage()->getChildren()) > 0);
                         $twig->addGlobal('destinationPath', null);

--- a/src/phpDocumentor/Transformer/Writer/Twig.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Transformer\Writer;
 
 use phpDocumentor\Descriptor\Collection as DescriptorCollection;
 use phpDocumentor\Descriptor\Descriptor;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\Query\Engine;
 use phpDocumentor\Transformer\Template;
@@ -114,9 +115,12 @@ final class Twig extends WriterAbstract implements Initializable, ProjectDescrip
         return 'twig';
     }
 
-    public function initialize(ProjectDescriptor $project, Template $template): void
-    {
-        $this->environment = $this->environmentFactory->create($project, $template);
+    public function initialize(
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
+        Template $template
+    ): void {
+        $this->environment = $this->environmentFactory->create($project, $documentationSet, $template);
     }
 
     /**
@@ -200,10 +204,8 @@ final class Twig extends WriterAbstract implements Initializable, ProjectDescrip
 
         $parameters = array_merge($transformation->getParameters(), $extraParameters);
 
-        $this->environment->addGlobal('project', $project);
         $this->environment->addGlobal('usesNamespaces', count($project->getNamespace()->getChildren()) > 0);
         $this->environment->addGlobal('usesPackages', count($project->getPackage()->getChildren()) > 0);
-        $this->environment->addGlobal('documentationSet', $project);
         $this->environment->addGlobal('node', $node);
         $this->environment->addGlobal('destinationPath', $path);
         $this->environment->addGlobal('parameter', $parameters);

--- a/src/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactory.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer\Writer\Twig;
 
 use League\CommonMark\ConverterInterface;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Guides\Graphs\Twig\UmlExtension;
 use phpDocumentor\Guides\Twig\AssetsExtension;
@@ -57,6 +58,7 @@ class EnvironmentFactory
 
     public function create(
         ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
         Template $template
     ): Environment {
         $mountManager = $template->files();
@@ -72,7 +74,7 @@ class EnvironmentFactory
 
         $env = new Environment(new ChainLoader($loaders));
 
-        $this->addPhpDocumentorExtension($project, $env);
+        $this->addPhpDocumentorExtension($project, $documentationSet, $env);
         $this->enableDebug($env);
 
         return $env;
@@ -83,10 +85,12 @@ class EnvironmentFactory
      */
     private function addPhpDocumentorExtension(
         ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
         Environment $twigEnvironment
     ): void {
         $extension = new Extension(
             $project,
+            $documentationSet,
             $this->markDownConverter,
             $this->renderer,
             $this->relativePathToRootConverter,

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -21,6 +21,7 @@ use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\Descriptor;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\DocBlock\DescriptionDescriptor;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\EnumDescriptor;
 use phpDocumentor\Descriptor\Interfaces\ArgumentInterface;
 use phpDocumentor\Descriptor\Interfaces\ClassInterface;
@@ -92,6 +93,8 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
     private ConverterInterface $markdownConverter;
     private RelativePathToRootConverter $relativePathToRootConverter;
     private PathBuilder $pathBuilder;
+    private DocumentationSetDescriptor $documentationSet;
+    private ProjectDescriptor $project;
 
     /**
      * Registers the structure and transformation with this extension.
@@ -100,14 +103,17 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
      */
     public function __construct(
         ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
         ConverterInterface $markdownConverter,
         LinkRenderer $routeRenderer,
         RelativePathToRootConverter $relativePathToRootConverter,
         PathBuilder $pathBuilder
     ) {
+        $this->project = $project;
+        $this->documentationSet = $documentationSet;
         $this->markdownConverter = $markdownConverter;
         $this->routeRenderer = $routeRenderer;
-        $this->routeRenderer = $this->routeRenderer->withProject($project);
+        $this->routeRenderer = $this->routeRenderer->withProject($project)->forDocumentationSet($documentationSet);
         $this->relativePathToRootConverter = $relativePathToRootConverter;
         $this->pathBuilder = $pathBuilder;
     }
@@ -120,8 +126,8 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
     public function getGlobals(): array
     {
         return [
-            'project' => null,
-            'documentationSet' => null,
+            'project' => $this->project,
+            'documentationSet' => $this->documentationSet,
             'node' => null,
             'usesNamespaces' => true,
             'usesPackages' => true,
@@ -447,7 +453,8 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
     {
         return $this->routeRenderer
             ->withDestination(ltrim($context['destinationPath'] ?? $context['env']->getCurrentFileDestination(), '/\\'))
-            ->withProject($context['project']);
+            ->withProject($context['project'])
+            ->forDocumentationSet($context['documentationSet']);
     }
 
     /**

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -121,7 +121,16 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
     /**
      * Initialize series of globals used by the writers to set the context
      *
-     * @return array<string, (true|string[]|null)>
+     * @return array{
+     *     project: ProjectDescriptor,
+     *     documentationSet: DocumentationSetDescriptor,
+     *     node: ?Descriptor,
+     *     usesNamespaces: bool,
+     *     usesPackages: bool,
+     *     destinationPath: ?string,
+     *     parameter: array<string, mixed>,
+     *     env: mixed
+     * }
      */
     public function getGlobals(): array
     {

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer\Writer\Twig;
 
 use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Path;
 use phpDocumentor\Reflection\DocBlock\Tags\Reference;
@@ -42,6 +43,7 @@ class LinkRenderer implements LinkRendererInterface
 
     private string $destination = '';
     private ProjectDescriptor $project;
+    private DocumentationSetDescriptor $documentationSet;
 
     /** @var LinkRendererInterface[] */
     private array $adapters;
@@ -62,6 +64,9 @@ class LinkRenderer implements LinkRendererInterface
         $this->adapters = $this->createAdapters();
     }
 
+    /**
+     * @deprecated will be removed once getProject is removed
+     */
     public function withProject(ProjectDescriptor $projectDescriptor): self
     {
         $result = clone $this;
@@ -70,9 +75,25 @@ class LinkRenderer implements LinkRendererInterface
         return $result;
     }
 
+    public function forDocumentationSet(DocumentationSetDescriptor $documentationSet): self
+    {
+        $result = clone $this;
+        $result->documentationSet = $documentationSet;
+
+        return $result;
+    }
+
+    /**
+     * @deprecated use {@see getDocumentationSet()}
+     */
     public function getProject(): ProjectDescriptor
     {
         return $this->project;
+    }
+
+    public function getDocumentationSet(): DocumentationSetDescriptor
+    {
+        return $this->documentationSet;
     }
 
     /**

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/LinkAdapter.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/LinkAdapter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
 
 use InvalidArgumentException;
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Path;
 use phpDocumentor\Reflection\DocBlock\Tags\Reference;
@@ -98,8 +99,9 @@ final class LinkAdapter implements LinkRendererInterface
             $target = $target->getFqsen() ?? $target;
         }
 
-        if ($target instanceof Fqsen) {
-            $target = $this->rendererChain->getDocumentationSet()->findElement($target) ?? $target;
+        $documentationSetDescriptor = $this->rendererChain->getDocumentationSet();
+        if ($target instanceof Fqsen && $documentationSetDescriptor instanceof ApiSetDescriptor) {
+            $target = $documentationSetDescriptor->findElement($target) ?? $target;
         }
 
         return $target;

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/LinkAdapter.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/LinkAdapter.php
@@ -99,7 +99,7 @@ final class LinkAdapter implements LinkRendererInterface
         }
 
         if ($target instanceof Fqsen) {
-            $target = $this->rendererChain->getProject()->findElement($target) ?? $target;
+            $target = $this->rendererChain->getDocumentationSet()->findElement($target) ?? $target;
         }
 
         return $target;

--- a/tests/integration/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
+++ b/tests/integration/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
@@ -47,22 +47,20 @@ final class LinkRendererTest extends TestCase
     use ProphecyTrait;
 
     /** @var Router|ObjectProphecy */
-    private $router;
+    private ObjectProphecy $router;
 
-    /** @var LinkRenderer */
-    private $renderer;
-
-    /** @var ProjectDescriptor */
-    private $projectDescriptor;
+    private LinkRenderer $renderer;
+    private ProjectDescriptor $projectDescriptor;
 
     protected function setUp(): void
     {
         $this->router = $this->prophesize(Router::class);
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
         $this->projectDescriptor = $this->faker()->projectDescriptor([
-            $this->faker()->versionDescriptor([$this->faker()->apiSetDescriptor()]),
+            $this->faker()->versionDescriptor([$apiSetDescriptor]),
         ]);
         $this->renderer = (new LinkRenderer($this->router->reveal(), new HtmlFormatter()))
-            ->withProject($this->projectDescriptor);
+            ->withProject($this->projectDescriptor)->forDocumentationSet($apiSetDescriptor);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Compiler/Pass/RemoveSourcecodeTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/RemoveSourcecodeTest.php
@@ -41,7 +41,7 @@ final class RemoveSourcecodeTest extends TestCase
 
         $fixture->execute($projectDescriptor);
 
-        foreach ($projectDescriptor->getFiles() as $file) {
+        foreach ($apiSetDescriptor->getFiles() as $file) {
             self::assertNull($file->getSource());
         }
     }
@@ -58,7 +58,7 @@ final class RemoveSourcecodeTest extends TestCase
 
         $fixture->execute($projectDescriptor);
 
-        foreach ($projectDescriptor->getFiles() as $file) {
+        foreach ($apiSetDescriptor->getFiles() as $file) {
             self::assertNotNull($file->getSource());
         }
     }
@@ -68,7 +68,7 @@ final class RemoveSourcecodeTest extends TestCase
         $projectDescriptor = $this->faker()->projectDescriptor();
         $versionDesciptor = $this->faker()->versionDescriptor([$apiDescriptor]);
         $projectDescriptor->getVersions()->add($versionDesciptor);
-        $projectDescriptor->setFiles(
+        $apiDescriptor->setFiles(
             DescriptorCollection::fromClassString(
                 DocumentationSetDescriptor::class,
                 [$this->faker()->fileDescriptor()]

--- a/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
@@ -47,7 +47,7 @@ SOURCE
 
         $projectDescriptor = new ProjectDescriptor('test project');
         $projectDescriptor->getVersions()->add(new VersionDescriptor('latest', $documentationsSets));
-        $projectDescriptor->setFiles(new Collection([$fileDescriptor]));
+        $apiDescriptor->setFiles(new Collection([$fileDescriptor]));
 
         $fixture->execute($projectDescriptor);
 

--- a/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\TestCase;
  * Tests the functionality for the ProjectDescriptor class.
  *
  * @coversDefaultClass \phpDocumentor\Descriptor\ProjectDescriptor
+ * @covers ::__construct
+ * @covers ::<private>
  */
 final class ProjectDescriptorTest extends TestCase
 {
@@ -28,8 +30,7 @@ final class ProjectDescriptorTest extends TestCase
 
     public const EXAMPLE_NAME = 'Initial name';
 
-    /** @var ProjectDescriptor */
-    private $fixture;
+    private ProjectDescriptor $fixture;
 
     /**
      * Initializes the fixture object.
@@ -40,7 +41,6 @@ final class ProjectDescriptorTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
      * @covers ::setName
      * @covers ::getName
      */
@@ -55,40 +55,26 @@ final class ProjectDescriptorTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::setFiles
      * @covers ::getFiles
      */
-    public function testGetSetFiles(): void
+    public function testGetFilesFromApiSet(): void
     {
         $set = $this->faker()->apiSetDescriptor();
         $version = $this->faker()->versionDescriptor([$set]);
         $this->fixture->getVersions()->add($version);
 
-        $this->assertInstanceOf(Collection::class, $this->fixture->getFiles());
-
-        $filesCollection = new Collection();
-        $this->fixture->setFiles($filesCollection);
-
-        $this->assertSame($filesCollection, $this->fixture->getFiles());
         $this->assertSame($set->getFiles(), $this->fixture->getFiles());
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::setIndexes
      * @covers ::getIndexes
      */
-    public function testGetSetIndexes(): void
+    public function testGetIndexesFromApiSet(): void
     {
-        $this->fixture->getVersions()->add($this->faker()->versionDescriptor([$this->faker()->apiSetDescriptor()]));
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $this->fixture->getVersions()->add($this->faker()->versionDescriptor([$apiSetDescriptor]));
 
-        $this->assertInstanceOf(Collection::class, $this->fixture->getIndexes());
-
-        $indexCollection = new Collection();
-        $this->fixture->setIndexes($indexCollection);
-
-        $this->assertSame($indexCollection, $this->fixture->getIndexes());
+        $this->assertSame($apiSetDescriptor->getIndexes(), $this->fixture->getIndexes());
     }
 
     /**
@@ -131,7 +117,6 @@ final class ProjectDescriptorTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
      * @covers ::setPartials
      * @covers ::getPartials
      */

--- a/tests/unit/phpDocumentor/Pipeline/Stage/TransformTest.php
+++ b/tests/unit/phpDocumentor/Pipeline/Stage/TransformTest.php
@@ -60,6 +60,7 @@ final class TransformTest extends TestCase
         $this->flySystemFactory = $this->prophesize(FlySystemFactory::class);
         $this->flySystemFactory->create(Argument::type(Dsn::class))->willReturn(new Filesystem(new NullAdapter()));
         $this->projectDescriptorBuilder = $this->prophesize(ProjectDescriptorBuilder::class);
+        $this->projectDescriptorBuilder->getProjectDescriptor()->willReturn($projectDescriptor);
         $this->transformer = $this->prophesize(Transformer::class);
         $this->logger = $this->prophesize(LoggerInterface::class);
         $this->transformer->execute($projectDescriptor, $documentationSet, [])->shouldBeCalled();
@@ -81,7 +82,6 @@ final class TransformTest extends TestCase
     public function test_if_target_location_for_output_is_set_with_a_relative_path(): void
     {
         $config = $this->givenAnExampleConfigWithDsnAndTemplates('.');
-
         $payload = new Payload($config, $this->projectDescriptorBuilder->reveal());
 
         $this->transformer->setTarget(getcwd() . DIRECTORY_SEPARATOR . '.')->shouldBeCalled();

--- a/tests/unit/phpDocumentor/Pipeline/Stage/TransformTest.php
+++ b/tests/unit/phpDocumentor/Pipeline/Stage/TransformTest.php
@@ -53,14 +53,16 @@ final class TransformTest extends TestCase
 
     public function setUp(): void
     {
+        $documentationSet = $this->faker()->apiSetDescriptor();
         $projectDescriptor = new ProjectDescriptor('test');
-        $this->flySystemFactory         = $this->prophesize(FlySystemFactory::class);
+        $projectDescriptor->getVersions()->add($this->faker()->versionDescriptor([$documentationSet]));
+
+        $this->flySystemFactory = $this->prophesize(FlySystemFactory::class);
         $this->flySystemFactory->create(Argument::type(Dsn::class))->willReturn(new Filesystem(new NullAdapter()));
         $this->projectDescriptorBuilder = $this->prophesize(ProjectDescriptorBuilder::class);
-        $this->projectDescriptorBuilder->getProjectDescriptor()->willReturn($projectDescriptor);
-        $this->transformer              = $this->prophesize(Transformer::class);
-        $this->logger                   = $this->prophesize(LoggerInterface::class);
-        $this->transformer->execute($projectDescriptor, [])->shouldBeCalled();
+        $this->transformer = $this->prophesize(Transformer::class);
+        $this->logger = $this->prophesize(LoggerInterface::class);
+        $this->transformer->execute($projectDescriptor, $documentationSet, [])->shouldBeCalled();
         $templateFactory = $this->prophesize(Factory::class);
         $templateFactory->getTemplates(Argument::any(), Argument::any())->willReturn(new Collection());
 
@@ -95,7 +97,6 @@ final class TransformTest extends TestCase
     public function test_if_target_location_for_output_is_set_with_an_absolute_path(): void
     {
         $config = $this->givenAnExampleConfigWithDsnAndTemplates('file:///my/absolute/folder');
-        $this->projectDescriptorBuilder->getProjectDescriptor()->willReturn(new ProjectDescriptor('test'));
         $payload = new Payload($config, $this->projectDescriptorBuilder->reveal());
 
         $this->transformer->setTarget('/my/absolute/folder')->shouldBeCalled();
@@ -109,8 +110,8 @@ final class TransformTest extends TestCase
      */
     public function test_transforming_the_project_will_invoke_all_compiler_passes(): void
     {
-        $config            = $this->givenAnExampleConfigWithDsnAndTemplates('file://.');
-        $payload           = new Payload($config, $this->projectDescriptorBuilder->reveal());
+        $config = $this->givenAnExampleConfigWithDsnAndTemplates('file://.');
+        $payload = new Payload($config, $this->projectDescriptorBuilder->reveal());
 
         $this->transformer->setTarget(Argument::any());
         $this->transformer->setDestination(Argument::type(FilesystemInterface::class));

--- a/tests/unit/phpDocumentor/Transformer/TransformerTest.php
+++ b/tests/unit/phpDocumentor/Transformer/TransformerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer;
 
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Faker\Faker;
 use phpDocumentor\Parser\FlySystemFactory;
 use phpDocumentor\Transformer\Writer\Collection;

--- a/tests/unit/phpDocumentor/Transformer/TransformerTest.php
+++ b/tests/unit/phpDocumentor/Transformer/TransformerTest.php
@@ -110,8 +110,8 @@ final class TransformerTest extends TestCase
      */
     public function testExecute(): void
     {
-        $myTestWriter = 'myTestWriter';
-        $project = $this->prophesize(ProjectDescriptor::class);
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSet])]);
 
         $this->writer->transform(Argument::any(), Argument::any())->shouldBeCalled();
 
@@ -122,7 +122,7 @@ final class TransformerTest extends TestCase
         $transformation->getArtifact()->shouldBeCalled()->willReturn('');
         $transformation->setTransformer(Argument::exact($this->fixture))->shouldBeCalled();
 
-        $this->fixture->execute($project->reveal(), [$transformation->reveal()]);
+        $this->fixture->execute($project, $apiSet, [$transformation->reveal()]);
     }
 
     /**

--- a/tests/unit/phpDocumentor/Transformer/Writer/SourcecodeTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/SourcecodeTest.php
@@ -72,17 +72,17 @@ final class SourcecodeTest extends MockeryTestCase
 
         $api = $this->faker()->apiSetDescriptor();
         $api->getSettings()['include-source'] = true;
-        $projecDescriptor = $this->giveProjectDescriptor($api);
+        $projectDescriptor = $this->giveProjectDescriptor($api);
 
-        $this->sourceCode->transform($projecDescriptor, $transformation->reveal());
+        $this->sourceCode->transform($projectDescriptor, $transformation->reveal());
     }
 
     private function giveProjectDescriptor(ApiSetDescriptor $apiDescriptor): ProjectDescriptor
     {
         $projectDescriptor = $this->faker()->projectDescriptor();
-        $versionDesciptor = $this->faker()->versionDescriptor([$apiDescriptor]);
-        $projectDescriptor->getVersions()->add($versionDesciptor);
-        $projectDescriptor->setFiles(
+        $versionDescriptor = $this->faker()->versionDescriptor([$apiDescriptor]);
+        $projectDescriptor->getVersions()->add($versionDescriptor);
+        $apiDescriptor->setFiles(
             DescriptorCollection::fromClassString(
                 DocumentationSetDescriptor::class,
                 [$this->faker()->fileDescriptor()]

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactoryTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactoryTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer\Writer\Twig;
 
 use League\CommonMark\ConverterInterface;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Faker\Faker;
 use phpDocumentor\Guides\Graphs\Renderer\DiagramRenderer;
 use phpDocumentor\Guides\Graphs\Twig\UmlExtension;
@@ -77,7 +76,11 @@ final class EnvironmentFactoryTest extends TestCase
     {
         $template = $this->faker()->template();
 
-        $environment = $this->factory->create(new ProjectDescriptor('name'), $template);
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $projectDescriptor = $this->faker()->projectDescriptor(
+            [$this->faker()->versionDescriptor([$apiSetDescriptor])]
+        );
+        $environment = $this->factory->create($projectDescriptor, $apiSetDescriptor, $template);
 
         $this->assertInstanceOf(Environment::class, $environment);
         $this->assertCount(7, $environment->getExtensions());
@@ -95,7 +98,11 @@ final class EnvironmentFactoryTest extends TestCase
         $template = $this->faker()->template();
         $mountManager = $template->files();
 
-        $environment = $this->factory->create(new ProjectDescriptor('name'), $template);
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $projectDescriptor = $this->faker()->projectDescriptor(
+            [$this->faker()->versionDescriptor([$apiSetDescriptor])]
+        );
+        $environment = $this->factory->create($projectDescriptor, $apiSetDescriptor, $template);
 
         /** @var ChainLoader $loader */
         $loader = $environment->getLoader();
@@ -122,7 +129,11 @@ final class EnvironmentFactoryTest extends TestCase
     {
         $template = $this->faker()->template();
 
-        $environment = $this->factory->create(new ProjectDescriptor('name'), $template);
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $projectDescriptor = $this->faker()->projectDescriptor(
+            [$this->faker()->versionDescriptor([$apiSetDescriptor])]
+        );
+        $environment = $this->factory->create($projectDescriptor, $apiSetDescriptor, $template);
 
         $this->assertFalse($environment->getCache());
         $this->assertTrue($environment->isDebug());

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/LinkAdapterTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/LinkAdapterTest.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
 use ArrayObject;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Faker\Faker;
 use phpDocumentor\Path;
 use phpDocumentor\Reflection\DocBlock\Tags\Reference;
 use phpDocumentor\Reflection\Fqsen;
@@ -29,6 +30,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 
 final class LinkAdapterTest extends TestCase
 {
+    use Faker;
     use ProphecyTrait;
 
     /** @var LinkRendererInterface|ObjectProphecy */
@@ -47,6 +49,8 @@ final class LinkAdapterTest extends TestCase
         $this->linkRenderer = $this->prophesize(LinkRenderer::class);
         $this->urlGenerator = $this->prophesize(UrlGenerator::class);
         $this->htmlFormatter = $this->prophesize(HtmlFormatter::class);
+
+        $this->linkRenderer->getDocumentationSet()->willReturn($this->faker()->apiSetDescriptor());
 
         // pre-loaded expectations for the data provider
         $this->urlGenerator

--- a/tests/unit/phpDocumentor/Transformer/Writer/TwigTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/TwigTest.php
@@ -126,8 +126,10 @@ final class TwigTest extends TestCase
         $transformation->setTransformer($transformer->reveal());
 
         $project = new ProjectDescriptor('project');
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $project->getVersions()->add($this->faker()->versionDescriptor([$apiSetDescriptor]));
         $project->getSettings()->setCustom($this->writer->getDefaultSettings());
-        $this->writer->initialize($project, $this->faker()->template());
+        $this->writer->initialize($project, $apiSetDescriptor, $this->faker()->template());
         $this->writer->transform($project, $transformation);
 
         $this->assertFileExists($targetDir . '/index.html');


### PR DESCRIPTION
In this change, I have begun the effort of moving stuff out of the ProjectDescriptor that doesn't belong there into the DocumentationSetDescriptors. This also means Project references might be deleted from some services in favour of this one.

This doesn't yet replace the getFiles and getIndexes calls because these are used in a lot of files and warrants a separate PR