### PR TITLE
Bugfix/3494 ignore symlinks

### DIFF
--- a/docs/guides/running-phpdocumentor.rst
+++ b/docs/guides/running-phpdocumentor.rst
@@ -100,7 +100,7 @@ Influencing the List of Project Files
 **``--hidden`` and ``--ignore-symlinks``**
     By default phpDocumentor will ignore hidden files and will not follow symlinks. This will prevent unwanted
     documentables and loops in paths. Should you want to document hidden files you can do so by supplying the option
-    ``--hidden=off``, for traversing symlinks you can provide the option ``--ignore-symlinks=off``. Easy!
+    ``--hidden=off``, for traversing symlinks you can provide the option ``--no-ignore-symlinks``.
 
 Customizing the Look and Feel
 -----------------------------

--- a/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
+++ b/src/phpDocumentor/Configuration/CommandlineOptionsMiddleware.php
@@ -75,6 +75,7 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
             $version = $this->setFilesInPath($version);
             $version = $this->registerExtensions($version);
             $version = $this->overwriteIgnoredPaths($version);
+            $version = $this->overwriteIgnoredSymlinks($version);
             $version = $this->overwriteIgnoredTags($version);
             $version = $this->overwriteMarkers($version);
             $version = $this->overwriteIncludeSource($version);
@@ -417,6 +418,24 @@ final class CommandlineOptionsMiddleware implements MiddlewareInterface
         }
 
         $version->api[0]['encoding'] = $encoding;
+
+        return $version;
+    }
+
+    private function overwriteIgnoredSymlinks(VersionSpecification $version): VersionSpecification
+    {
+        if (isset($this->options['ignore-symlinks']) === false) {
+            return $version;
+        }
+
+        $version->api[0]->setIgnore(
+            array_merge(
+                $version->api[0]['ignore'],
+                [
+                    'symlinks' => $this->options['ignore-symlinks'],
+                ]
+            )
+        );
 
         return $version;
     }

--- a/src/phpDocumentor/Console/Command/Project/RunCommand.php
+++ b/src/phpDocumentor/Console/Command/Project/RunCommand.php
@@ -187,7 +187,7 @@ HELP
             ->addOption(
                 'ignore-symlinks',
                 null,
-                InputOption::VALUE_NONE,
+                InputOption::VALUE_NEGATABLE,
                 'Ignore symlinks to other files or directories, default is on'
             )
             ->addOption(


### PR DESCRIPTION
The setting `--ignore-symlinks` was not implemented correctly. I introduced the `--no-ignore-symlinks` to have the negative flag without the need for a value. This makes more sense in the way command line tools work in general. 

Fixes #3494 