### PR TITLE
Cache per documentation set

### DIFF
--- a/src/phpDocumentor/Pipeline/Stage/Cache/GarbageCollectCache.php
+++ b/src/phpDocumentor/Pipeline/Stage/Cache/GarbageCollectCache.php
@@ -27,7 +27,11 @@ final class GarbageCollectCache
 
     public function __invoke(ApiSetPayload $payload): ApiSetPayload
     {
-        $this->descriptorMapper->garbageCollect($payload->getFiles());
+        $this->descriptorMapper->garbageCollect(
+            $payload->getVersion(),
+            $payload->getApiSet(),
+            $payload->getFiles()
+        );
 
         return $payload;
     }

--- a/src/phpDocumentor/Pipeline/Stage/ParseApiDocumentationSets.php
+++ b/src/phpDocumentor/Pipeline/Stage/ParseApiDocumentationSets.php
@@ -32,7 +32,7 @@ final class ParseApiDocumentationSets
         foreach ($versions as $version) {
             foreach ($version->getDocumentationSets()->filter(ApiSetDescriptor::class) as $apiSet) {
                 $this->parseApiDocumentationSetPipeline->process(
-                    new Parser\ApiSetPayload($payload->getConfig(), $payload->getBuilder(), $apiSet)
+                    new Parser\ApiSetPayload($payload->getConfig(), $payload->getBuilder(), $version, $apiSet)
                 );
             }
         }

--- a/src/phpDocumentor/Pipeline/Stage/Parser/ApiSetPayload.php
+++ b/src/phpDocumentor/Pipeline/Stage/Parser/ApiSetPayload.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Pipeline\Stage\Parser;
 use phpDocumentor\Configuration\Configuration;
 use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
+use phpDocumentor\Descriptor\VersionDescriptor;
 use phpDocumentor\Reflection\File;
 
 use function array_merge;
@@ -25,10 +26,12 @@ use function array_merge;
  */
 final class ApiSetPayload
 {
+    private ProjectDescriptorBuilder $builder;
+    private VersionDescriptor $version;
+    private ApiSetDescriptor $apiSet;
+
     /** @var ConfigurationMap */
     private array $configuration;
-    private ProjectDescriptorBuilder $builder;
-    private ApiSetDescriptor $apiSet;
 
     /** @var File[] */
     private array $files;
@@ -40,13 +43,14 @@ final class ApiSetPayload
     public function __construct(
         array $configuration,
         ProjectDescriptorBuilder $builder,
+        VersionDescriptor $version,
         ApiSetDescriptor $apiSet,
         array $files = []
     ) {
         $this->configuration = $configuration;
         $this->builder = $builder;
+        $this->version = $version;
         $this->apiSet = $apiSet;
-
         $this->files = $files;
     }
 
@@ -63,6 +67,11 @@ final class ApiSetPayload
         return $this->builder;
     }
 
+    public function getVersion(): VersionDescriptor
+    {
+        return $this->version;
+    }
+
     public function getApiSet(): ApiSetDescriptor
     {
         return $this->apiSet;
@@ -76,6 +85,7 @@ final class ApiSetPayload
         return new static(
             $this->getConfiguration(),
             $this->getBuilder(),
+            $this->getVersion(),
             $this->getApiSet(),
             array_merge($this->getFiles(), $files)
         );

--- a/tests/unit/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapperTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Cache/ProjectDescriptorMapperTest.php
@@ -49,14 +49,17 @@ final class ProjectDescriptorMapperTest extends TestCase
      */
     public function testThatATheSettingsForAProjectDescriptorArePersistedAndCanBeRetrievedFromCache(): void
     {
+        $versionNumber = $this->faker()->numerify('v#.#.#');
+        $apiSetName = $this->faker()->word;
+
         $fileDescriptor = new FileDescriptor('fileHash');
         $fileDescriptor->setPath('./src/MyClass.php');
 
         $projectDescriptor = new ProjectDescriptor('project');
-        $set = $this->faker()->apiSetDescriptor();
-        $version = $this->faker()->versionDescriptor([$set]);
-        $projectDescriptor->getVersions()->add($version);
-        $projectDescriptor->getFiles()->set('./src/MyClass.php', $fileDescriptor);
+        $restoredSet = $this->faker()->apiSetDescriptor($apiSetName);
+        $restoredVersion = $this->faker()->versionDescriptor([$restoredSet], $versionNumber);
+        $projectDescriptor->getVersions()->add($restoredVersion);
+        $restoredSet->getFiles()->set('./src/MyClass.php', $fileDescriptor);
 
         $this->assertFalse($projectDescriptor->getSettings()->shouldIncludeSource());
         $projectDescriptor->getSettings()->includeSource();
@@ -65,12 +68,12 @@ final class ProjectDescriptorMapperTest extends TestCase
         $this->mapper->save($projectDescriptor);
 
         $restoredProjectDescriptor = new ProjectDescriptor('project2');
-        $set = $this->faker()->apiSetDescriptor();
-        $version = $this->faker()->versionDescriptor([$set]);
-        $restoredProjectDescriptor->getVersions()->add($version);
+        $restoredSet = $this->faker()->apiSetDescriptor($apiSetName);
+        $restoredVersion = $this->faker()->versionDescriptor([$restoredSet], $versionNumber);
+        $restoredProjectDescriptor->getVersions()->add($restoredVersion);
         $this->mapper->populate($restoredProjectDescriptor);
 
         $this->assertTrue($restoredProjectDescriptor->getSettings()->shouldIncludeSource());
-        $this->assertEquals($fileDescriptor, $restoredProjectDescriptor->getFiles()->get($fileDescriptor->getPath()));
+        $this->assertEquals($fileDescriptor, $restoredSet->getFiles()->get($fileDescriptor->getPath()));
     }
 }

--- a/tests/unit/phpDocumentor/Faker/Provider.php
+++ b/tests/unit/phpDocumentor/Faker/Provider.php
@@ -136,18 +136,18 @@ final class Provider extends Base
     }
 
     /** @param DocumentationSetDescriptor[] $documentationSets */
-    public function versionDescriptor(array $documentationSets): VersionDescriptor
+    public function versionDescriptor(array $documentationSets, ?string $version = null): VersionDescriptor
     {
         return new VersionDescriptor(
-            $this->generator->numerify('v#.#.#'),
+            $version ?? $this->generator->numerify('v#.#.#'),
             DescriptorCollection::fromClassString(DocumentationSetDescriptor::class, $documentationSets)
         );
     }
 
-    public function apiSetDescriptor(): ApiSetDescriptor
+    public function apiSetDescriptor(?string $name = null): ApiSetDescriptor
     {
         return new ApiSetDescriptor(
-            $this->generator->word(),
+            $name ?? $this->generator->word(),
             $this->source(),
             (string) $this->path(),
             $this->apiSpecification()

--- a/tests/unit/phpDocumentor/Pipeline/Stage/Cache/GarbageCollectCacheTest.php
+++ b/tests/unit/phpDocumentor/Pipeline/Stage/Cache/GarbageCollectCacheTest.php
@@ -38,17 +38,15 @@ final class GarbageCollectCacheTest extends TestCase
         $files = ['file1'];
 
         $descriptorMapper = $this->prophesize(ProjectDescriptorMapper::class);
-        $descriptorMapper->garbageCollect($files)->shouldBeCalledOnce();
 
         $fixture = new GarbageCollectCache($descriptorMapper->reveal());
 
-        $fixture(
-            new ApiSetPayload(
-                [],
-                $this->prophesize(ProjectDescriptorBuilder::class)->reveal(),
-                $this->faker()->apiSetDescriptor(),
-                $files
-            )
-        );
+        $builder = $this->prophesize(ProjectDescriptorBuilder::class)->reveal();
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$apiSet]);
+
+        $descriptorMapper->garbageCollect($version, $apiSet, $files)->shouldBeCalledOnce();
+
+        $fixture(new ApiSetPayload([], $builder, $version, $apiSet, $files));
     }
 }

--- a/tests/unit/phpDocumentor/Pipeline/Stage/Parser/CollectFilesTest.php
+++ b/tests/unit/phpDocumentor/Pipeline/Stage/Parser/CollectFilesTest.php
@@ -56,13 +56,15 @@ final class CollectFilesTest extends TestCase
             null
         );
 
-        $payload = new ApiSetPayload(
-            ['phpdocumentor' => ['versions' => ['1.0.0' => $version]]],
-            $this->prophesize(ProjectDescriptorBuilder::class)->reveal(),
-            $this->faker()->apiSetDescriptor()
-        );
+        $config = ['phpdocumentor' => ['versions' => ['1.0.0' => $version]]];
+        $builder = $this->prophesize(ProjectDescriptorBuilder::class)->reveal();
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $version = $this->faker()->versionDescriptor([$apiSet]);
+
+        $payload = new ApiSetPayload($config, $builder, $version, $apiSet);
 
         $result = $fixture($payload);
-        self::assertEquals([], $result->getFiles());
+
+        self::assertSame([], $result->getFiles());
     }
 }


### PR DESCRIPTION
As part of the larger effort to change the architecture of phpDocumentor
to support multiple versions and sets, I have updated the caching
mechanism to properly cache per documentation set instead of all files
in the project