### PR TITLE
feat: add class magic methods to xml template, fix magic method return tag

### DIFF
--- a/data/templates/xml/structure.xml.twig
+++ b/data/templates/xml/structure.xml.twig
@@ -84,6 +84,9 @@
                     {% for method in class.inheritedMethods %}
                         {{ include('method.xml.twig', {method: method, inherited_from: method.parent}) }}
                     {% endfor %}
+                    {% for method in class.magicMethods %}
+                        {{ include('method.xml.twig', {method: method}) }}
+                    {% endfor %}
                 </class>
             {% endfor %}
 

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -18,7 +18,6 @@ use phpDocumentor\Descriptor\Interfaces\ClassInterface;
 use phpDocumentor\Descriptor\Interfaces\MethodInterface;
 use phpDocumentor\Descriptor\Interfaces\PropertyInterface;
 use phpDocumentor\Descriptor\Interfaces\TraitInterface;
-use phpDocumentor\Descriptor\Tag\ReturnDescriptor;
 use phpDocumentor\Descriptor\Validation\Error;
 use phpDocumentor\Reflection\Fqsen;
 

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -100,7 +100,7 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
             $method->setReturnType($methodTag->getResponse()->getType());
             $method->setHasReturnByReference($methodTag->getHasReturnByReference());
 
-            $returnTags = $method->getTags()->fetch('return', new Collection())->filter(ReturnDescriptor::class);
+            $returnTags = $method->getTags()->fetch('return', new Collection());
             $returnTags->add($methodTag->getResponse());
 
             foreach ($methodTag->getArguments() as $name => $argument) {

--- a/src/phpDocumentor/Descriptor/EnumDescriptor.php
+++ b/src/phpDocumentor/Descriptor/EnumDescriptor.php
@@ -18,7 +18,6 @@ use phpDocumentor\Descriptor\Interfaces\EnumInterface;
 use phpDocumentor\Descriptor\Interfaces\FileInterface;
 use phpDocumentor\Descriptor\Interfaces\MethodInterface;
 use phpDocumentor\Descriptor\Interfaces\TraitInterface;
-use phpDocumentor\Descriptor\Tag\ReturnDescriptor;
 use phpDocumentor\Reflection\Location;
 use phpDocumentor\Reflection\Type;
 

--- a/src/phpDocumentor/Descriptor/EnumDescriptor.php
+++ b/src/phpDocumentor/Descriptor/EnumDescriptor.php
@@ -85,7 +85,7 @@ final class EnumDescriptor extends DescriptorAbstract implements EnumInterface
             $method->setReturnType($methodTag->getResponse()->getType());
             $method->setHasReturnByReference($methodTag->getHasReturnByReference());
 
-            $returnTags = $method->getTags()->fetch('return', new Collection())->filter(ReturnDescriptor::class);
+            $returnTags = $method->getTags()->fetch('return', new Collection());
             $returnTags->add($methodTag->getResponse());
 
             foreach ($methodTag->getArguments() as $name => $argument) {


### PR DESCRIPTION
## Adds class magic methods to XML template

Magic methods from class annotations (e.g. `@method`) are not being added to `structure.xml` (e.g. `--template=xml`),. This PR adds them

## Fixes class and trait magic method return tags

When setting the `return` tag for magic methods in traits and classes, the call to `filter` is breaking the reference chain. The `filter` method returns a _new_ collection, and so anything set with `add` will not be set on the original `Collection` as intended. The method `EnumDescriptor::getMagicMethods` does not have this issue. 