### PR TITLE
Add callable rendering

### DIFF
--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php
@@ -23,6 +23,7 @@ use phpDocumentor\Reflection\Type;
 use phpDocumentor\Transformer\Router\Router;
 use phpDocumentor\Transformer\Writer\Twig\LinkRenderer\AbstractListAdapter;
 use phpDocumentor\Transformer\Writer\Twig\LinkRenderer\ArrayOfTypeAdapter;
+use phpDocumentor\Transformer\Writer\Twig\LinkRenderer\CallableAdapter;
 use phpDocumentor\Transformer\Writer\Twig\LinkRenderer\HtmlFormatter;
 use phpDocumentor\Transformer\Writer\Twig\LinkRenderer\IterableAdapter;
 use phpDocumentor\Transformer\Writer\Twig\LinkRenderer\LinkAdapter;
@@ -163,6 +164,7 @@ class LinkRenderer implements LinkRendererInterface
             new NullableAdapter($this),
             new AbstractListAdapter($this),
             new IterableAdapter($this),
+            new CallableAdapter($this),
             new LinkAdapter(
                 $this,
                 new UrlGenerator($this, $this->router),

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/CallableAdapter.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/CallableAdapter.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
+
+use InvalidArgumentException;
+use phpDocumentor\Reflection\Types\Callable_;
+use phpDocumentor\Transformer\Writer\Twig\LinkRendererInterface;
+
+use function assert;
+use function implode;
+use function sprintf;
+use function trim;
+
+final class CallableAdapter implements LinkRendererInterface
+{
+    private LinkRendererInterface $rendererChain;
+
+    public function __construct(LinkRendererInterface $rendererChain)
+    {
+        $this->rendererChain = $rendererChain;
+    }
+
+    /** @param mixed $value */
+    public function supports($value): bool
+    {
+        return $value instanceof Callable_;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return string
+     */
+    public function render($value, string $presentation)
+    {
+        if ($this->supports($value) === false) {
+            throw new InvalidArgumentException('The given value is not supported by this adapter');
+        }
+
+        // the above would already assert this, but phpstan and phpstorm need this
+        assert($value instanceof Callable_);
+
+        if ($value->getReturnType() === null && $value->getParameters() === []) {
+            return 'callable';
+        }
+
+        $parameters = [];
+        foreach ($value->getParameters() as $parameter) {
+            $type = $this->rendererChain->render($parameter->getType(), $presentation);
+            $extraInfo = [];
+            $name = '';
+
+            if ($parameter->isVariadic()) {
+                $extraInfo[] = '...';
+            }
+
+            if ($parameter->isReference()) {
+                $extraInfo[] = '&';
+            }
+
+            if ($parameter->getName() !== null) {
+                $name = '$' . $parameter->getName();
+            }
+
+            $parameters[] = sprintf(
+                '%s%s%s%s%s',
+                $type,
+                $parameter->getName() !== null ? ' ' : '',
+                implode('', $extraInfo),
+                $name,
+                $parameter->isOptional() ? '=' : ''
+            );
+        }
+
+        return trim(sprintf(
+            'callable(%s)%s',
+            implode(', ', $parameters),
+            $value->getReturnType() !== null ? ': ' . $this->rendererChain->render(
+                $value->getReturnType(),
+                $presentation
+            ) : ''
+        ));
+    }
+}

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/CallableAdapterTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/CallableAdapterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
+
+use phpDocumentor\Reflection\Types\Callable_;
+use phpDocumentor\Reflection\Types\CallableParameter;
+use phpDocumentor\Reflection\Types\String_;
+use phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
+use phpDocumentor\Transformer\Writer\Twig\LinkRendererInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class CallableAdapterTest extends TestCase
+{
+    private CallableAdapter $adapter;
+    private ObjectProphecy|LinkRendererInterface $linkRenderer;
+
+    protected function setUp(): void
+    {
+        $this->linkRenderer = $this->prophesize(LinkRendererInterface::class);
+        $this->adapter = new CallableAdapter($this->linkRenderer->reveal());
+    }
+
+    public function testItSupportsCallables(): void
+    {
+        self::assertTrue($this->adapter->supports(new Callable_()));
+        self::assertFalse($this->adapter->supports(new String_()));
+    }
+
+    /** @dataProvider callableProvider */
+    public function testRenderProducesExpectedOutput(Callable_ $input, string $output): void
+    {
+        $this->linkRenderer->render(new String_(), LinkRenderer::PRESENTATION_NORMAL)->willReturn('string');
+        self::assertSame($output, $this->adapter->render($input, LinkRenderer::PRESENTATION_NORMAL));
+    }
+
+    /** @return iterable<string, array{input: Callable_, output: string}> */
+    public function callableProvider(): iterable
+    {
+        yield
+          'empty callable' => [
+              'input' => new Callable_(),
+              'output' => 'callable',
+          ];
+
+        yield
+          'callable with parameters' => [
+              'input' => new Callable_(
+                  [new CallableParameter(new String_()), new CallableParameter(new String_())]
+              ),
+              'output' => 'callable(string, string)',
+          ];
+
+        yield
+          'callable with return type' => [
+              'input' => new Callable_(
+                  [],
+                  new String_()
+              ),
+              'output' => 'callable(): string',
+          ];
+
+        yield 'callable with named parameters' => [
+            'input' => new Callable_(
+                [new CallableParameter(new String_(), 'foo'), new CallableParameter(new String_(), 'bar')]
+            ),
+            'output' => 'callable(string $foo, string $bar)',
+        ];
+
+        yield 'callable with variadic parameter' => [
+            'input' => new Callable_(
+                [new CallableParameter(new String_(), null, false, true)]
+            ),
+            'output' => 'callable(string...)',
+        ];
+
+        yield 'callable with named variadic parameter' => [
+            'input' => new Callable_(
+                [new CallableParameter(new String_(), 'foo', false, true)]
+            ),
+            'output' => 'callable(string ...$foo)',
+        ];
+
+        yield 'callable with reference parameter' => [
+            'input' => new Callable_(
+                [new CallableParameter(new String_(), null, true)]
+            ),
+            'output' => 'callable(string&)',
+        ];
+
+        yield 'callable with named variadic reference parameter' => [
+            'input' => new Callable_(
+                [new CallableParameter(new String_(), 'foo', true, true)]
+            ),
+            'output' => 'callable(string ...&$foo)',
+        ];
+    }
+}


### PR DESCRIPTION
This pr will fix https://github.com/phpDocumentor/phpDocumentor/issues/3060. 

callables will be rendered now correctly. 
![image](https://github.com/phpDocumentor/phpDocumentor/assets/1060433/2b89a027-d3e5-41bf-825f-48b3e00b3f1b)
