### PR TITLE
Refactor all compilers to work on a DocumentationSet

### DIFF
--- a/config/stages.yaml
+++ b/config/stages.yaml
@@ -1,6 +1,7 @@
 parameters:
   linker.substitutions:
     'phpDocumentor\Descriptor\ProjectDescriptor': ['files']
+    'phpDocumentor\Descriptor\ApiSetDescriptor': ['files']
     'phpDocumentor\Descriptor\FileDescriptor':
       - 'tags'
       - 'classes'

--- a/src/phpDocumentor/Compiler/CompilerPassInterface.php
+++ b/src/phpDocumentor/Compiler/CompilerPassInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler;
 
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 
 /**
  * Represents a single pass / business rule to be executed by the Compiler.
@@ -34,7 +34,7 @@ interface CompilerPassInterface
      * This method will execute the business logic associated with a given compiler pass and allow it to manipulate
      * or consumer the Object Graph using the ProjectDescriptor object.
      *
-     * @param ProjectInterface $project Representation of the Object Graph that can be manipulated.
+     * @param DocumentationSetDescriptor $documentationSet Representation of the Object Graph that can be manipulated.
      */
-    public function __invoke(ProjectInterface $project): ProjectInterface;
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor;
 }

--- a/src/phpDocumentor/Compiler/Linker/Linker.php
+++ b/src/phpDocumentor/Compiler/Linker/Linker.php
@@ -18,10 +18,10 @@ use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\Descriptor;
 use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\Interfaces\EnumInterface;
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\NamespaceDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\Reflection\Fqsen;
@@ -81,12 +81,12 @@ class Linker implements CompilerPassInterface
         $this->descriptorRepository = $descriptorRepository;
     }
 
-    public function __invoke(ProjectInterface $project): ProjectInterface
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
-        $this->descriptorRepository->setObjectAliasesList($project->getIndexes()->get('elements')->getAll());
-        $this->substitute($project);
+        $this->descriptorRepository->setObjectAliasesList($documentationSet->getIndexes()->get('elements')->getAll());
+        $this->substitute($documentationSet);
 
-        return $project;
+        return $documentationSet;
     }
 
     /**
@@ -124,9 +124,9 @@ class Linker implements CompilerPassInterface
      * This method will return null if no substitution was possible and all of the above should not update the parent
      * item when null is passed.
      *
-     * @param string|Fqsen|Type|Collection<mixed>|array<mixed>|Descriptor|ProjectInterface $item
+     * @param string|Fqsen|Type|Collection<mixed>|array<mixed>|Descriptor|DocumentationSetDescriptor $item
      *
-     * @return string|ProjectInterface|DescriptorAbstract|Collection<string|DescriptorAbstract>|array<string|DescriptorAbstract>|null
+     * @return string|DocumentationSetDescriptor|DescriptorAbstract|Collection<string|DescriptorAbstract>|array<string|DescriptorAbstract>|null
      */
     public function substitute($item, ?DescriptorAbstract $container = null)
     {

--- a/src/phpDocumentor/Compiler/Pass/Debug.php
+++ b/src/phpDocumentor/Compiler/Pass/Debug.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Compiler\CompilerPassInterface;
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectAnalyzer;
 use Psr\Log\LoggerInterface;
 
@@ -48,11 +48,11 @@ class Debug implements CompilerPassInterface
         return 'Analyze results and write report to log';
     }
 
-    public function __invoke(ProjectInterface $project): ProjectInterface
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
-        $this->analyzer->analyze($project);
+        $this->analyzer->analyze($documentationSet);
         $this->log->debug((string) $this->analyzer);
 
-        return $project;
+        return $documentationSet;
     }
 }

--- a/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
@@ -15,11 +15,11 @@ namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\Interfaces\ClassInterface;
 use phpDocumentor\Descriptor\Interfaces\ElementInterface;
 use phpDocumentor\Descriptor\Interfaces\EnumInterface;
 use phpDocumentor\Descriptor\Interfaces\InterfaceInterface;
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\Interfaces\TraitInterface;
 
 use function array_merge;
@@ -40,19 +40,19 @@ class ElementsIndexBuilder implements CompilerPassInterface
         return 'Build "elements" index';
     }
 
-    public function __invoke(ProjectInterface $project): ProjectInterface
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
         $elementCollection = new Collection();
-        $project->getIndexes()->set('elements', $elementCollection);
+        $documentationSet->getIndexes()->set('elements', $elementCollection);
 
-        $constantsIndex  = $project->getIndexes()->fetch('constants', new Collection());
-        $functionsIndex  = $project->getIndexes()->fetch('functions', new Collection());
-        $classesIndex    = $project->getIndexes()->fetch('classes', new Collection());
-        $interfacesIndex = $project->getIndexes()->fetch('interfaces', new Collection());
-        $traitsIndex     = $project->getIndexes()->fetch('traits', new Collection());
-        $enumsIndex     = $project->getIndexes()->fetch('enums', new Collection());
+        $constantsIndex  = $documentationSet->getIndexes()->fetch('constants', new Collection());
+        $functionsIndex  = $documentationSet->getIndexes()->fetch('functions', new Collection());
+        $classesIndex    = $documentationSet->getIndexes()->fetch('classes', new Collection());
+        $interfacesIndex = $documentationSet->getIndexes()->fetch('interfaces', new Collection());
+        $traitsIndex     = $documentationSet->getIndexes()->fetch('traits', new Collection());
+        $enumsIndex     = $documentationSet->getIndexes()->fetch('enums', new Collection());
 
-        foreach ($project->getFiles() as $file) {
+        foreach ($documentationSet->getFiles() as $file) {
             $this->addElementsToIndexes($file->getConstants()->getAll(), [$constantsIndex, $elementCollection]);
             $this->addElementsToIndexes($file->getFunctions()->getAll(), [$functionsIndex, $elementCollection]);
 
@@ -77,7 +77,7 @@ class ElementsIndexBuilder implements CompilerPassInterface
             }
         }
 
-        return $project;
+        return $documentationSet;
     }
 
     /**

--- a/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Compiler\CompilerPassInterface;
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\Interfaces\ClassInterface;
@@ -42,6 +43,10 @@ class ElementsIndexBuilder implements CompilerPassInterface
 
     public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
+        if ($documentationSet instanceof ApiSetDescriptor === false) {
+            return $documentationSet;
+        }
+
         $elementCollection = new Collection();
         $documentationSet->getIndexes()->set('elements', $elementCollection);
 

--- a/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/ElementsIndexBuilder.php
@@ -43,12 +43,12 @@ class ElementsIndexBuilder implements CompilerPassInterface
 
     public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
+        $elementCollection = new Collection();
+        $documentationSet->getIndexes()->set('elements', $elementCollection);
+
         if ($documentationSet instanceof ApiSetDescriptor === false) {
             return $documentationSet;
         }
-
-        $elementCollection = new Collection();
-        $documentationSet->getIndexes()->set('elements', $elementCollection);
 
         $constantsIndex  = $documentationSet->getIndexes()->fetch('constants', new Collection());
         $functionsIndex  = $documentationSet->getIndexes()->fetch('functions', new Collection());

--- a/src/phpDocumentor/Compiler/Pass/GuidesCompiler.php
+++ b/src/phpDocumentor/Compiler/Pass/GuidesCompiler.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Compiler\CompilerPassInterface;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\DocumentDescriptor;
 use phpDocumentor\Descriptor\GuideSetDescriptor;
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Guides\Compiler\Compiler;
 use phpDocumentor\Guides\Metas;
 
@@ -29,29 +29,24 @@ final class GuidesCompiler implements CompilerPassInterface
         return 'Compiling guides';
     }
 
-    public function __invoke(ProjectInterface $project): ProjectInterface
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
-        foreach ($project->getVersions() as $version) {
-            foreach ($version->getDocumentationSets() as $documentationSet) {
-                if (!($documentationSet instanceof GuideSetDescriptor)) {
-                    continue;
-                }
-
-               // $this->metas->setMetaEntries([]);
-                $documents = $this->compiler->run(
-                    array_map(
-                        static fn (DocumentDescriptor $descriptor) => $descriptor->getDocumentNode(),
-                        $documentationSet->getDocuments()->getAll()
-                    )
-                );
-                foreach ($documents as $document) {
-                    $documentationSet->getDocuments()->get($document->getFilePath())->setDocumentNode($document);
-                }
-
-                $documentationSet->setMetas(new Metas($this->metas->getAll()));
-            }
+        if ($documentationSet instanceof GuideSetDescriptor === false) {
+            return $documentationSet;
         }
 
-        return $project;
+        $documents = $this->compiler->run(
+            array_map(
+                static fn (DocumentDescriptor $descriptor) => $descriptor->getDocumentNode(),
+                $documentationSet->getDocuments()->getAll()
+            )
+        );
+        foreach ($documents as $document) {
+            $documentationSet->getDocuments()->get($document->getFilePath())->setDocumentNode($document);
+        }
+
+        $documentationSet->setMetas(new Metas($this->metas->getAll()));
+
+        return $documentationSet;
     }
 }

--- a/src/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractor.php
+++ b/src/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractor.php
@@ -16,8 +16,8 @@ namespace phpDocumentor\Compiler\Pass;
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\TagDescriptor;
 use UnexpectedValueException;
 
@@ -33,10 +33,10 @@ final class MarkerFromTagsExtractor implements CompilerPassInterface
         return 'Collect all markers embedded in tags';
     }
 
-    public function __invoke(ProjectInterface $project): ProjectInterface
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
         /** @var DescriptorAbstract $element */
-        foreach ($project->getIndexes()->fetch('elements', new Collection()) as $element) {
+        foreach ($documentationSet->getIndexes()->fetch('elements', new Collection()) as $element) {
             /** @var TagDescriptor[] $todos */
             $todos = $element->getTags()->fetch('todo');
 
@@ -50,7 +50,7 @@ final class MarkerFromTagsExtractor implements CompilerPassInterface
             }
         }
 
-        return $project;
+        return $documentationSet;
     }
 
     /**

--- a/src/phpDocumentor/Compiler/Pass/RemoveSourcecode.php
+++ b/src/phpDocumentor/Compiler/Pass/RemoveSourcecode.php
@@ -15,7 +15,7 @@ namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\ApiSetDescriptor;
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 
 final class RemoveSourcecode implements CompilerPassInterface
 {
@@ -26,23 +26,19 @@ final class RemoveSourcecode implements CompilerPassInterface
         return 'Removing sourcecode from file descriptors';
     }
 
-    public function __invoke(ProjectInterface $project): ProjectInterface
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
-        foreach ($project->getVersions() as $version) {
-            foreach ($version->getDocumentationSets() as $documentationSet) {
-                if (
-                    !$documentationSet instanceof ApiSetDescriptor ||
-                    $documentationSet->getSettings()['include-source']
-                ) {
-                    continue;
-                }
-
-                foreach ($project->getFiles() as $file) {
-                    $file->setSource(null);
-                }
-            }
+        if (
+            $documentationSet instanceof ApiSetDescriptor === false ||
+            $documentationSet->getSettings()['include-source']
+        ) {
+            return $documentationSet;
         }
 
-        return $project;
+        foreach ($documentationSet->getFiles() as $file) {
+            $file->setSource(null);
+        }
+
+        return $documentationSet;
     }
 }

--- a/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
+++ b/src/phpDocumentor/Compiler/Pass/ResolveInlineMarkers.php
@@ -15,8 +15,8 @@ namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\ApiSetDescriptor;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 
 use function implode;
 use function preg_match_all;
@@ -40,45 +40,40 @@ final class ResolveInlineMarkers implements CompilerPassInterface
     /**
      * Scans the files for markers and records them in the markers property of a file.
      */
-    public function __invoke(ProjectInterface $project): ProjectInterface
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
-        ///This looks ugly, when versions are introduced we get rid of these 2 foreach loops.
-        foreach ($project->getVersions() as $version) {
-            foreach ($version->getDocumentationSets() as $documentationSet) {
-                if ($documentationSet instanceof ApiSetDescriptor === false) {
-                    continue;
-                }
+        if ($documentationSet instanceof ApiSetDescriptor === false) {
+            return $documentationSet;
+        }
 
-                $markerTerms = $documentationSet->getSettings()['markers'];
+        $markerTerms = $documentationSet->getSettings()['markers'];
 
-                /** @var FileDescriptor $file */
-                foreach ($project->getFiles() as $file) {
-                    $matches = [];
-                    $source  = $file->getSource() ?? '';
+        /** @var FileDescriptor $file */
+        foreach ($documentationSet->getFiles() as $file) {
+            $matches = [];
+            $source  = $file->getSource() ?? '';
 
-                    preg_match_all(
-                        '~//[\s]*(' . implode('|', $markerTerms) . ')\:?[\s]*(.*)~',
-                        $source,
-                        $matches,
-                        PREG_SET_ORDER | PREG_OFFSET_CAPTURE
-                    );
+            preg_match_all(
+                '~//[\s]*(' . implode('|', $markerTerms) . ')\:?[\s]*(.*)~',
+                $source,
+                $matches,
+                PREG_SET_ORDER | PREG_OFFSET_CAPTURE
+            );
 
-                    foreach ($matches as $match) {
-                        [$before] = str_split($source, $match[1][1]); // fetches all the text before the match
+            foreach ($matches as $match) {
+                [$before] = str_split($source, $match[1][1]); // fetches all the text before the match
 
-                        $lineNumber = strlen($before) - strlen(str_replace("\n", '', $before)) + 1;
-                        $file->getMarkers()->add(
-                            [
-                                'type' => trim($match[1][0], '@'),
-                                'line' => $lineNumber,
-                                'message' => $match[2][0],
-                            ]
-                        );
-                    }
-                }
+                $lineNumber = strlen($before) - strlen(str_replace("\n", '', $before)) + 1;
+                $file->getMarkers()->add(
+                    [
+                        'type' => trim($match[1][0], '@'),
+                        'line' => $lineNumber,
+                        'message' => $match[2][0],
+                    ]
+                );
             }
         }
 
-        return $project;
+        return $documentationSet;
     }
 }

--- a/src/phpDocumentor/Compiler/Pass/TableOfContentsBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/TableOfContentsBuilder.php
@@ -15,10 +15,10 @@ namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\ApiSetDescriptor;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\DocumentDescriptor;
 use phpDocumentor\Descriptor\GuideSetDescriptor;
 use phpDocumentor\Descriptor\Interfaces\NamespaceInterface;
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\TableOfContents\Entry;
 use phpDocumentor\Descriptor\TocDescriptor;
 use phpDocumentor\Guides\Meta\DocumentReferenceEntry;
@@ -42,54 +42,49 @@ final class TableOfContentsBuilder implements CompilerPassInterface
         return 'Builds table of contents for api documentation sets';
     }
 
-    public function __invoke(ProjectInterface $project): ProjectInterface
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
-        //This looks ugly, when versions are introduced we get rid of these 2 foreach loops.
-        foreach ($project->getVersions() as $version) {
-            foreach ($version->getDocumentationSets() as $documentationSet) {
-                if ($documentationSet instanceof ApiSetDescriptor) {
-                    if ($project->getNamespace()->getChildren()->count() > 0) {
-                        $namespacesToc = new TocDescriptor('Namespaces');
-                        foreach ($project->getNamespace()->getChildren() as $child) {
-                            $this->createNamespaceEntries($child, $namespacesToc);
-                        }
-
-                        $documentationSet->addTableOfContents($namespacesToc);
-                    }
-
-                    if ($project->getPackage()->getChildren()->count() > 0) {
-                        $packagesToc = new TocDescriptor('Packages');
-                        foreach ($project->getPackage()->getChildren() as $child) {
-                            $this->createNamespaceEntries($child, $packagesToc);
-                        }
-
-                        $documentationSet->addTableOfContents($packagesToc);
-                    }
+        if ($documentationSet instanceof ApiSetDescriptor) {
+            if ($documentationSet->getNamespace()->getChildren()->count() > 0) {
+                $namespacesToc = new TocDescriptor('Namespaces');
+                foreach ($documentationSet->getNamespace()->getChildren() as $child) {
+                    $this->createNamespaceEntries($child, $namespacesToc);
                 }
 
-                if (!($documentationSet instanceof GuideSetDescriptor)) {
-                    continue;
+                $documentationSet->addTableOfContents($namespacesToc);
+            }
+
+            if ($documentationSet->getPackage()->getChildren()->count() > 0) {
+                $packagesToc = new TocDescriptor('Packages');
+                foreach ($documentationSet->getPackage()->getChildren() as $child) {
+                    $this->createNamespaceEntries($child, $packagesToc);
                 }
 
-                $documents = $documentationSet->getDocuments();
-                $index     = $documents->fetch('index');
-                if ($index === null) {
-                    continue;
-                }
-
-                $guideToc = new TocDescriptor($index->getTitle());
-                $this->createGuideEntries(
-                    $index,
-                    $documentationSet->getMetas()->findDocument($index->getFile()),
-                    $documentationSet,
-                    $guideToc
-                );
-
-                $documentationSet->addTableOfContents($guideToc);
+                $documentationSet->addTableOfContents($packagesToc);
             }
         }
 
-        return $project;
+        if (!($documentationSet instanceof GuideSetDescriptor)) {
+            return $documentationSet;
+        }
+
+        $documents = $documentationSet->getDocuments();
+        $index     = $documents->fetch('index');
+        if ($index === null) {
+            return $documentationSet;
+        }
+
+        $guideToc = new TocDescriptor($index->getTitle());
+        $this->createGuideEntries(
+            $index,
+            $documentationSet->getMetas()->findDocument($index->getFile()),
+            $documentationSet,
+            $guideToc
+        );
+
+        $documentationSet->addTableOfContents($guideToc);
+
+        return $documentationSet;
     }
 
     private function createNamespaceEntries(

--- a/src/phpDocumentor/Compiler/Pass/UsedByBuilder.php
+++ b/src/phpDocumentor/Compiler/Pass/UsedByBuilder.php
@@ -15,8 +15,8 @@ namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Compiler\CompilerPassInterface;
 use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\Interfaces\ElementInterface;
-use phpDocumentor\Descriptor\Interfaces\ProjectInterface;
 use phpDocumentor\Descriptor\Tag\UsedByDescriptor;
 use phpDocumentor\Descriptor\Tag\UsesDescriptor;
 use phpDocumentor\Descriptor\TagDescriptor;
@@ -28,9 +28,9 @@ final class UsedByBuilder implements CompilerPassInterface
         return 'Creates a link for uses tags on the counter side';
     }
 
-    public function __invoke(ProjectInterface $project): ProjectInterface
+    public function __invoke(DocumentationSetDescriptor $documentationSet): DocumentationSetDescriptor
     {
-        foreach ($project->getIndexes()->get('elements') as $element) {
+        foreach ($documentationSet->getIndexes()->get('elements') as $element) {
             $uses = $element->getTags()->fetch('uses', Collection::fromClassString(TagDescriptor::class));
             foreach ($uses->filter(UsesDescriptor::class) as $usesTag) {
                 $counterSide = $usesTag->getReference();
@@ -47,6 +47,6 @@ final class UsedByBuilder implements CompilerPassInterface
             }
         }
 
-        return $project;
+        return $documentationSet;
     }
 }

--- a/src/phpDocumentor/Descriptor/ApiSetDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ApiSetDescriptor.php
@@ -16,10 +16,15 @@ namespace phpDocumentor\Descriptor;
 use phpDocumentor\Configuration\ApiSpecification;
 use phpDocumentor\Configuration\Source;
 use phpDocumentor\Descriptor\Interfaces\ElementInterface;
+use phpDocumentor\Descriptor\Traits\HasNamespace;
+use phpDocumentor\Descriptor\Traits\HasPackage;
 use phpDocumentor\Reflection\Fqsen;
 
 final class ApiSetDescriptor extends DocumentationSetDescriptor
 {
+    use HasPackage;
+    use HasNamespace;
+
     private ApiSpecification $apiSpecification;
 
     public function __construct(
@@ -34,6 +39,16 @@ final class ApiSetDescriptor extends DocumentationSetDescriptor
         $this->apiSpecification = $apiSpecification;
 
         parent::__construct();
+
+        $namespace = new NamespaceDescriptor();
+        $namespace->setName('\\');
+        $namespace->setFullyQualifiedStructuralElementName(new Fqsen('\\'));
+        $this->setNamespace($namespace);
+
+        $package = new PackageDescriptor();
+        $package->setName('\\');
+        $package->setFullyQualifiedStructuralElementName(new Fqsen('\\'));
+        $this->setPackage($package);
 
         // Pre-initialize elements index
         $this->getIndexes()['elements'] = Collection::fromInterfaceString(ElementInterface::class);

--- a/src/phpDocumentor/Descriptor/ProjectDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptor.php
@@ -14,12 +14,11 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor;
 
 use phpDocumentor\Descriptor\Interfaces\FileInterface;
+use phpDocumentor\Descriptor\Interfaces\NamespaceInterface;
+use phpDocumentor\Descriptor\Interfaces\PackageInterface;
 use phpDocumentor\Descriptor\ProjectDescriptor\Settings;
 use phpDocumentor\Descriptor\Traits\HasDescription;
 use phpDocumentor\Descriptor\Traits\HasName;
-use phpDocumentor\Descriptor\Traits\HasNamespace;
-use phpDocumentor\Descriptor\Traits\HasPackage;
-use phpDocumentor\Reflection\Fqsen;
 use Webmozart\Assert\Assert;
 
 /**
@@ -32,8 +31,6 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
 {
     use HasName;
     use HasDescription;
-    use HasPackage;
-    use HasNamespace;
 
     private Settings $settings;
 
@@ -50,17 +47,6 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
     {
         $this->setName($name);
         $this->setSettings(new Settings());
-
-        $namespace = new NamespaceDescriptor();
-        $namespace->setName('\\');
-        $namespace->setFullyQualifiedStructuralElementName(new Fqsen('\\'));
-        $this->setNamespace($namespace);
-
-        $package = new PackageDescriptor();
-        $package->setName('\\');
-        $package->setFullyQualifiedStructuralElementName(new Fqsen('\\'));
-        $this->setPackage($package);
-
         $this->setPartials(new Collection());
         $this->versions = Collection::fromClassString(VersionDescriptor::class);
     }
@@ -134,6 +120,54 @@ class ProjectDescriptor implements Interfaces\ProjectInterface, Descriptor
     public function getVersions(): Collection
     {
         return $this->versions;
+    }
+
+    /**
+     * Sets the namespace (name) for this element.
+     *
+     * @internal should not be called by any other class than the assemblers
+     * @deprecated
+     *
+     * @param NamespaceInterface|string $namespace
+     */
+    public function setNamespace($namespace): void
+    {
+        $this->getApiDocumentationSet()->setNamespace($namespace);
+    }
+
+    /**
+     * Returns the namespace for this element (defaults to global "\")
+     *
+     * @deprecated
+     *
+     * @return NamespaceInterface|string
+     */
+    public function getNamespace()
+    {
+        return $this->getApiDocumentationSet()->getNamespace();
+    }
+
+    /**
+     * Sets the package (name) for this element.
+     *
+     * @internal should not be called by any other class than the assemblers
+     * @deprecated
+     *
+     * @param PackageInterface|string $package
+     */
+    public function setPackage($package): void
+    {
+        $this->getApiDocumentationSet()->setPackage($package);
+    }
+
+    /**
+     * Returns the package for this element (defaults to global "\")
+     *
+     * @deprecated
+     */
+    public function getPackage(): ?PackageInterface
+    {
+        return $this->getApiDocumentationSet()->getPackage();
     }
 
     /**

--- a/src/phpDocumentor/Pipeline/Stage/Compile.php
+++ b/src/phpDocumentor/Pipeline/Stage/Compile.php
@@ -38,7 +38,13 @@ final class Compile
      */
     public function __invoke(Payload $payload): Payload
     {
-        $this->compilerPipeline->process($payload->getBuilder()->getProjectDescriptor());
+        $projectDescriptor = $payload->getBuilder()->getProjectDescriptor();
+
+        foreach ($projectDescriptor->getVersions() as $version) {
+            foreach ($version->getDocumentationSets() as $documentationSet) {
+                $this->compilerPipeline->process($documentationSet);
+            }
+        }
 
         return $payload;
     }

--- a/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Linker/LinkerTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Linker;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Faker\Faker;
 use phpDocumentor\Reflection\Fqsen;
 use PHPUnit\Framework\TestCase;
@@ -54,9 +54,9 @@ final class LinkerTest extends TestCase
     public function testSetFieldsToSubstitute(): void
     {
         $elementList = [
-            ProjectDescriptor::class => 'files',
-            FileDescriptor::class    => 'classes',
-            ClassDescriptor::class   => 'parent',
+            ApiSetDescriptor::class => 'files',
+            FileDescriptor::class => 'classes',
+            ClassDescriptor::class => 'parent',
         ];
         $linker = new Linker($elementList, new DescriptorRepository());
 
@@ -286,9 +286,6 @@ final class LinkerTest extends TestCase
         $fqsen = get_class($object);
 
         $apiSetDescriptor = $this->faker()->apiSetDescriptor();
-        $project = $this->faker()->projectDescriptor([
-            $this->faker()->versionDescriptor([$apiSetDescriptor]),
-        ]);
         $apiSetDescriptor->getIndex('elements')->set($fqsen, $result);
 
         // prepare linker
@@ -297,7 +294,7 @@ final class LinkerTest extends TestCase
         $linker = new Linker([$fqsen => ['field']], $repository->reveal());
 
         // execute test.
-        $linker->__invoke($project);
+        $linker->__invoke($apiSetDescriptor);
     }
 
     private function givenAnExampleClassDescriptor(string $fqsenString): ClassDescriptor

--- a/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/DebugTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Descriptor\ProjectAnalyzer;
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Faker\Faker;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -28,6 +28,7 @@ use Psr\Log\NullLogger;
  */
 final class DebugTest extends TestCase
 {
+    use Faker;
     use ProphecyTrait;
 
     /**
@@ -36,17 +37,17 @@ final class DebugTest extends TestCase
     public function testLogDebugAnalysis(): void
     {
         $testString = 'test';
-        $projectDescriptorMock = $this->prophesize(ProjectDescriptor::class);
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
 
         $loggerMock = $this->prophesize(LoggerInterface::class);
         $loggerMock->debug(Argument::exact($testString))->shouldBeCalled();
 
         $analyzerMock = $this->prophesize(ProjectAnalyzer::class);
-        $analyzerMock->analyze(Argument::exact($projectDescriptorMock->reveal()))->shouldBeCalled();
+        $analyzerMock->analyze(Argument::exact($apiSetDescriptor))->shouldBeCalled();
         $analyzerMock->__toString()->shouldBeCalled()->willReturn($testString);
 
         $fixture = new Debug($loggerMock->reveal(), $analyzerMock->reveal());
-        $fixture->__invoke($projectDescriptorMock->reveal());
+        $fixture->__invoke($apiSetDescriptor);
 
         $this->assertTrue(true);
     }

--- a/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ElementsIndexBuilderTest.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\ConstantDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\FunctionDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\MethodDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\PropertyDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\Faker\Faker;
@@ -32,32 +32,29 @@ use function array_values;
 /**
  * Tests the functionality for the ElementsIndexBuilder
  *
- * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder
+ * @coversDefaultClass \phpDocumentor\Compiler\Pass\ElementsIndexBuilder
  */
 class ElementsIndexBuilderTest extends TestCase
 {
     use Faker;
 
     protected ElementsIndexBuilder $fixture;
-    protected ProjectDescriptor $project;
+    private ApiSetDescriptor $apiSet;
 
     protected function setUp(): void
     {
         $this->fixture = new ElementsIndexBuilder();
 
-        $this->project = new ProjectDescriptor('title');
-        $set = $this->faker()->apiSetDescriptor();
-        $version = $this->faker()->versionDescriptor([$set]);
-        $this->project->getVersions()->add($version);
+        $this->apiSet = $this->faker()->apiSetDescriptor();
 
         $file1 = new FileDescriptor('hash');
         $file2 = new FileDescriptor('hash2');
-        $this->project->getFiles()->add($file1);
-        $this->project->getFiles()->add($file2);
+        $this->apiSet->getFiles()->add($file1);
+        $this->apiSet->getFiles()->add($file2);
     }
 
     /**
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getDescription
+     * @covers ::getDescription
      */
     public function testGetDescription(): void
     {
@@ -65,164 +62,164 @@ class ElementsIndexBuilderTest extends TestCase
     }
 
     /**
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::__invoke
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::addElementsToIndexes
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getIndexKey
+     * @covers ::__invoke
+     * @covers ::addElementsToIndexes
+     * @covers ::getIndexKey
      */
     public function testAddClassesToIndex(): void
     {
-        $file1 = $this->project->getFiles()->get(0);
+        $file1 = $this->apiSet->getFiles()->get(0);
         $classDescriptor1 = new ClassDescriptor();
         $classDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class1'));
         $file1->getClasses()->add($classDescriptor1);
 
-        $file2 = $this->project->getFiles()->get(1);
+        $file2 = $this->apiSet->getFiles()->get(1);
         $classDescriptor2 = new ClassDescriptor();
         $classDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class2'));
         $file2->getClasses()->add($classDescriptor2);
 
-        $this->fixture->__invoke($this->project);
+        $this->fixture->__invoke($this->apiSet);
 
-        $elements = $this->project->getIndexes()->get('elements')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('elements')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\My\Space\Class1', '\My\Space\Class2'], array_keys($elements));
         $this->assertSame([$classDescriptor1, $classDescriptor2], array_values($elements));
 
-        $elements = $this->project->getIndexes()->get('classes')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('classes')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\My\Space\Class1', '\My\Space\Class2'], array_keys($elements));
         $this->assertSame([$classDescriptor1, $classDescriptor2], array_values($elements));
     }
 
     /**
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::__invoke
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::addElementsToIndexes
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getIndexKey
+     * @covers ::__invoke
+     * @covers ::addElementsToIndexes
+     * @covers ::getIndexKey
      */
     public function testAddInterfacesToIndex(): void
     {
-        $file1 = $this->project->getFiles()->get(0);
+        $file1 = $this->apiSet->getFiles()->get(0);
         $interfaceDescriptor1 = new InterfaceDescriptor();
         $interfaceDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Interface1'));
         $file1->getInterfaces()->add($interfaceDescriptor1);
 
-        $file2 = $this->project->getFiles()->get(1);
+        $file2 = $this->apiSet->getFiles()->get(1);
         $interfaceDescriptor2 = new InterfaceDescriptor();
         $interfaceDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Interface2'));
         $file2->getInterfaces()->add($interfaceDescriptor2);
 
-        $this->fixture->__invoke($this->project);
+        $this->fixture->__invoke($this->apiSet);
 
-        $elements = $this->project->getIndexes()->get('elements')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('elements')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\My\Space\Interface1', '\My\Space\Interface2'], array_keys($elements));
         $this->assertSame([$interfaceDescriptor1, $interfaceDescriptor2], array_values($elements));
 
-        $elements = $this->project->getIndexes()->get('interfaces')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('interfaces')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\My\Space\Interface1', '\My\Space\Interface2'], array_keys($elements));
         $this->assertSame([$interfaceDescriptor1, $interfaceDescriptor2], array_values($elements));
     }
 
     /**
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::__invoke
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::addElementsToIndexes
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getIndexKey
+     * @covers ::__invoke
+     * @covers ::addElementsToIndexes
+     * @covers ::getIndexKey
      */
     public function testAddTraitsToIndex(): void
     {
-        $file1 = $this->project->getFiles()->get(0);
+        $file1 = $this->apiSet->getFiles()->get(0);
         $traitDescriptor1 = new TraitDescriptor();
         $traitDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Trait1'));
         $file1->getTraits()->add($traitDescriptor1);
 
-        $file2 = $this->project->getFiles()->get(1);
+        $file2 = $this->apiSet->getFiles()->get(1);
         $traitDescriptor2 = new TraitDescriptor();
         $traitDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Trait2'));
         $file2->getTraits()->add($traitDescriptor2);
 
-        $this->fixture->__invoke($this->project);
+        $this->fixture->__invoke($this->apiSet);
 
-        $elements = $this->project->getIndexes()->get('elements')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('elements')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\My\Space\Trait1', '\My\Space\Trait2'], array_keys($elements));
         $this->assertSame([$traitDescriptor1, $traitDescriptor2], array_values($elements));
 
-        $elements = $this->project->getIndexes()->get('traits')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('traits')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\My\Space\Trait1', '\My\Space\Trait2'], array_keys($elements));
         $this->assertSame([$traitDescriptor1, $traitDescriptor2], array_values($elements));
     }
 
     /**
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::__invoke
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::addElementsToIndexes
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getIndexKey
+     * @covers ::__invoke
+     * @covers ::addElementsToIndexes
+     * @covers ::getIndexKey
      */
     public function testAddFunctionsToIndex(): void
     {
-        $file1 = $this->project->getFiles()->get(0);
+        $file1 = $this->apiSet->getFiles()->get(0);
         $functionDescriptor1 = new FunctionDescriptor();
         $functionDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\function1'));
         $file1->getFunctions()->add($functionDescriptor1);
 
-        $file2 = $this->project->getFiles()->get(1);
+        $file2 = $this->apiSet->getFiles()->get(1);
         $functionDescriptor2 = new FunctionDescriptor();
         $functionDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\function2'));
         $file2->getFunctions()->add($functionDescriptor2);
 
-        $this->fixture->__invoke($this->project);
+        $this->fixture->__invoke($this->apiSet);
 
-        $elements = $this->project->getIndexes()->get('elements')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('elements')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\function1', '\function2'], array_keys($elements));
         $this->assertSame([$functionDescriptor1, $functionDescriptor2], array_values($elements));
 
-        $elements = $this->project->getIndexes()->get('functions')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('functions')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\function1', '\function2'], array_keys($elements));
         $this->assertSame([$functionDescriptor1, $functionDescriptor2], array_values($elements));
     }
 
     /**
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::__invoke
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::addElementsToIndexes
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getIndexKey
+     * @covers ::__invoke
+     * @covers ::addElementsToIndexes
+     * @covers ::getIndexKey
      */
     public function testAddConstantsToIndex(): void
     {
-        $file1 = $this->project->getFiles()->get(0);
+        $file1 = $this->apiSet->getFiles()->get(0);
         $constantDescriptor1 = new ConstantDescriptor();
         $constantDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\CONSTANT1'));
         $file1->getConstants()->add($constantDescriptor1);
 
-        $file2 = $this->project->getFiles()->get(1);
+        $file2 = $this->apiSet->getFiles()->get(1);
         $constantDescriptor2 = new ConstantDescriptor();
         $constantDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\CONSTANT2'));
         $file2->getConstants()->add($constantDescriptor2);
 
-        $this->fixture->__invoke($this->project);
+        $this->fixture->__invoke($this->apiSet);
 
-        $elements = $this->project->getIndexes()->get('elements')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('elements')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\CONSTANT1', '\CONSTANT2'], array_keys($elements));
         $this->assertSame([$constantDescriptor1, $constantDescriptor2], array_values($elements));
 
-        $elements = $this->project->getIndexes()->get('constants')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('constants')->getAll();
         $this->assertCount(2, $elements);
         $this->assertSame(['\CONSTANT1', '\CONSTANT2'], array_keys($elements));
         $this->assertSame([$constantDescriptor1, $constantDescriptor2], array_values($elements));
     }
 
     /**
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::__invoke
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::addElementsToIndexes
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getIndexKey
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getSubElements
+     * @covers ::__invoke
+     * @covers ::addElementsToIndexes
+     * @covers ::getIndexKey
+     * @covers ::getSubElements
      */
     public function testAddClassConstantsToIndex(): void
     {
-        $file1 = $this->project->getFiles()->get(0);
+        $file1 = $this->apiSet->getFiles()->get(0);
         $classDescriptor1 = new ClassDescriptor();
         $classDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class1'));
         $file1->getClasses()->add($classDescriptor1);
@@ -231,7 +228,7 @@ class ElementsIndexBuilderTest extends TestCase
         $classConstantDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class1::CONSTANT'));
         $classDescriptor1->getConstants()->add($classConstantDescriptor1);
 
-        $file2 = $this->project->getFiles()->get(1);
+        $file2 = $this->apiSet->getFiles()->get(1);
         $classDescriptor2 = new ClassDescriptor();
         $classDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class2'));
         $file2->getClasses()->add($classDescriptor2);
@@ -240,9 +237,9 @@ class ElementsIndexBuilderTest extends TestCase
         $classConstantDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class2::CONSTANT'));
         $classDescriptor2->getConstants()->add($classConstantDescriptor2);
 
-        $this->fixture->__invoke($this->project);
+        $this->fixture->__invoke($this->apiSet);
 
-        $elements = $this->project->getIndexes()->get('elements')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('elements')->getAll();
         $this->assertCount(4, $elements);
         $this->assertSame(
             ['\My\Space\Class1', '\My\Space\Class1::CONSTANT', '\My\Space\Class2', '\My\Space\Class2::CONSTANT'],
@@ -254,19 +251,19 @@ class ElementsIndexBuilderTest extends TestCase
         );
 
         // class constants are not indexed separately
-        $elements = $this->project->getIndexes()->get('constants')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('constants')->getAll();
         $this->assertCount(0, $elements);
     }
 
     /**
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::__invoke
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::addElementsToIndexes
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getIndexKey
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getSubElements
+     * @covers ::__invoke
+     * @covers ::addElementsToIndexes
+     * @covers ::getIndexKey
+     * @covers ::getSubElements
      */
     public function testAddPropertiesToIndex(): void
     {
-        $file1 = $this->project->getFiles()->get(0);
+        $file1 = $this->apiSet->getFiles()->get(0);
         $classDescriptor1 = new ClassDescriptor();
         $classDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class1'));
         $file1->getClasses()->add($classDescriptor1);
@@ -275,7 +272,7 @@ class ElementsIndexBuilderTest extends TestCase
         $classPropertyDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class1::$property'));
         $classDescriptor1->getProperties()->add($classPropertyDescriptor1);
 
-        $file2 = $this->project->getFiles()->get(1);
+        $file2 = $this->apiSet->getFiles()->get(1);
         $classDescriptor2 = new ClassDescriptor();
         $classDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class2'));
         $file2->getClasses()->add($classDescriptor2);
@@ -284,9 +281,9 @@ class ElementsIndexBuilderTest extends TestCase
         $classPropertyDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class2::$property'));
         $classDescriptor2->getProperties()->add($classPropertyDescriptor2);
 
-        $this->fixture->__invoke($this->project);
+        $this->fixture->__invoke($this->apiSet);
 
-        $elements = $this->project->getIndexes()->get('elements')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('elements')->getAll();
         $this->assertCount(4, $elements);
         $this->assertSame(
             ['\My\Space\Class1', '\My\Space\Class1::$property', '\My\Space\Class2', '\My\Space\Class2::$property'],
@@ -298,18 +295,18 @@ class ElementsIndexBuilderTest extends TestCase
         );
 
         // class properties are not indexed separately
-        $this->assertNull($this->project->getIndexes()->fetch('properties'));
+        $this->assertNull($this->apiSet->getIndexes()->fetch('properties'));
     }
 
     /**
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::__invoke
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::addElementsToIndexes
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getIndexKey
-     * @covers \phpDocumentor\Compiler\Pass\ElementsIndexBuilder::getSubElements
+     * @covers ::__invoke
+     * @covers ::addElementsToIndexes
+     * @covers ::getIndexKey
+     * @covers ::getSubElements
      */
     public function testAddMethodsToIndex(): void
     {
-        $file1 = $this->project->getFiles()->get(0);
+        $file1 = $this->apiSet->getFiles()->get(0);
         $classDescriptor1 = new ClassDescriptor();
         $classDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class1'));
         $file1->getClasses()->add($classDescriptor1);
@@ -318,7 +315,7 @@ class ElementsIndexBuilderTest extends TestCase
         $classMethodDescriptor1->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class1::METHOD'));
         $classDescriptor1->getMethods()->add($classMethodDescriptor1);
 
-        $file2 = $this->project->getFiles()->get(1);
+        $file2 = $this->apiSet->getFiles()->get(1);
         $classDescriptor2 = new ClassDescriptor();
         $classDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class2'));
         $file2->getClasses()->add($classDescriptor2);
@@ -327,9 +324,9 @@ class ElementsIndexBuilderTest extends TestCase
         $classMethodDescriptor2->setFullyQualifiedStructuralElementName(new Fqsen('\My\Space\Class2::METHOD'));
         $classDescriptor2->getMethods()->add($classMethodDescriptor2);
 
-        $this->fixture->__invoke($this->project);
+        $this->fixture->__invoke($this->apiSet);
 
-        $elements = $this->project->getIndexes()->get('elements')->getAll();
+        $elements = $this->apiSet->getIndexes()->get('elements')->getAll();
         $this->assertCount(4, $elements);
         $this->assertSame(
             ['\My\Space\Class1', '\My\Space\Class1::METHOD', '\My\Space\Class2', '\My\Space\Class2::METHOD'],
@@ -341,6 +338,6 @@ class ElementsIndexBuilderTest extends TestCase
         );
 
         // class methods are not indexed separately
-        $this->assertNull($this->project->getIndexes()->fetch('methods'));
+        $this->assertNull($this->apiSet->getIndexes()->fetch('methods'));
     }
 }

--- a/tests/unit/phpDocumentor/Compiler/Pass/PackageTreeBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/PackageTreeBuilderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Compiler\Pass;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\ConstantDescriptor;
@@ -21,7 +22,6 @@ use phpDocumentor\Descriptor\DocBlock\DescriptionDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\FunctionDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TagDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\Faker\Faker;
@@ -69,13 +69,10 @@ final class PackageTreeBuilderTest extends TestCase
      */
     public function testRootPackageIsSet(): void
     {
-        $project = new ProjectDescriptor('title');
-        $set = $this->faker()->apiSetDescriptor();
-        $version = $this->faker()->versionDescriptor([$set]);
-        $project->getVersions()->add($version);
-        $this->fixture->__invoke($project);
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages['\\']));
     }
@@ -90,11 +87,11 @@ final class PackageTreeBuilderTest extends TestCase
         $file = new FileDescriptor('hash');
         $this->withPackage($packageName, $file);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages[$packageName]));
         $this->assertContains($file, $packages[$packageName]->getFiles()->getAll());
@@ -112,11 +109,11 @@ final class PackageTreeBuilderTest extends TestCase
 
         $this->assertNull($file->getPackage());
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages[$packageName]));
         $this->assertContains($file, $packages[$packageName]->getFiles()->getAll());
@@ -135,11 +132,11 @@ final class PackageTreeBuilderTest extends TestCase
         $file2 = new FileDescriptor('hash');
         $this->withPackage($packageName, $file2);
 
-        $project = $this->givenProjectWithFiles([$file1, $file2]);
+        $apiSet = $this->givenApiSetWithFiles([$file1, $file2]);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages[$packageName]));
         $this->assertContains($file1, $packages[$packageName]->getFiles()->getAll());
@@ -159,11 +156,11 @@ final class PackageTreeBuilderTest extends TestCase
         $file2 = new FileDescriptor('hash');
         $this->withPackage($subPackageName, $file2);
 
-        $project = $this->givenProjectWithFiles([$file1, $file2]);
+        $apiSet = $this->givenApiSetWithFiles([$file1, $file2]);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $rootPackage = $project->getIndexes()->get('packages')['\\'];
+        $rootPackage = $apiSet->getIndexes()->get('packages')['\\'];
         $this->assertNotNull($rootPackage->getChildren()['My']);
         $this->assertNotNull($rootPackage->getChildren()['My']->getChildren()['Package']);
         $this->assertNotNull($rootPackage->getChildren()['My']->getChildren()['Package']->getChildren()['ButDeeper']);
@@ -179,11 +176,11 @@ final class PackageTreeBuilderTest extends TestCase
         $file = new FileDescriptor('hash');
         $this->withPackage($packageName, $file);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages['\\My\\Package']));
         $this->assertContains($file, $packages['\\My\\Package']->getFiles()->getAll());
@@ -199,11 +196,11 @@ final class PackageTreeBuilderTest extends TestCase
         $file = new FileDescriptor('hash');
         $this->withPackage($packageName, $file);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages['\\My\\Package']));
         $this->assertContains($file, $packages['\\My\\Package']->getFiles()->getAll());
@@ -219,11 +216,11 @@ final class PackageTreeBuilderTest extends TestCase
         $file = new FileDescriptor('hash');
         $this->withPackage($packageName, $file);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages['\\My\\Package']));
         $this->assertContains($file, $packages['\\My\\Package']->getFiles()->getAll());
@@ -239,11 +236,11 @@ final class PackageTreeBuilderTest extends TestCase
         $file = new FileDescriptor('hash');
         $this->withPackage($packageName, $file);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages['\\My\\Package']));
         $this->assertContains($file, $packages['\\My\\Package']->getFiles()->getAll());
@@ -261,11 +258,11 @@ final class PackageTreeBuilderTest extends TestCase
         $this->withPackage($packageName, $file);
         $this->withSubpackage($subPackageName, $file);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages[$packageName . '\\' . $subPackageName]));
         $this->assertContains($file, $packages[$packageName . '\\' . $subPackageName]->getFiles()->getAll());
@@ -283,11 +280,11 @@ final class PackageTreeBuilderTest extends TestCase
         $this->withPackage($packageName, $file);
         $this->withSubpackage($subPackageName, $file);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         $this->assertTrue(isset($packages[$packageName . '\\' . $subPackageName]));
         $this->assertContains($file, $packages[$packageName . '\\' . $subPackageName]->getFiles()->getAll());
@@ -305,11 +302,11 @@ final class PackageTreeBuilderTest extends TestCase
         $this->withPackage($packageName, $file);
         $file->getConstants()->add($constant);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         // @todo: shouldn't this constant have inherited his file's Package?
         $this->assertContains($constant, $packages['\\' . self::DEFAULT_PACKAGE_NAME]->getConstants()->getAll());
@@ -327,11 +324,11 @@ final class PackageTreeBuilderTest extends TestCase
         $this->withPackage($packageName, $file);
         $file->getFunctions()->add($function);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         // @todo: shouldn't this function have inherited his file's Package?
         $this->assertContains($function, $packages['\\' . self::DEFAULT_PACKAGE_NAME]->getFunctions()->getAll());
@@ -349,11 +346,11 @@ final class PackageTreeBuilderTest extends TestCase
         $this->withPackage($packageName, $file);
         $file->getInterfaces()->add($interface);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         // @todo: shouldn't this interface have inherited his file's Package?
         $this->assertContains($interface, $packages['\\' . self::DEFAULT_PACKAGE_NAME]->getInterfaces()->getAll());
@@ -371,11 +368,11 @@ final class PackageTreeBuilderTest extends TestCase
         $this->withPackage($packageName, $file);
         $file->getTraits()->add($trait);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         // @todo: shouldn't this trait have inherited his file's Package?
         $this->assertContains($trait, $packages['\\' . self::DEFAULT_PACKAGE_NAME]->getTraits()->getAll());
@@ -393,11 +390,11 @@ final class PackageTreeBuilderTest extends TestCase
         $this->withPackage($packageName, $file);
         $file->getClasses()->add($class);
 
-        $project = $this->givenProjectWithFile($file);
+        $apiSet = $this->givenApiSetWithFile($file);
 
-        $this->fixture->__invoke($project);
+        $this->fixture->__invoke($apiSet);
 
-        $packages = $project->getIndexes()->get('packages');
+        $packages = $apiSet->getIndexes()->get('packages');
 
         // @todo: shouldn't this class have inherited his file's Package?
         $this->assertContains($class, $packages['\\' . self::DEFAULT_PACKAGE_NAME]->getClasses()->getAll());
@@ -419,28 +416,22 @@ final class PackageTreeBuilderTest extends TestCase
         $file->getTags()['subpackage'] = new Collection([$packageTag]);
     }
 
-    private function givenProjectWithFile(FileDescriptor $file): ProjectDescriptor
+    private function givenApiSetWithFile(FileDescriptor $file): ApiSetDescriptor
     {
-        $project = new ProjectDescriptor('title');
-        $set = $this->faker()->apiSetDescriptor();
-        $version = $this->faker()->versionDescriptor([$set]);
-        $project->getVersions()->add($version);
-        $project->getFiles()->add($file);
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $apiSet->getFiles()->add($file);
 
-        return $project;
+        return $apiSet;
     }
 
-    private function givenProjectWithFiles(array $files): ProjectDescriptor
+    private function givenApiSetWithFiles(array $files): ApiSetDescriptor
     {
-        $project = new ProjectDescriptor('title');
-        $set = $this->faker()->apiSetDescriptor();
-        $version = $this->faker()->versionDescriptor([$set]);
-        $project->getVersions()->add($version);
+        $apiSet = $this->faker()->apiSetDescriptor();
 
         foreach ($files as $file) {
-            $project->getFiles()->add($file);
+            $apiSet->getFiles()->add($file);
         }
 
-        return $project;
+        return $apiSet;
     }
 }

--- a/tests/unit/phpDocumentor/Compiler/Pass/RemoveSourcecodeTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/RemoveSourcecodeTest.php
@@ -16,7 +16,6 @@ namespace phpDocumentor\Compiler\Pass;
 use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\Collection as DescriptorCollection;
 use phpDocumentor\Descriptor\DocumentationSetDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Faker\Faker;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -36,10 +35,10 @@ final class RemoveSourcecodeTest extends TestCase
     public function testRemovesSourceWhenDisabled(): void
     {
         $apiSetDescriptor = $this->faker()->apiSetDescriptor();
-        $projectDescriptor = $this->giveProjectDescriptor($apiSetDescriptor);
+        $apiSetDescriptor = $this->givenFiles($apiSetDescriptor);
         $fixture = new RemoveSourcecode();
 
-        $fixture->__invoke($projectDescriptor);
+        $fixture->__invoke($apiSetDescriptor);
 
         foreach ($apiSetDescriptor->getFiles() as $file) {
             self::assertNull($file->getSource());
@@ -53,21 +52,18 @@ final class RemoveSourcecodeTest extends TestCase
     {
         $apiSetDescriptor = $this->faker()->apiSetDescriptor();
         $apiSetDescriptor->getSettings()['include-source'] = true;
-        $projectDescriptor = $this->giveProjectDescriptor($apiSetDescriptor);
+        $apiSetDescriptor = $this->givenFiles($apiSetDescriptor);
         $fixture = new RemoveSourcecode();
 
-        $fixture->__invoke($projectDescriptor);
+        $fixture->__invoke($apiSetDescriptor);
 
         foreach ($apiSetDescriptor->getFiles() as $file) {
             self::assertNotNull($file->getSource());
         }
     }
 
-    private function giveProjectDescriptor(ApiSetDescriptor $apiDescriptor): ProjectDescriptor
+    private function givenFiles(ApiSetDescriptor $apiDescriptor): ApiSetDescriptor
     {
-        $projectDescriptor = $this->faker()->projectDescriptor();
-        $versionDesciptor = $this->faker()->versionDescriptor([$apiDescriptor]);
-        $projectDescriptor->getVersions()->add($versionDesciptor);
         $apiDescriptor->setFiles(
             DescriptorCollection::fromClassString(
                 DocumentationSetDescriptor::class,
@@ -75,7 +71,7 @@ final class RemoveSourcecodeTest extends TestCase
             )
         );
 
-        return $projectDescriptor;
+        return $apiDescriptor;
     }
 
     /**

--- a/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/ResolveInlineMarkersTest.php
@@ -14,10 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Compiler\Pass;
 
 use phpDocumentor\Descriptor\Collection;
-use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
-use phpDocumentor\Descriptor\ProjectDescriptor;
-use phpDocumentor\Descriptor\VersionDescriptor;
 use phpDocumentor\Faker\Faker;
 use PHPUnit\Framework\TestCase;
 
@@ -42,14 +39,9 @@ SOURCE
         );
 
         $apiDescriptor = $this->faker()->apiSetDescriptor();
-        $documentationsSets = Collection::fromClassString(DocumentationSetDescriptor::class);
-        $documentationsSets->add($apiDescriptor);
-
-        $projectDescriptor = new ProjectDescriptor('test project');
-        $projectDescriptor->getVersions()->add(new VersionDescriptor('latest', $documentationsSets));
         $apiDescriptor->setFiles(new Collection([$fileDescriptor]));
 
-        $fixture->__invoke($projectDescriptor);
+        $fixture->__invoke($apiDescriptor);
 
         self::assertCount(1, $fileDescriptor->getMarkers());
     }

--- a/tests/unit/phpDocumentor/Compiler/Pass/TableOfContentsBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/TableOfContentsBuilderTest.php
@@ -32,16 +32,14 @@ final class TableOfContentsBuilderTest extends TestCase
     public function testApiDocumentationSetNamespacesAreAddedAsTOC(): void
     {
         $apiDocumentationSet = $this->faker()->apiSetDescriptor();
-        $project             = $this->faker()->projectDescriptor();
-        $project->getVersions()->add($this->faker()->versionDescriptor([$apiDocumentationSet]));
-        $project->getNamespace()->addChild($this->faker()->namespaceDescriptorTree());
+        $apiDocumentationSet->getNamespace()->addChild($this->faker()->namespaceDescriptorTree());
 
         $router = $this->prophesize(Router::class);
         $router->generate(Argument::any())->will(function ($args) {
             return (string) $args[0]->getFullyQualifiedStructuralElementName();
         });
         $pass = new TableOfContentsBuilder($router->reveal(), new NullLogger());
-        $pass->__invoke($project);
+        $pass->__invoke($apiDocumentationSet);
 
         self::assertCount(1, $apiDocumentationSet->getTableOfContents());
         /** @var TocDescriptor $namespacesToc */
@@ -59,16 +57,14 @@ final class TableOfContentsBuilderTest extends TestCase
     public function testApiDocumentationSetPackagesAreAddedAsTOC(): void
     {
         $apiDocumentationSet = $this->faker()->apiSetDescriptor();
-        $project             = $this->faker()->projectDescriptor();
-        $project->getVersions()->add($this->faker()->versionDescriptor([$apiDocumentationSet]));
-        $project->getPackage()->addChild($this->faker()->namespaceDescriptorTree());
+        $apiDocumentationSet->getPackage()->addChild($this->faker()->namespaceDescriptorTree());
 
         $router = $this->prophesize(Router::class);
         $router->generate(Argument::any())->will(function ($args) {
             return (string) $args[0]->getFullyQualifiedStructuralElementName();
         });
         $pass = new TableOfContentsBuilder($router->reveal(), new NullLogger());
-        $pass->__invoke($project);
+        $pass->__invoke($apiDocumentationSet);
 
         self::assertCount(1, $apiDocumentationSet->getTableOfContents());
         /** @var TocDescriptor $namespacesToc */

--- a/tests/unit/phpDocumentor/Compiler/Pass/UsedByBuilderTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/UsedByBuilderTest.php
@@ -30,13 +30,10 @@ final class UsedByBuilderTest extends TestCase
         $class->getTags()->set('uses', Collection::fromClassString(UsesDescriptor::class, [$usesTag]));
 
         $apiSetDescriptor = $this->faker()->apiSetDescriptor();
-        $projectDescriptor = $this->faker()->projectDescriptor([
-            $this->faker()->versionDescriptor([$apiSetDescriptor]),
-        ]);
         $apiSetDescriptor->getIndex('elements')->add($class);
         $apiSetDescriptor->getIndex('elements')->add($counterClass);
 
-        $this->pass->__invoke($projectDescriptor);
+        $this->pass->__invoke($apiSetDescriptor);
 
         $usedBy = $counterClass->getTags()->fetch(
             'used-by',

--- a/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
@@ -83,6 +83,9 @@ final class ProjectDescriptorTest extends TestCase
      */
     public function testGetSetNamespace(): void
     {
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $this->fixture->getVersions()->add($this->faker()->versionDescriptor([$apiSetDescriptor]));
+
         $this->assertInstanceOf(NamespaceDescriptor::class, $this->fixture->getNamespace());
 
         $namespaceDescriptor = new NamespaceDescriptor();
@@ -97,6 +100,9 @@ final class ProjectDescriptorTest extends TestCase
      */
     public function testRootPackageIsSetForProject(): void
     {
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $this->fixture->getVersions()->add($this->faker()->versionDescriptor([$apiSetDescriptor]));
+
         $this->assertInstanceOf(PackageDescriptor::class, $this->fixture->getPackage());
         $this->assertSame('\\', (string) $this->fixture->getPackage()->getName());
         $this->assertSame('\\', (string) $this->fixture->getPackage()->getFullyQualifiedStructuralElementName());


### PR DESCRIPTION
Since the compilers work on files and indexes on a DocumentationSet, the entirety of them should really interact with a DocumentationSet and not a project