### PR TITLE
Enable Code Coverage when locally running PHPUnit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,3 +14,4 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
           snapshot: true
           tags: 'latest, 3, 3.4'
+          buildoptions: "--target=prod"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
             username: ${{ secrets.DOCKER_HUB_USERNAME }}
             password: ${{ secrets.DOCKER_HUB_PASSWORD }}
             tag_semver: true
+            buildoptions: "--target=prod"
         - name: Trigger
           uses: benc-uk/workflow-dispatch@v121
           with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,17 +29,17 @@ RUN echo "memory_limit=-1" >> /usr/local/etc/php/conf.d/phpdoc.ini && phpdoc cac
 
 ENTRYPOINT ["/opt/phpdoc/bin/phpdoc"]
 
-FROM phpdoc_base as dev
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+FROM phpdoc_base as prod
+
+FROM prod as dev
 
 RUN apt-get update \
     && apt-get install -yq git \
     && useradd -m -s /bin/bash phpdoc
 
-COPY --from=composer /usr/bin/composer /usr/bin/composer
-
-FROM phpdoc_base as prod
-
-FROM prod as dev-pcov
+FROM dev as dev-pcov
 
 RUN pecl install pcov \
 	&& docker-php-ext-enable pcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,3 +38,8 @@ RUN apt-get update \
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 FROM phpdoc_base as prod
+
+FROM prod as dev-pcov
+
+RUN pecl install pcov \
+	&& docker-php-ext-enable pcov

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ integration-test: SUITE=--testsuite=integration --no-coverage
 functional-test: SUITE=--testsuite=functional --no-coverage
 
 unit-test integration-test functional-test:
-	${.PHP} bin/phpunit $(SUITE) $(ARGS)
+	${.DOCKER_COMPOSE_RUN} --entrypoint=bin/phpunit phpdoc-pcov $(SUITE) $(ARGS)
 
 .PHONY: e2e-test
 e2e-test: node_modules/.bin/cypress build/default/index.html build/clean/index.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,11 @@ services:
     user: ${CURRENT_UID}
     volumes: [".:/opt/phpdoc"]
     working_dir: "/opt/phpdoc"
+  phpdoc-pcov:
+    build:
+      context: .
+      target: dev-pcov
+      dockerfile: Dockerfile
+    user: ${CURRENT_UID}
+    volumes: [".:/opt/phpdoc"]
+    working_dir: "/opt/phpdoc"


### PR DESCRIPTION
I occasionally want to add a unit test from the backlog of unwritten tests. To do this, I need the code coverage report but that was disabled a while ago.

To reintroduce the code coverage in a non-intrusive way I have introduced a new build stage in the Dockerfile that will install pcov, and I make sure the production builds stop at the prod target.

The added benefit from this is that we use the phpdoc container to run the tests in, meaning that if a test fails in the container it will surely fail in production as both environments are identical