### PR TITLE
feat: add magic flag to xml template

### DIFF
--- a/data/templates/xml/method.xml.twig
+++ b/data/templates/xml/method.xml.twig
@@ -1,5 +1,5 @@
 {# @var method phpDocumentor\Descriptor\MethodDescriptor #}
-<method final="{{ method.final | export }}" abstract="{{ method.abstract | export }}" static="{{ method.static | export }}" namespace="{{ method.namespace }}" line="{{ method.line }}" visibility="{{ method.visibility }}" returnByReference="{{ method.hasReturnByReference | export }}">
+<method final="{{ method.final | export }}" abstract="{{ method.abstract | export }}" static="{{ method.static | export }}" namespace="{{ method.namespace }}" line="{{ method.line }}" visibility="{{ method.visibility }}" returnByReference="{{ method.hasReturnByReference | export }}"{% if magic %} magic="true"{% endif %}>
     <name>{{ method.name }}</name>
     <full_name>{{ method.fullyQualifiedStructuralElementName }}</full_name>
     <value>{{ method.value }}</value>

--- a/data/templates/xml/structure.xml.twig
+++ b/data/templates/xml/structure.xml.twig
@@ -85,7 +85,7 @@
                         {{ include('method.xml.twig', {method: method, inherited_from: method.parent}) }}
                     {% endfor %}
                     {% for method in class.magicMethods %}
-                        {{ include('method.xml.twig', {method: method}) }}
+                        {{ include('method.xml.twig', {method: method, magic: true}) }}
                     {% endfor %}
                 </class>
             {% endfor %}

--- a/data/templates/xml/structure.xml.twig
+++ b/data/templates/xml/structure.xml.twig
@@ -85,7 +85,7 @@
                         {{ include('method.xml.twig', {method: method, inherited_from: method.parent}) }}
                     {% endfor %}
                     {% for method in class.magicMethods %}
-                        {{ include('method.xml.twig', {method: method, magic: true}) }}
+                        {{ include('method.xml.twig', {method: method, inherited_from: method.parent == class ? null : method.parent, magic: true}) }}
                     {% endfor %}
                 </class>
             {% endfor %}


### PR DESCRIPTION
We added support for [magic methods added to the Class template](https://github.com/phpDocumentor/phpDocumentor/pull/3514) recently, but in the generated `structure.xml`, there's no way to tell if they've been inherited, or if they're magic methods. 

Summary of changes: 

 - sets `inherited_from` for magic methods
     - This logic is determined in the template when `method.class` does not match `class`. This may not be the best way, but it seemed like the approach with the least churn
     - this feature is (I think) important, since it exists for other methods, and so the behavior now is inconsistent
 - a `magic="true"` attribute to the `<method>` tag (e.g. `<method /* ... */ magic="true">`)
    - I think it makes sense to have some way to know if the methods are magic or not, but since the users could check the existence of the `@method` tag, that's already possible, so I'm 100% okay getting rid of this. 


I'd love some feedback here!!

**Note**: `magic` is probably the wrong label to use for methods added with `__call`, because according to the PHP Documentation, [PHP magic methods](https://www.php.net/manual/en/language.oop5.magic.php) are methods prefixed with `__`.  The methods added with `__call` are referred to as "[overloaded methods](https://www.php.net/manual/en/language.oop5.overloading.php#object.call)", which I also don't like, as that represents something different in other OO languages such as Java. 