### PR TITLE
Introduce views to make sure templates keep working

### DIFF
--- a/src/phpDocumentor/Transformer/View/DefaultViewSet.php
+++ b/src/phpDocumentor/Transformer/View/DefaultViewSet.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Transformer\View;
+
+use phpDocumentor\Descriptor\ApiSetDescriptor;
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
+use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Transformer\Transformation;
+
+use function array_merge;
+use function count;
+use function strlen;
+use function strpos;
+use function substr;
+
+final class DefaultViewSet implements ViewSet
+{
+    private ProjectDescriptor $project;
+    private DocumentationSetDescriptor $documentationSet;
+    private Transformation $transformation;
+
+    public function __construct(
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
+        Transformation $transformation
+    ) {
+        $this->project = $project;
+        $this->documentationSet = $documentationSet;
+        $this->transformation = $transformation;
+    }
+
+    public static function create(
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
+        Transformation $transformation
+    ): self {
+        return new static($project, $documentationSet, $transformation);
+    }
+
+    public function getViews(): array
+    {
+        $extraParameters = [];
+        foreach ($this->project->getSettings()->getCustom() as $key => $value) {
+            if (strpos($key, 'template.') !== 0) {
+                continue;
+            }
+
+            $extraParameters[substr($key, strlen('template.'))] = $value;
+        }
+
+        $parameters = array_merge($this->transformation->getParameters(), $extraParameters);
+
+        $usesNamespaces = $this->documentationSet instanceof ApiSetDescriptor
+            && count($this->documentationSet->getNamespace()->getChildren()) > 0;
+        $usesPackages = $this->documentationSet instanceof ApiSetDescriptor
+            && $this->documentationSet->getPackage() !== null
+            && count($this->documentationSet->getPackage()->getChildren()) > 0;
+
+        return [
+            'project' => $this->project,
+            'documentationSet' => $this->documentationSet,
+            'usesNamespaces' => $usesNamespaces,
+            'usesPackages' => $usesPackages,
+            'parameter' => $parameters,
+        ];
+    }
+}

--- a/src/phpDocumentor/Transformer/View/DefaultViewSet.php
+++ b/src/phpDocumentor/Transformer/View/DefaultViewSet.php
@@ -61,14 +61,27 @@ final class DefaultViewSet implements ViewSet
 
         $parameters = array_merge($this->transformation->getParameters(), $extraParameters);
 
-        $usesNamespaces = $this->documentationSet instanceof ApiSetDescriptor
-            && count($this->documentationSet->getNamespace()->getChildren()) > 0;
-        $usesPackages = $this->documentationSet instanceof ApiSetDescriptor
-            && $this->documentationSet->getPackage() !== null
-            && count($this->documentationSet->getPackage()->getChildren()) > 0;
+        $rootNamespace = $this->documentationSet instanceof ApiSetDescriptor
+            ? $this->documentationSet->getNamespace()
+            : null;
+        $usesNamespaces = $rootNamespace !== null && count($rootNamespace->getChildren()) > 0;
+
+        $rootPackage = $this->documentationSet instanceof ApiSetDescriptor
+            ? $this->documentationSet->getPackage()
+            : null;
+        $usesPackages = $rootPackage !== null && count($rootPackage->getChildren()) > 0;
 
         return [
-            'project' => $this->project,
+            'project' => [
+                'name' => $this->project->getName(),
+                'title' => $this->project->getName(),
+                'settings' => $this->project->getSettings(),
+                'versions' => $this->project->getVersions(),
+                'files' => $this->documentationSet->getFiles(),
+                'indexes' => $this->documentationSet->getIndexes(),
+                'package' => $rootPackage,
+                'namespace' => $rootNamespace,
+            ],
             'documentationSet' => $this->documentationSet,
             'usesNamespaces' => $usesNamespaces,
             'usesPackages' => $usesPackages,

--- a/src/phpDocumentor/Transformer/View/ViewSet.php
+++ b/src/phpDocumentor/Transformer/View/ViewSet.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Transformer\View;
+
+use phpDocumentor\Descriptor\DocumentationSetDescriptor;
+use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Transformer\Transformation;
+
+interface ViewSet
+{
+    public static function create(
+        ProjectDescriptor $project,
+        DocumentationSetDescriptor $documentationSet,
+        Transformation $transformation
+    ): self;
+
+    /**
+     * Returns all views that can be exposed to writers.
+     *
+     * @return array<string, mixed>
+     */
+    public function getViews(): array;
+}

--- a/src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
+++ b/src/phpDocumentor/Transformer/Writer/Graph/GraphVizClassDiagram.php
@@ -20,7 +20,6 @@ use phpDocumentor\Descriptor\DescriptorAbstract;
 use phpDocumentor\Descriptor\DocumentationSetDescriptor;
 use phpDocumentor\Descriptor\InterfaceDescriptor;
 use phpDocumentor\Descriptor\Interfaces\NamespaceInterface;
-use phpDocumentor\Descriptor\ProjectDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\GraphViz\Edge;
 use phpDocumentor\GraphViz\Graph as GraphVizGraph;

--- a/src/phpDocumentor/Transformer/Writer/RenderGuide.php
+++ b/src/phpDocumentor/Transformer/Writer/RenderGuide.php
@@ -22,6 +22,7 @@ use phpDocumentor\Guides\RenderCommand;
 use phpDocumentor\Guides\Twig\EnvironmentBuilder;
 use phpDocumentor\Parser\FlySystemFactory;
 use phpDocumentor\Transformer\Transformation;
+use phpDocumentor\Transformer\View\DefaultViewSet;
 use phpDocumentor\Transformer\Writer\Twig\EnvironmentFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -83,6 +84,11 @@ final class RenderGuide extends WriterAbstract implements ProjectDescriptor\With
             function () use ($transformation, $project, $documentationSet) {
                 $twig = $this->environmentFactory->create($project, $documentationSet, $transformation->template());
                 $twig->addGlobal('destinationPath', null);
+
+                $viewSet = DefaultViewSet::create($project, $documentationSet, $transformation);
+                foreach ($viewSet->getViews() as $name => $view) {
+                    $twig->addGlobal($name, $view);
+                }
 
                 return $twig;
             }

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -93,8 +93,6 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
     private ConverterInterface $markdownConverter;
     private RelativePathToRootConverter $relativePathToRootConverter;
     private PathBuilder $pathBuilder;
-    private DocumentationSetDescriptor $documentationSet;
-    private ProjectDescriptor $project;
 
     /**
      * Registers the structure and transformation with this extension.
@@ -109,8 +107,6 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
         RelativePathToRootConverter $relativePathToRootConverter,
         PathBuilder $pathBuilder
     ) {
-        $this->project = $project;
-        $this->documentationSet = $documentationSet;
         $this->markdownConverter = $markdownConverter;
         $this->routeRenderer = $routeRenderer;
         $this->routeRenderer = $this->routeRenderer->withProject($project)->forDocumentationSet($documentationSet);
@@ -122,26 +118,14 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
      * Initialize series of globals used by the writers to set the context
      *
      * @return array{
-     *     project: ProjectDescriptor,
-     *     documentationSet: DocumentationSetDescriptor,
-     *     node: ?Descriptor,
-     *     usesNamespaces: bool,
-     *     usesPackages: bool,
      *     destinationPath: ?string,
-     *     parameter: array<string, mixed>,
      *     env: mixed
      * }
      */
     public function getGlobals(): array
     {
         return [
-            'project' => $this->project,
-            'documentationSet' => $this->documentationSet,
-            'node' => null,
-            'usesNamespaces' => true,
-            'usesPackages' => true,
             'destinationPath' => null,
-            'parameter' => [],
             'env' => null,
         ];
     }
@@ -460,10 +444,9 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
      */
     private function contextRouteRenderer(array $context): LinkRenderer
     {
-        return $this->routeRenderer
-            ->withDestination(ltrim($context['destinationPath'] ?? $context['env']->getCurrentFileDestination(), '/\\'))
-            ->withProject($context['project'])
-            ->forDocumentationSet($context['documentationSet']);
+        $destination = ltrim($context['destinationPath'] ?? $context['env']->getCurrentFileDestination(), '/\\');
+
+        return $this->routeRenderer->withDestination($destination);
     }
 
     /**


### PR DESCRIPTION
The templates currently rely on the project descriptor, but we want to
get rid of the getFiles and getIndexes methods in the Project
Descriptor.

Instead of changing all the templates, I am looking at introducing a
View layer in phpDocumentor so that we can replace the direct use of
these top level descriptors with a set of views.

The idea behind this is that in the long run, views are aware of the
type of documentation set and can change their output depending on this.

But, give it a couple more commits to crystalize. I am also not too sold
on it being a static factory method at the moment..
