### PR TITLE
Change writers to be performed on a per-documentation-set basis

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -101,7 +101,7 @@ jobs:
       run: phpunit --testsuite=unit
 
     - name: Quick check code coverage level
-      run: php tests/coverage-checker.php 65
+      run: php tests/coverage-checker.php 64
 
   codestyle:
     runs-on: ubuntu-latest

--- a/src/phpDocumentor/Descriptor/DocumentationSetDescriptor.php
+++ b/src/phpDocumentor/Descriptor/DocumentationSetDescriptor.php
@@ -16,10 +16,14 @@ namespace phpDocumentor\Descriptor;
 use phpDocumentor\Configuration\Source;
 use phpDocumentor\Descriptor\Interfaces\ElementInterface;
 use phpDocumentor\Descriptor\Interfaces\FileInterface;
+use phpDocumentor\Descriptor\Traits\HasDescription;
+use phpDocumentor\Descriptor\Traits\HasName;
 
-abstract class DocumentationSetDescriptor
+abstract class DocumentationSetDescriptor implements Descriptor
 {
-    protected string $name = '';
+    use HasName;
+    use HasDescription;
+
     protected Source $source;
     protected string $outputLocation = '.';
 
@@ -39,11 +43,6 @@ abstract class DocumentationSetDescriptor
 
         /** @phpstan-ignore-next-line */
         $this->indexes = Collection::fromClassString(Collection::class);
-    }
-
-    public function getName(): string
-    {
-        return $this->name;
     }
 
     public function addTableOfContents(TocDescriptor $descriptor): void

--- a/src/phpDocumentor/Descriptor/Query/Engine.php
+++ b/src/phpDocumentor/Descriptor/Query/Engine.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace phpDocumentor\Descriptor\Query;
 
 use phpDocumentor\Descriptor\Descriptor;
@@ -19,7 +28,9 @@ class Engine
         $this->parser = $parser;
     }
 
-    /** @return mixed */
+    /**
+     * @return mixed
+     */
     public function perform(Descriptor $descriptor, string $query)
     {
         return $this->executor->evaluate($this->parser->parse($query), $descriptor);

--- a/src/phpDocumentor/Pipeline/Stage/Transform.php
+++ b/src/phpDocumentor/Pipeline/Stage/Transform.php
@@ -2,11 +2,19 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace phpDocumentor\Pipeline\Stage;
 
 use Exception;
 use League\Flysystem\FilesystemInterface;
-use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Dsn;
 use phpDocumentor\Event\Dispatcher;
 use phpDocumentor\Parser\FlySystemFactory;
@@ -89,8 +97,8 @@ class Transform
         $transformations = $templates->getTransformations();
 
         foreach ($project->getVersions() as $version) {
-            $apiSets = $version->getDocumentationSets()->filter(ApiSetDescriptor::class);
-            foreach ($apiSets as $apiSet) {
+            $documentationSets = $version->getDocumentationSets();
+            foreach ($documentationSets as $documentationSet) {
                 /** @var PreTransformEvent $preTransformEvent */
                 $preTransformEvent = PreTransformEvent::createInstance($this);
                 $preTransformEvent->setProject($project);
@@ -102,7 +110,7 @@ class Transform
 
                 $this->transformer->execute(
                     $project,
-                    $apiSet,
+                    $documentationSet,
                     $transformations
                 );
 

--- a/src/phpDocumentor/Transformer/Transformer.php
+++ b/src/phpDocumentor/Transformer/Transformer.php
@@ -134,7 +134,7 @@ class Transformer
         array $transformations
     ): void {
         $this->initializeWriters($project, $documentationSet, $transformations);
-        $this->transformProject($project, $transformations);
+        $this->transform($project, $documentationSet, $transformations);
 
         $this->logger->log(LogLevel::NOTICE, 'Finished transformation process');
     }
@@ -202,11 +202,14 @@ class Transformer
      *
      * @param Transformation[] $transformations
      */
-    private function transformProject(ProjectDescriptor $project, array $transformations): void
-    {
+    private function transform(
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
+        array $transformations
+    ): void {
         foreach ($transformations as $transformation) {
             $transformation->setTransformer($this);
-            $this->applyTransformationToProject($transformation, $project);
+            $this->applyTransformation($transformation, $project, $documentationSet);
         }
     }
 
@@ -223,8 +226,11 @@ class Transformer
      *
      * @uses Dispatcher to emit the events surrounding a transformation.
      */
-    private function applyTransformationToProject(Transformation $transformation, ProjectDescriptor $project): void
-    {
+    private function applyTransformation(
+        Transformation $transformation,
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet
+    ): void {
         $this->logger->log(
             LogLevel::NOTICE,
             sprintf(
@@ -239,7 +245,7 @@ class Transformer
         $this->eventDispatcher->dispatch($preTransformationEvent, self::EVENT_PRE_TRANSFORMATION);
 
         $writer = $this->writers->get($transformation->getWriter());
-        $writer->transform($project, $transformation);
+        $writer->transform($transformation, $project, $documentationSet);
 
         $postTransformationEvent = PostTransformationEvent::createInstance($this);
         $this->eventDispatcher->dispatch($postTransformationEvent, self::EVENT_POST_TRANSFORMATION);

--- a/src/phpDocumentor/Transformer/Writer/FileIo.php
+++ b/src/phpDocumentor/Transformer/Writer/FileIo.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Transformer\Writer;
 use InvalidArgumentException;
 use League\Flysystem\FileExistsException;
 use League\Flysystem\FileNotFoundException;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Transformer\Transformation;
 
@@ -41,15 +42,18 @@ class FileIo extends WriterAbstract
     /**
      * Invokes the query method contained in this class.
      *
-     * @param ProjectDescriptor $project Document containing the structure.
      * @param Transformation $transformation Transformation to execute.
+     * @param ProjectDescriptor $project Document containing the structure.
      *
      * @throws InvalidArgumentException If the query is not supported.
      * @throws FileNotFoundException If the source file does not exist or could not be read.
      * @throws FileExistsException
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation): void
-    {
+    public function transform(
+        Transformation $transformation,
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet
+    ): void {
         $method = $transformation->getQuery();
         if (strtolower($method) !== '$.copy') {
             throw new InvalidArgumentException(

--- a/src/phpDocumentor/Transformer/Writer/Graph.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Transformer\Transformation;
@@ -33,11 +34,8 @@ use const DIRECTORY_SEPARATOR;
  */
 final class Graph extends WriterAbstract implements ProjectDescriptor\WithCustomSettings
 {
-    /** @var GraphVizClassDiagram */
-    private $classDiagramGenerator;
-
-    /** @var PlantumlClassDiagram */
-    private $plantumlClassDiagram;
+    private GraphVizClassDiagram $classDiagramGenerator;
+    private PlantumlClassDiagram $plantumlClassDiagram;
 
     public function __construct(GraphVizClassDiagram $classDiagramGenerator, PlantumlClassDiagram $plantumlClassDiagram)
     {
@@ -70,6 +68,10 @@ final class Graph extends WriterAbstract implements ProjectDescriptor\WithCustom
         DocumentationSetDescriptor $documentationSet
     ): void {
         if ($project->getSettings()->getCustom()['graphs.enabled'] === false) {
+            return;
+        }
+
+        if ($documentationSet instanceof ApiSetDescriptor === false) {
             return;
         }
 

--- a/src/phpDocumentor/Transformer/Writer/Graph.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph.php
@@ -80,8 +80,8 @@ final class Graph extends WriterAbstract implements ProjectDescriptor\WithCustom
         switch ($transformation->getSource() ?: 'class') {
             case 'class':
             default:
-                $this->classDiagramGenerator->create($project, $filename);
-                $this->plantumlClassDiagram->create($project, $filename);
+                $this->classDiagramGenerator->create($documentationSet, $filename);
+                $this->plantumlClassDiagram->create($documentationSet, $filename);
         }
     }
 

--- a/src/phpDocumentor/Transformer/Writer/Graph.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer;
 
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Transformer\Transformation;
 use phpDocumentor\Transformer\Writer\Graph\GraphVizClassDiagram;
@@ -60,11 +61,14 @@ final class Graph extends WriterAbstract implements ProjectDescriptor\WithCustom
     /**
      * Generates a UML class diagram using PlantUML or our native GraphViz integration.
      *
-     * @param ProjectDescriptor $project Document containing the structure.
      * @param Transformation $transformation Transformation to execute.
+     * @param ProjectDescriptor $project Document containing the structure.
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation): void
-    {
+    public function transform(
+        Transformation $transformation,
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet
+    ): void {
         if ($project->getSettings()->getCustom()['graphs.enabled'] === false) {
             return;
         }

--- a/src/phpDocumentor/Transformer/Writer/Graph/Generator.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph/Generator.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer\Graph;
 
-use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 
 interface Generator
 {
-    public function create(ProjectDescriptor $project, string $filename): void;
+    public function create(DocumentationSetDescriptor $documentationSet, string $filename): void;
 }

--- a/src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
@@ -20,7 +20,6 @@ use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\Interfaces\NamespaceInterface;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\GraphViz\Edge;
 use phpDocumentor\GraphViz\Graph as GraphVizGraph;

--- a/src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer\Graph;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\DescriptorAbstract;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\Interfaces\NamespaceInterface;
 use phpDocumentor\Descriptor\ProjectDescriptor;
@@ -34,16 +36,20 @@ use function explode;
 final class GraphVizClassDiagram implements Generator
 {
     /** @var array<string, ?Node> a cache where nodes for classes, interfaces and traits are stored for reference */
-    private $nodeCache = [];
+    private array $nodeCache = [];
 
     /** @var GraphVizGraph[] */
-    private $namespaceCache = [];
+    private array $namespaceCache = [];
 
     /**
      * Creates a class inheritance diagram.
      */
-    public function create(ProjectDescriptor $project, string $filename): void
+    public function create(DocumentationSetDescriptor $documentationSet, string $filename): void
     {
+        if ($documentationSet instanceof ApiSetDescriptor === false) {
+            return;
+        }
+
         try {
             $this->checkIfGraphVizIsInstalled();
         } catch (Throwable $e) {
@@ -60,11 +66,11 @@ final class GraphVizClassDiagram implements Generator
             ->setSplines('true')
             ->setConcentrate('true');
 
-        $this->buildNamespaceTree($graph, $project->getNamespace());
+        $this->buildNamespaceTree($graph, $documentationSet->getNamespace());
 
-        $classes = $project->getIndexes()->fetch('classes', new Collection())->getAll();
-        $interfaces = $project->getIndexes()->fetch('interfaces', new Collection())->getAll();
-        $traits = $project->getIndexes()->fetch('traits', new Collection())->getAll();
+        $classes = $documentationSet->getIndexes()->fetch('classes', new Collection())->getAll();
+        $interfaces = $documentationSet->getIndexes()->fetch('interfaces', new Collection())->getAll();
+        $traits = $documentationSet->getIndexes()->fetch('traits', new Collection())->getAll();
 
         /** @var ClassDescriptor[]|InterfaceDescriptor[]|TraitDescriptor[] $containers */
         $containers = array_merge($classes, $interfaces, $traits);

--- a/src/phpDocumentor/Transformer/Writer/Graph/PlantumlClassDiagram.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph/PlantumlClassDiagram.php
@@ -13,10 +13,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer\Graph;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\Interfaces\NamespaceInterface;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use Psr\Log\LoggerInterface;
 
@@ -28,11 +29,8 @@ use const PHP_EOL;
 
 final class PlantumlClassDiagram implements Generator
 {
-    /** @var LoggerInterface */
-    private $logger;
-
-    /** @var PlantumlRenderer */
-    private $plantumlRenderer;
+    private LoggerInterface $logger;
+    private PlantumlRenderer $plantumlRenderer;
 
     public function __construct(LoggerInterface $logger, PlantumlRenderer $plantumlRenderer)
     {
@@ -40,8 +38,12 @@ final class PlantumlClassDiagram implements Generator
         $this->plantumlRenderer = $plantumlRenderer;
     }
 
-    public function create(ProjectDescriptor $project, string $filename): void
+    public function create(DocumentationSetDescriptor $documentationSet, string $filename): void
     {
+        if ($documentationSet instanceof ApiSetDescriptor === false) {
+            return;
+        }
+
         $output = $this->plantumlRenderer->render(
             <<<PUML
 skinparam shadowing false
@@ -50,7 +52,7 @@ hide empty members
 left to right direction
 set namespaceSeparator \\\\
 
-{$this->renderNamespace($project->getNamespace())}
+{$this->renderNamespace($documentationSet->getNamespace())}
 PUML
         );
 

--- a/src/phpDocumentor/Transformer/Writer/RenderGuide.php
+++ b/src/phpDocumentor/Transformer/Writer/RenderGuide.php
@@ -70,7 +70,7 @@ final class RenderGuide extends WriterAbstract implements ProjectDescriptor\With
             return;
         }
 
-        if (!$documentationSet instanceof GuideSetDescriptor) {
+        if ($documentationSet instanceof GuideSetDescriptor === false) {
             return;
         }
 

--- a/src/phpDocumentor/Transformer/Writer/Sourcecode.php
+++ b/src/phpDocumentor/Transformer/Writer/Sourcecode.php
@@ -58,7 +58,7 @@ class Sourcecode extends WriterAbstract
         }
 
         /** @var FileDescriptor $file */
-        foreach ($project->getFiles() as $file) {
+        foreach ($documentationSet->getFiles() as $file) {
             $source = $file->getSource();
             if ($source === null) {
                 continue;

--- a/src/phpDocumentor/Transformer/Writer/Sourcecode.php
+++ b/src/phpDocumentor/Transformer/Writer/Sourcecode.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer\Writer;
 
 use phpDocumentor\Descriptor\ApiSetDescriptor;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Transformer\Transformation;
@@ -41,31 +42,30 @@ class Sourcecode extends WriterAbstract
     /**
      * This method writes every source code entry in the structure file to a highlighted file.
      *
-     * @param ProjectDescriptor $project        Document containing the structure.
      * @param Transformation    $transformation Transformation to execute.
+     * @param ProjectDescriptor $project        Document containing the structure.
      */
-    public function transform(ProjectDescriptor $project, Transformation $transformation): void
-    {
-        foreach ($project->getVersions() as $version) {
-            foreach ($version->getDocumentationSets() as $documentationSet) {
-                if (
-                    $documentationSet instanceof ApiSetDescriptor &&
-                    $documentationSet->getSettings()['include-source'] === false
-                ) {
-                    return;
-                }
+    public function transform(
+        Transformation $transformation,
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet
+    ): void {
+        if (
+            $documentationSet instanceof ApiSetDescriptor === false ||
+            $documentationSet->getSettings()['include-source'] === false
+        ) {
+            return;
+        }
 
-                /** @var FileDescriptor $file */
-                foreach ($project->getFiles() as $file) {
-                    $source = $file->getSource();
-                    if ($source === null) {
-                        continue;
-                    }
-
-                    $path = $this->pathGenerator->generate($file, $transformation);
-                    $this->persistTo($transformation, $path, $source);
-                }
+        /** @var FileDescriptor $file */
+        foreach ($project->getFiles() as $file) {
+            $source = $file->getSource();
+            if ($source === null) {
+                continue;
             }
+
+            $path = $this->pathGenerator->generate($file, $transformation);
+            $this->persistTo($transformation, $path, $source);
         }
     }
 }

--- a/src/phpDocumentor/Transformer/Writer/Twig.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig.php
@@ -140,6 +140,13 @@ final class Twig extends WriterAbstract implements Initializable, ProjectDescrip
         ProjectDescriptor $project,
         DocumentationSetDescriptor $documentationSet
     ): void {
+        // TODO: At a later stage we want to support more types of Documentation Sets using the Twig writer
+        //       but at the moment this causes headaches in the migration process towards multiple sets of
+        //       documentation. As such, this limitation has been added
+        if ($documentationSet instanceof ApiSetDescriptor === false) {
+            return;
+        }
+
         $templatePath = substr($transformation->getSource(), strlen($this->getTemplatePath($transformation)));
 
         $nodes = [$documentationSet];

--- a/src/phpDocumentor/Transformer/Writer/WriterAbstract.php
+++ b/src/phpDocumentor/Transformer/Writer/WriterAbstract.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer;
 
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Transformer\Transformation;
 
@@ -47,10 +48,14 @@ abstract class WriterAbstract
     /**
      * Abstract definition of the transformation method.
      *
-     * @param ProjectDescriptor $project Document containing the structure.
      * @param Transformation $transformation Transformation to execute.
+     * @param ProjectDescriptor $project Document containing the structure.
      */
-    abstract public function transform(ProjectDescriptor $project, Transformation $transformation): void;
+    abstract public function transform(
+        Transformation $transformation,
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet
+    ): void;
 
     public function __toString(): string
     {

--- a/tests/functional/phpDocumentor/FunctionalTestCase.php
+++ b/tests/functional/phpDocumentor/FunctionalTestCase.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace phpDocumentor;
 
 use FilesystemIterator;

--- a/tests/functional/phpDocumentor/core/FileLevelFunctionalTest.php
+++ b/tests/functional/phpDocumentor/core/FileLevelFunctionalTest.php
@@ -2,8 +2,18 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace functional\phpDocumentor\core;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\FunctionalTestCase;
 use phpDocumentor\Descriptor\FileDescriptor;
 
@@ -17,8 +27,17 @@ final class FileLevelFunctionalTest extends FunctionalTestCase
         $this->runPHPDocWithFile($file);
         $project = $this->loadAst();
 
-        $this->assertCount(1, $project->getFiles());
-        $this->assertFileSummary('This file is part of phpDocumentor.',  $project->getFiles()['test.php']);
+        $versions = $project->getVersions();
+        $this->assertCount(1, $versions);
+
+        $apiSets = $versions->first()->getDocumentationSets()->filter(ApiSetDescriptor::class);
+        $this->assertCount(1, $apiSets);
+
+        /** @var ApiSetDescriptor $apiSet */
+        $apiSet = $apiSets->first();
+        $this->assertCount(1, $apiSet->getFiles());
+
+        $this->assertFileSummary('This file is part of phpDocumentor.',  $apiSet->getFiles()['test.php']);
     }
 
     public function emptishFileProvider() : array

--- a/tests/functional/phpDocumentor/core/RootElementsFunctionalTest.php
+++ b/tests/functional/phpDocumentor/core/RootElementsFunctionalTest.php
@@ -2,8 +2,18 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace functional\phpDocumentor\core;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\FunctionalTestCase;
 
@@ -14,15 +24,22 @@ final class RootElementsFunctionalTest extends FunctionalTestCase
         $this->runPHPDocWithFile(__DIR__ . '/../../assets/core/rootElements/trait.php');
         $project = $this->loadAst();
 
-        $traitDescriptor = $project->getIndexes()->get('traits')->get('\App\Traits\Test');
+        $versions = $project->getVersions();
+        $this->assertCount(1, $versions);
+
+        $apiSets = $versions->first()->getDocumentationSets()->filter(ApiSetDescriptor::class);
+        $this->assertCount(1, $apiSets);
+
+        /** @var ApiSetDescriptor $apiSet */
+        $apiSet = $apiSets->first();
+
+        $traitDescriptor = $apiSet->getIndexes()->get('traits')->get('\App\Traits\Test');
         self::assertInstanceOf(TraitDescriptor::class, $traitDescriptor);
 
-        $fileDescriptor = $project->getFiles()->get('test.php');
+        $fileDescriptor = $apiSet->getFiles()->get('test.php');
         self::assertInstanceOf(TraitDescriptor::class, $fileDescriptor->getTraits()->get('\App\Traits\Test'));
 
-        ///dd($project->getNamespace()->getChildren()->getAll());
-
-        $namespaceDescriptor = $project->getNamespace()->getChildren()->get('App')->getChildren()->get('Traits');
+        $namespaceDescriptor = $apiSet->getNamespace()->getChildren()->get('App')->getChildren()->get('Traits');
         self::assertInstanceOf(TraitDescriptor::class, $namespaceDescriptor->getTraits()->get('\App\Traits\Test'));
     }
 }

--- a/tests/functional/phpDocumentor/core/VisibilityFilterFunctionalTest.php
+++ b/tests/functional/phpDocumentor/core/VisibilityFilterFunctionalTest.php
@@ -4,18 +4,28 @@ declare(strict_types=1);
 
 namespace functional\phpDocumentor\core;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\FunctionalTestCase;
 
-final class VisiblityFilterFuncionalTest extends FunctionalTestCase
+final class VisibilityFilterFunctionalTest extends FunctionalTestCase
 {
-    public function testDefaultVisiblityFilter() : void
+    public function testDefaultVisibilityFilter() : void
     {
         $this->runPHPDocWithFile(__DIR__ .'/../../assets/core/visibility.php');
         $project = $this->loadAst();
 
+        $versions = $project->getVersions();
+        $this->assertCount(1, $versions);
+
+        $apiSets = $versions->first()->getDocumentationSets()->filter(ApiSetDescriptor::class);
+        $this->assertCount(1, $apiSets);
+
+        /** @var ApiSetDescriptor $apiSet */
+        $apiSet = $apiSets->first();
+
         /** @var ClassDescriptor $classDescriptor */
-        $classDescriptor = $project->getIndexes()->get('classes')->get('\Visibility');
+        $classDescriptor = $apiSet->getIndexes()->get('classes')->get('\Visibility');
 
         $this->assertCount(3, $classDescriptor->getMethods());
         $this->assertCount(3, $classDescriptor->getProperties());
@@ -25,13 +35,22 @@ final class VisiblityFilterFuncionalTest extends FunctionalTestCase
     /**
      * @dataProvider visibilityProvider
      */
-    public function testVisiblityFilterByCli(string $visability, int $expectedCount) : void
+    public function testVisibilityFilterByCli(string $visability, int $expectedCount) : void
     {
         $this->runPHPDocWithFile(__DIR__ .'/../../assets/core/visibility.php', ['--visibility='.$visability]);
         $project = $this->loadAst();
 
+        $versions = $project->getVersions();
+        $this->assertCount(1, $versions);
+
+        $apiSets = $versions->first()->getDocumentationSets()->filter(ApiSetDescriptor::class);
+        $this->assertCount(1, $apiSets);
+
+        /** @var ApiSetDescriptor $apiSet */
+        $apiSet = $apiSets->first();
+
         /** @var ClassDescriptor $classDescriptor */
-        $classDescriptor = $project->getIndexes()->get('classes')->get('\Visibility');
+        $classDescriptor = $apiSet->getIndexes()->get('classes')->get('\Visibility');
 
         $this->assertCount($expectedCount, $classDescriptor->getMethods());
         $this->assertCount($expectedCount, $classDescriptor->getProperties());

--- a/tests/functional/phpDocumentor/issues/Issue2425FunctionalTest.php
+++ b/tests/functional/phpDocumentor/issues/Issue2425FunctionalTest.php
@@ -2,12 +2,19 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace functional\phpDocumentor\issues;
 
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
-use phpDocumentor\Descriptor\ConstantDescriptor;
-use phpDocumentor\Descriptor\MethodDescriptor;
-use phpDocumentor\Descriptor\PropertyDescriptor;
 use phpDocumentor\FunctionalTestCase;
 
 final class Issue2425FunctionalTest extends FunctionalTestCase
@@ -17,8 +24,17 @@ final class Issue2425FunctionalTest extends FunctionalTestCase
         $this->runPHPDocWithFile(__DIR__ . '/../../assets/core/issues/issue-2425/issue-2425.php');
         $project = $this->loadAst();
 
+        $versions = $project->getVersions();
+        $this->assertCount(1, $versions);
+
+        $apiSets = $versions->first()->getDocumentationSets()->filter(ApiSetDescriptor::class);
+        $this->assertCount(1, $apiSets);
+
+        /** @var ApiSetDescriptor $apiSet */
+        $apiSet = $apiSets->first();
+
         /** @var ClassDescriptor $classDescriptor */
-        $classDescriptor = $project->getIndexes()->get('classes')->get('\Project\Sub\Level\Issue2425A');
+        $classDescriptor = $apiSet->getIndexes()->get('classes')->get('\Project\Sub\Level\Issue2425A');
 
         self::assertSame(
             <<<DESCRIPTION

--- a/tests/integration/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
+++ b/tests/integration/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer\Writer\Twig;
 
 use Generator;
+use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\ProjectDescriptor;
@@ -50,17 +51,18 @@ final class LinkRendererTest extends TestCase
     private ObjectProphecy $router;
 
     private LinkRenderer $renderer;
-    private ProjectDescriptor $projectDescriptor;
+    private ApiSetDescriptor $apiSetDescriptor;
 
     protected function setUp(): void
     {
         $this->router = $this->prophesize(Router::class);
-        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
-        $this->projectDescriptor = $this->faker()->projectDescriptor([
-            $this->faker()->versionDescriptor([$apiSetDescriptor]),
+        $this->apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $projectDescriptor = $this->faker()->projectDescriptor([
+            $this->faker()->versionDescriptor([$this->apiSetDescriptor]),
         ]);
         $this->renderer = (new LinkRenderer($this->router->reveal(), new HtmlFormatter()))
-            ->withProject($this->projectDescriptor)->forDocumentationSet($apiSetDescriptor);
+            ->withProject($projectDescriptor)
+            ->forDocumentationSet($this->apiSetDescriptor);
     }
 
     /**
@@ -71,7 +73,7 @@ final class LinkRendererTest extends TestCase
     public function testRenderLinkFromDescriptor($input, string $presentation, string $output): void
     {
         $classDescriptor = $this->createClassDescriptor(new Fqsen('\My\Namespace\Class'));
-        $this->projectDescriptor->getIndexes()->get('elements')
+        $this->apiSetDescriptor->getIndexes()->get('elements')
             ->set((string) $classDescriptor->getFullyQualifiedStructuralElementName(), $classDescriptor);
 
         $this->router->generate($classDescriptor)->willReturn('/classes/My.Namespace.Class.html');
@@ -147,7 +149,7 @@ final class LinkRendererTest extends TestCase
         $fqsen = new Fqsen('\My\Namespace\Class');
         $descriptor = new ClassDescriptor();
         $descriptor->setFullyQualifiedStructuralElementName($fqsen);
-        $this->projectDescriptor->getIndexes()->get('elements')->set('\My\Namespace\Class', $descriptor);
+        $this->apiSetDescriptor->getIndexes()->get('elements')->set('\My\Namespace\Class', $descriptor);
 
         $this->router->generate(Argument::any())->willReturn('/classes/My.Namespace.Class.html');
 
@@ -162,7 +164,7 @@ final class LinkRendererTest extends TestCase
         $fqsen = new Fqsen('\My\Namespace\Class');
         $descriptor = new ClassDescriptor();
         $descriptor->setFullyQualifiedStructuralElementName($fqsen);
-        $this->projectDescriptor->getIndexes()->get('elements')->set('\My\Namespace\Class', $descriptor);
+        $this->apiSetDescriptor->getIndexes()->get('elements')->set('\My\Namespace\Class', $descriptor);
 
         $this->router->generate(Argument::any())->willReturn('/classes/My.Namespace.Class.html');
 
@@ -187,7 +189,7 @@ final class LinkRendererTest extends TestCase
         $fqsen = new Fqsen('\My\Namespace\Class');
         $descriptor = new ClassDescriptor();
         $descriptor->setFullyQualifiedStructuralElementName($fqsen);
-        $this->projectDescriptor->getIndexes()->get('elements')->set('\My\Namespace\Class', $descriptor);
+        $this->apiSetDescriptor->getIndexes()->get('elements')->set('\My\Namespace\Class', $descriptor);
 
         $this->router->generate(Argument::any())->shouldBeCalled()->willReturn('/classes/My.Namespace.Class.html');
 
@@ -205,7 +207,7 @@ final class LinkRendererTest extends TestCase
     public function testRenderType(Type $input, string $presentation, string $output): void
     {
         $classDescriptor = $this->createClassDescriptor(new Fqsen('\My\Namespace\Class'));
-        $this->projectDescriptor->getIndexes()->get('elements')
+        $this->apiSetDescriptor->getIndexes()->get('elements')
             ->set((string) $classDescriptor->getFullyQualifiedStructuralElementName(), $classDescriptor);
 
         $this->router->generate($classDescriptor)->willReturn('/classes/My.Namespace.Class.html');

--- a/tests/unit/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractorTest.php
+++ b/tests/unit/phpDocumentor/Compiler/Pass/MarkerFromTagsExtractorTest.php
@@ -27,7 +27,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \phpDocumentor\Compiler\Pass\MarkerFromTagsExtractor
- * @covers ::__construct
  * @covers ::<private>
  */
 final class MarkerFromTagsExtractorTest extends TestCase

--- a/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorTest.php
@@ -55,29 +55,6 @@ final class ProjectDescriptorTest extends TestCase
     }
 
     /**
-     * @covers ::getFiles
-     */
-    public function testGetFilesFromApiSet(): void
-    {
-        $set = $this->faker()->apiSetDescriptor();
-        $version = $this->faker()->versionDescriptor([$set]);
-        $this->fixture->getVersions()->add($version);
-
-        $this->assertSame($set->getFiles(), $this->fixture->getFiles());
-    }
-
-    /**
-     * @covers ::getIndexes
-     */
-    public function testGetIndexesFromApiSet(): void
-    {
-        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
-        $this->fixture->getVersions()->add($this->faker()->versionDescriptor([$apiSetDescriptor]));
-
-        $this->assertSame($apiSetDescriptor->getIndexes(), $this->fixture->getIndexes());
-    }
-
-    /**
      * @covers ::setNamespace
      * @covers ::getNamespace
      */

--- a/tests/unit/phpDocumentor/Descriptor/ValueObjects/IsApplicableTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ValueObjects/IsApplicableTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass IsApplicable
- * @covers ::__construct
  * @covers ::<private>
  */
 final class IsApplicableTest extends TestCase

--- a/tests/unit/phpDocumentor/Transformer/TransformerTest.php
+++ b/tests/unit/phpDocumentor/Transformer/TransformerTest.php
@@ -112,14 +112,14 @@ final class TransformerTest extends TestCase
         $apiSet = $this->faker()->apiSetDescriptor();
         $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSet])]);
 
-        $this->writer->transform(Argument::any(), Argument::any())->shouldBeCalled();
-
         $transformation = $this->prophesize(Transformation::class);
         $transformation->getQuery()->shouldBeCalled()->willReturn('');
         $transformation->template()->willReturn($this->faker()->template());
         $transformation->getWriter()->shouldBeCalled()->willReturn($this->writer);
         $transformation->getArtifact()->shouldBeCalled()->willReturn('');
         $transformation->setTransformer(Argument::exact($this->fixture))->shouldBeCalled();
+
+        $this->writer->transform($transformation, $project, $apiSet)->shouldBeCalled();
 
         $this->fixture->execute($project, $apiSet, [$transformation->reveal()]);
     }

--- a/tests/unit/phpDocumentor/Transformer/Writer/FileIoTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/FileIoTest.php
@@ -21,7 +21,6 @@ use League\Flysystem\MountManager;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Faker\Faker;
 use phpDocumentor\Transformer\Template;
 use phpDocumentor\Transformer\Transformation;
@@ -30,22 +29,17 @@ use PHPUnit\Framework\TestCase;
 /**
  * @coversDefaultClass \phpDocumentor\Transformer\Writer\FileIo
  * @covers \phpDocumentor\Transformer\Writer\IoTrait
+ * @covers ::<private>
+ * @covers ::__construct
  */
 final class FileIoTest extends TestCase
 {
     use Faker;
 
-    /** @var vfsStreamDirectory */
-    private $templatesFolder;
-
-    /** @var vfsStreamDirectory */
-    private $sourceFolder;
-
-    /** @var vfsStreamDirectory */
-    private $destinationFolder;
-
-    /** @var Template */
-    private $template;
+    private vfsStreamDirectory $templatesFolder;
+    private vfsStreamDirectory $sourceFolder;
+    private vfsStreamDirectory $destinationFolder;
+    private Template $template;
 
     protected function setUp(): void
     {
@@ -76,10 +70,20 @@ final class FileIoTest extends TestCase
 
         $writer = new FileIo();
 
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSet])]);
+
         $this->assertFalse($this->destinationFolder->hasChild('index.html'));
         $writer->transform(
-            new ProjectDescriptor('project'),
-            new Transformation($this->template, 'copy', 'fileio', 'index.html.twig', 'index.html')
+            new Transformation(
+                $this->template,
+                'copy',
+                'fileio',
+                'index.html.twig',
+                'index.html'
+            ),
+            $project,
+            $apiSet
         );
         $this->assertTrue($this->destinationFolder->hasChild('index.html'));
     }
@@ -93,16 +97,20 @@ final class FileIoTest extends TestCase
 
         $writer = new FileIo();
 
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSet])]);
+
         $this->assertFalse($this->destinationFolder->hasChild('images/destination.png'));
         $writer->transform(
-            new ProjectDescriptor('project'),
             new Transformation(
                 $this->template,
                 'copy',
                 'fileio',
                 'templates/templateName/images/image.png',
                 'images/destination.png'
-            )
+            ),
+            $project,
+            $apiSet
         );
         $this->assertTrue($this->destinationFolder->hasChild('images/destination.png'));
     }
@@ -112,14 +120,23 @@ final class FileIoTest extends TestCase
      */
     public function testCopiedFileOverwritesExistingFile(): void
     {
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSet])]);
         $this->sourceFolder->addChild(vfsStream::newFile('index.html.twig')->withContent('new content'));
         $this->destinationFolder->addChild(vfsStream::newFile('index.html')->withContent('original content'));
 
         $writer = new FileIo();
 
         $writer->transform(
-            new ProjectDescriptor('project'),
-            new Transformation($this->template, 'copy', 'fileio', 'index.html.twig', 'index.html')
+            new Transformation(
+                $this->template,
+                'copy',
+                'fileio',
+                'index.html.twig',
+                'index.html'
+            ),
+            $project,
+            $apiSet
         );
         $this->assertTrue($this->destinationFolder->hasChild('index.html'));
         $this->assertStringEqualsFile($this->destinationFolder->getChild('index.html')->url(), 'new content');
@@ -130,6 +147,8 @@ final class FileIoTest extends TestCase
      */
     public function testCopiesDirectoryFromCustomTemplateToDestination(): void
     {
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSet])]);
         $sourceDirectory = new vfsStreamDirectory('images');
         $sourceDirectory->addChild(new vfsStreamFile('image1.png'));
         $this->sourceFolder->addChild($sourceDirectory);
@@ -138,8 +157,15 @@ final class FileIoTest extends TestCase
 
         $this->assertFalse($this->destinationFolder->hasChild('images'));
         $writer->transform(
-            new ProjectDescriptor('project'),
-            new Transformation($this->template, 'copy', 'fileio', 'images', 'images')
+            new Transformation(
+                $this->template,
+                'copy',
+                'fileio',
+                'images',
+                'images'
+            ),
+            $project,
+            $apiSet
         );
         $this->assertTrue($this->destinationFolder->hasChild('images'));
         $this->assertTrue($this->destinationFolder->hasChild('images/image1.png'));
@@ -150,6 +176,8 @@ final class FileIoTest extends TestCase
      */
     public function testCopiesDirectoryFromGlobalTemplateToDestination(): void
     {
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSet])]);
         $sourceDirectory = new vfsStreamDirectory('images');
         $sourceDirectory->addChild(new vfsStreamFile('image1.png'));
         $templateDirectory = new vfsStreamDirectory('templateName');
@@ -160,8 +188,15 @@ final class FileIoTest extends TestCase
 
         $this->assertFalse($this->destinationFolder->hasChild('images'));
         $writer->transform(
-            new ProjectDescriptor('project'),
-            new Transformation($this->template, 'copy', 'fileio', 'templates/templateName/images', 'images')
+            new Transformation(
+                $this->template,
+                'copy',
+                'fileio',
+                'templates/templateName/images',
+                'images'
+            ),
+            $project,
+            $apiSet
         );
         $this->assertTrue($this->destinationFolder->hasChild('images'));
         $this->assertTrue($this->destinationFolder->hasChild('images/image1.png'));
@@ -172,6 +207,8 @@ final class FileIoTest extends TestCase
      */
     public function testCopiesDirectoryRecursivelyFromCustomTemplateToDestination(): void
     {
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSet])]);
         $subfolder = new vfsStreamDirectory('subfolder');
         $subfolder->addChild(new vfsStreamFile('image2.png'));
         $sourceDirectory = new vfsStreamDirectory('images');
@@ -182,8 +219,15 @@ final class FileIoTest extends TestCase
 
         $this->assertFalse($this->destinationFolder->hasChild('images'));
         $writer->transform(
-            new ProjectDescriptor('project'),
-            new Transformation($this->template, 'copy', 'fileio', 'images', 'images')
+            new Transformation(
+                $this->template,
+                'copy',
+                'fileio',
+                'images',
+                'images'
+            ),
+            $project,
+            $apiSet
         );
         $this->assertTrue($this->destinationFolder->hasChild('images'));
         $this->assertTrue($this->destinationFolder->hasChild('images/subfolder/image2.png'));
@@ -194,6 +238,8 @@ final class FileIoTest extends TestCase
      */
     public function testCopiesDirectoryRecursivelyFromGlobalTemplateToDestination(): void
     {
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSet])]);
         $subfolder = new vfsStreamDirectory('subfolder');
         $subfolder->addChild(new vfsStreamFile('image2.png'));
         $sourceDirectory = new vfsStreamDirectory('images');
@@ -206,8 +252,15 @@ final class FileIoTest extends TestCase
 
         $this->assertFalse($this->destinationFolder->hasChild('images'));
         $writer->transform(
-            new ProjectDescriptor('project'),
-            new Transformation($this->template, 'copy', 'fileio', 'templates/templateName/images', 'images')
+            new Transformation(
+                $this->template,
+                'copy',
+                'fileio',
+                'templates/templateName/images',
+                'images'
+            ),
+            $project,
+            $apiSet
         );
         $this->assertTrue($this->destinationFolder->hasChild('images'));
         $this->assertTrue($this->destinationFolder->hasChild('images/subfolder/image2.png'));
@@ -221,10 +274,19 @@ final class FileIoTest extends TestCase
         $this->expectException(FileNotFoundException::class);
         $writer = new FileIo();
 
-        $writer->transform(
-            new ProjectDescriptor('project'),
-            new Transformation($this->template, 'copy', 'fileio', 'unknown_file', 'nah.png')
+        $transformation = new Transformation(
+            $this->template,
+            'copy',
+            'fileio',
+            'unknown_file',
+            'nah.png'
         );
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $projectDescriptor = $this->faker()->projectDescriptor(
+            [$this->faker()->versionDescriptor([$apiSetDescriptor])]
+        );
+
+        $writer->transform($transformation, $projectDescriptor, $apiSetDescriptor);
     }
 
     /**
@@ -235,9 +297,18 @@ final class FileIoTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $writer = new FileIo();
 
-        $writer->transform(
-            new ProjectDescriptor('project'),
-            new Transformation($this->template, 'not-a-copy', 'fileio', 'unknown_file', 'nah.png')
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $projectDescriptor = $this->faker()->projectDescriptor(
+            [$this->faker()->versionDescriptor([$apiSetDescriptor])]
         );
+        $transformation = new Transformation(
+            $this->template,
+            'not-a-copy',
+            'fileio',
+            'unknown_file',
+            'nah.png'
+        );
+
+        $writer->transform($transformation, $projectDescriptor, $apiSetDescriptor);
     }
 }

--- a/tests/unit/phpDocumentor/Transformer/Writer/FileIoTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/FileIoTest.php
@@ -30,7 +30,6 @@ use PHPUnit\Framework\TestCase;
  * @coversDefaultClass \phpDocumentor\Transformer\Writer\FileIo
  * @covers \phpDocumentor\Transformer\Writer\IoTrait
  * @covers ::<private>
- * @covers ::__construct
  */
 final class FileIoTest extends TestCase
 {

--- a/tests/unit/phpDocumentor/Transformer/Writer/PathGeneratorTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/PathGeneratorTest.php
@@ -26,7 +26,6 @@ use Prophecy\Prophecy\ObjectProphecy;
 use RuntimeException;
 
 /**
- * @uses \phpDocumentor\Transformer\Writer\Pathfinder
  * @uses \phpDocumentor\Transformer\Template
  *
  * @coversDefaultClass \phpDocumentor\Transformer\Writer\PathGenerator

--- a/tests/unit/phpDocumentor/Transformer/Writer/SourcecodeTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/SourcecodeTest.php
@@ -57,9 +57,10 @@ final class SourcecodeTest extends MockeryTestCase
         $transformation = $this->prophesize(Transformation::class);
         $transformation->template()->shouldNotBeCalled();
 
-        $projectDescriptor = $this->giveProjectDescriptor($this->faker()->apiSetDescriptor());
+        $apiSet = $this->faker()->apiSetDescriptor();
+        $projectDescriptor = $this->giveProjectDescriptor($apiSet);
 
-        $this->sourceCode->transform($projectDescriptor, $transformation->reveal());
+        $this->sourceCode->transform($transformation->reveal(), $projectDescriptor, $apiSet);
     }
 
     /**
@@ -74,7 +75,7 @@ final class SourcecodeTest extends MockeryTestCase
         $api->getSettings()['include-source'] = true;
         $projectDescriptor = $this->giveProjectDescriptor($api);
 
-        $this->sourceCode->transform($projectDescriptor, $transformation->reveal());
+        $this->sourceCode->transform($transformation->reveal(), $projectDescriptor, $api);
     }
 
     private function giveProjectDescriptor(ApiSetDescriptor $apiDescriptor): ProjectDescriptor

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/ArrayOfTypeAdapterTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/ArrayOfTypeAdapterTest.php
@@ -23,7 +23,6 @@ use PHPUnit\Framework\TestCase;
 /**
  * @coversDefaultClass \phpDocumentor\Transformer\Writer\Twig\LinkRenderer\ArrayOfTypeAdapter
  * @covers ::<private>
- * @covers ::__construct
  */
 final class ArrayOfTypeAdapterTest extends TestCase
 {

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/LinkAdapterTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/LinkAdapterTest.php
@@ -68,7 +68,7 @@ final class LinkAdapterTest extends TestCase
     }
 
     /**
-     * @covers ::supports
+     * @covers ::supports()
      */
     public function testItSupportsAnyType(): void
     {
@@ -85,7 +85,7 @@ final class LinkAdapterTest extends TestCase
     /**
      * @param array<Type>|Type|DescriptorAbstract|Fqsen|Reference\Reference|Path|string|iterable<mixed> $value
      *
-     * @covers ::render
+     * @covers ::render()
      * @dataProvider renderingVariations
      */
     public function testRenderProducesExpectedOutputBasedOn($value, Target $expectedTarget): void

--- a/tests/unit/phpDocumentor/Transformer/Writer/TwigTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/TwigTest.php
@@ -18,7 +18,6 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\MountManager;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\Query\Engine;
 use phpDocumentor\Faker\Faker;
 use phpDocumentor\Transformer\Template;
@@ -110,7 +109,6 @@ final class TwigTest extends TestCase
     {
         $targetDir = $this->destinationFolder->url();
         $transformer = $this->givenTransformerWithTarget($targetDir);
-        $this->pathGenerator->generate(Argument::any(), Argument::any())->willReturn('index.html');
 
         $this->givenATwigEnvironmentFactoryWithTemplates(
             ['/index.html.twig' => 'This is a twig file']
@@ -125,12 +123,13 @@ final class TwigTest extends TestCase
         );
         $transformation->setTransformer($transformer->reveal());
 
-        $project = new ProjectDescriptor('project');
         $apiSetDescriptor = $this->faker()->apiSetDescriptor();
-        $project->getVersions()->add($this->faker()->versionDescriptor([$apiSetDescriptor]));
+        $project = $this->faker()->projectDescriptor([$this->faker()->versionDescriptor([$apiSetDescriptor])]);
         $project->getSettings()->setCustom($this->writer->getDefaultSettings());
+        $this->pathGenerator->generate($apiSetDescriptor, $transformation)->willReturn('index.html');
+
         $this->writer->initialize($project, $apiSetDescriptor, $this->faker()->template());
-        $this->writer->transform($project, $transformation);
+        $this->writer->transform($transformation, $project, $apiSetDescriptor);
 
         $this->assertFileExists($targetDir . '/index.html');
         $this->assertStringEqualsFile($targetDir . '/index.html', 'This is a twig file');


### PR DESCRIPTION
We are inching closer to supporting the whole documentation pipeline per documentation set instead of a per-project level.

This is one of the final steps to make the architecture work in this way.

Once this is solved, we can start experimenting with enabling multi-documentation-set rendering and discovering the issues stemming from that.