### PR TITLE
Feat: Add basic extension loading

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -237,6 +237,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           set-safe-directory: '/github/workspace'
+          fetch-depth: 0
+
       - uses: ./.github/workflows/phar
         with:
           php-version: ${{ env.defaultPHPVersion }}

--- a/bin/phpdoc
+++ b/bin/phpdoc
@@ -2,6 +2,7 @@
 <?php
 
 use phpDocumentor\AutoloaderLocator;
+use phpDocumentor\Extension\ExtensionHandler;
 use Symfony\Component\Console\Input\ArgvInput;
 
 set_time_limit(0);
@@ -10,7 +11,10 @@ require __DIR__ . '/../src/phpDocumentor/AutoloaderLocator.php';
 $loader = AutoloaderLocator::autoload();
 
 $containerFactory = new \phpDocumentor\Console\ContainerFactory();
-$container = $containerFactory->create(AutoloaderLocator::findVendorPath());
+$container = $containerFactory->create(
+    AutoloaderLocator::findVendorPath(),
+    ExtensionHandler::getInstance(getcwd() . '/.phpdoc/extensions')
+);
 $output = new \Symfony\Component\Console\Output\ConsoleOutput();
 
 $application = $container->get(\phpDocumentor\Console\Application::class);

--- a/bin/phpdoc
+++ b/bin/phpdoc
@@ -2,7 +2,7 @@
 <?php
 
 use phpDocumentor\AutoloaderLocator;
-use phpDocumentor\Extension\ExtensionHandler;
+use phpDocumentor\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 
 set_time_limit(0);
@@ -10,12 +10,5 @@ set_time_limit(0);
 require __DIR__ . '/../src/phpDocumentor/AutoloaderLocator.php';
 $loader = AutoloaderLocator::autoload();
 
-$containerFactory = new \phpDocumentor\Console\ContainerFactory();
-$container = $containerFactory->create(
-    AutoloaderLocator::findVendorPath(),
-    ExtensionHandler::getInstance(getcwd() . '/.phpdoc/extensions')
-);
-$output = new \Symfony\Component\Console\Output\ConsoleOutput();
-
-$application = $container->get(\phpDocumentor\Console\Application::class);
+$application = new Application();
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,8 @@
         "league/uri-interfaces": "^2.0",
         "monolog/monolog": "^2.9",
         "nikic/php-parser": "^4.14",
+        "phar-io/manifest": "^2.0",
+        "phar-io/version": "^3.2",
         "phpdocumentor/flyfinder": "^1.0",
         "phpdocumentor/graphviz": "^2.0",
         "phpdocumentor/guides": "dev-main@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dcc63ca6a92a7819718759325af729d6",
+    "content-hash": "753d86154f80ab330cec7f909f7f66eb",
     "packages": [
         {
             "name": "cypresslab/php-curry",
@@ -1518,6 +1518,117 @@
                 }
             ],
             "time": "2021-04-10T12:58:34+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpdocumentor/flyfinder",
@@ -5124,117 +5235,6 @@
                 }
             ],
             "time": "2023-03-08T13:26:56+00:00"
-        },
-        {
-            "name": "phar-io/manifest",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-phar": "*",
-                "ext-xmlwriter": "*",
-                "phar-io/version": "^3.0.1",
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "support": {
-                "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
-            },
-            "time": "2021-07-20T11:28:43+00:00"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
-                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "support": {
-                "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.2.1"
-            },
-            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpspec/prophecy",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -71,16 +71,12 @@ services:
     phpDocumentor\Application:
       public: true
 
-    phpDocumentor\Console\Application:
-      public: true
-      arguments:
-        $commands: !tagged_iterator { tag: 'console.command' }
-
     phpDocumentor\Console\Command\Project\RunCommand:
         arguments:
           - '@phpDocumentor\Descriptor\ProjectDescriptorBuilder'
           - '@phpdoc.pipeline.complete'
         tags: [ { name: 'console.command' } ]
+        public: true
 
     phpDocumentor\Console\Command\Project\ListSettingsCommand:
         tags: [ { name: 'console.command' } ]
@@ -168,11 +164,16 @@ services:
       class: phpDocumentor\Parser\Cache\FilesystemAdapter
 
     Monolog\Logger:
+      public: true
       arguments:
         - 'app'
 
-    Psr\Log\LoggerInterface: '@Monolog\Logger'
-    Symfony\Component\EventDispatcher\EventDispatcher: ~
+    Psr\Log\LoggerInterface:
+      alias: 'Monolog\Logger'
+      public: true
+
+    Symfony\Component\EventDispatcher\EventDispatcher:
+      public: true
     Symfony\Contracts\EventDispatcher\EventDispatcherInterface: '@Symfony\Component\EventDispatcher\EventDispatcher'
     Psr\EventDispatcher\EventDispatcherInterface: '@Symfony\Contracts\EventDispatcher\EventDispatcherInterface'
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -154,6 +154,9 @@ services:
         $files: '@files'
         $descriptors: '@descriptors'
 
+    phpDocumentor\Extension\ExtensionHandler:
+      factory: [ '\phpDocumentor\Extension\ExtensionHandler', 'getInstance' ]
+
     ###################################################################################
     ## Autoloading definitions for external services ##################################
     ###################################################################################

--- a/docs/features/extensions/index.rst
+++ b/docs/features/extensions/index.rst
@@ -1,0 +1,88 @@
+##########
+Extensions
+##########
+
+.. warning::
+
+    This feature is still under development and only available in the nightly docker builds.
+
+**********
+Installing
+**********
+
+PhpDocumentor can be extended with additional functionality by installing extensions. By default the application
+will search for an extensions folder in the ``.phpdoc`` folder in your working directory.
+
+Supported extension styles:
+
+- folder
+
+Once extensions are correctly loaded phpDocumentor will print a message in the console:
+
+    Loaded extensions:
+    [OK] phpdocumentor/directives:1.0.0
+
+    Failed to load extensions:
+    [WARNING] phpdocumentor/invalid:1.0.0
+
+Extensions are validated before they are acually loaded. If an extension is invalid it will not be loaded and a warning
+will be printed in the console. Like in the example above. To load an extension it must be valid and compatible with
+the current version of phpDocumentor. Extension developers must specify the phpDocumentor version they are compatible
+with in the manifest file.
+
+************************
+Write your own extension
+************************
+
+To write your own extension you need to create a folder in the extensions folder with the name of your extension.
+In this folder you need to create a manifest file called ``manifest.xml``. This file contains the information:
+
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="utf-8" ?>
+    <phar xmlns="https://phar.io/xml/manifest/1.0">
+        <contains name="phpDocumentor\Example" version="1.0" type="extension">
+            <extension for="phpdocumentor/phpdocumentor" compatible="^3.5"/>
+        </contains>
+
+        <copyright>
+            <author name="You" email="you@example.com"/>
+            <license type="MIT" url="https://github.com/phpdocumentor/phpdocumentor-example-extension/blob/1.0.0/LICENSE"/>
+        </copyright>
+
+        <requires>
+            <php version="^8.1"/>
+        </requires>
+
+        <bundles>
+            <component name="phpDocumentor\Example\Extension" version="1.0" />
+        </bundles>
+    </phar>
+
+The ``bundles`` section contains the class that should be loaded when the extension is loaded. This class must extend
+:php:class:`phpDocumentor\Extension\Extension`. And should not contain any other logic rather than registering services.
+
+.. hint::
+
+   Under the hood PhpDocumentor uses the Symfony Dependency Injection component. You can find more information about
+   this component in the `Symfony Dependency Injection documentation <https://symfony.com/doc/current/components/dependency_injection.html>`_.
+   This also shows how to register services. We are using the DI extensions of Symfony to register services. Like bundles
+   do in a Symfony application.
+
+Autoloading
+-----------
+
+The directory of the extension is added to the autoloader. So you can use the autoloader to load classes in your
+extension. Please note that the autoloader is not accessible by the extension itself. So you cannot add classes yourself
+to the autoloader. This is done by phpDocumentor following the PSR-4 standard. The root namespace is the name of the
+extension. So in the example above the root namespace is ``phpDocumentor\Example``.
+
+By using the same autoloader as the application itself you have access to all classes that are loaded by the application.
+Services that are registered in the application can be used in the extension.
+
+Extension points
+----------------
+
+phpDocumentor does not have real extension points. But we have defined some common locations that can be used to extend
+the application. Depending on the type of extension you are writing you can use them.
+

--- a/docs/features/index.rst
+++ b/docs/features/index.rst
@@ -5,4 +5,5 @@ Features
     :maxdepth: 2
 
     theming/index
+    extensions/index
     caching

--- a/src/phpDocumentor/Application.php
+++ b/src/phpDocumentor/Application.php
@@ -13,21 +13,15 @@ declare(strict_types=1);
 
 namespace phpDocumentor;
 
-use Jean85\PrettyVersions;
-use OutOfBoundsException;
 use RuntimeException;
 use Webmozart\Assert\Assert;
 
 use function date_default_timezone_set;
 use function extension_loaded;
 use function file_exists;
-use function file_get_contents;
 use function getcwd;
 use function ini_get;
 use function ini_set;
-use function ltrim;
-use function sprintf;
-use function trim;
 
 /**
  * Application class for phpDocumentor.
@@ -38,27 +32,6 @@ use function trim;
  */
 final class Application
 {
-    private const VERSION = '@package_version@';
-
-    public static function VERSION(): string
-    {
-        $version = self::VERSION;
-
-        $trickBoxIntoNotReplacingThisScalar = sprintf('%s%s%s', '@', 'package_version', '@');
-        $didBoxReplaceTheVersionPlaceholder = $trickBoxIntoNotReplacingThisScalar !== self::VERSION;
-
-        if ($didBoxReplaceTheVersionPlaceholder === false) {
-            $version = trim(file_get_contents(__DIR__ . '/../../VERSION'));
-            try {
-                $version = PrettyVersions::getRootPackageVersion()->getPrettyVersion();
-                $version = sprintf('%s', ltrim($version, 'v'));
-            } catch (OutOfBoundsException) {
-            }
-        }
-
-        return $version;
-    }
-
     public static function templateDirectory(): string
     {
         $templateDir = __DIR__ . '/../../data/templates';

--- a/src/phpDocumentor/AutoloaderLocator.php
+++ b/src/phpDocumentor/AutoloaderLocator.php
@@ -28,9 +28,27 @@ final class AutoloaderLocator
 {
     private static ClassLoader|null $classLoader;
 
+    /**
+     * Fallback classloader for extensions.
+     *
+     * When running with an authoritative classmap, the classloader will not be able to load classes from extensions.
+     * This classloader will be used as a fallback to load classes from extensions. This is a security flaw, but
+     * phpDocumentor should never be installed in production.
+     */
+    private static ClassLoader|null $fallbackClassLoader;
+
     public static function loader(): ClassLoader
     {
-        return self::autoload();
+        if (isset(self::$classLoader) === false || self::$classLoader->isClassMapAuthoritative() === false) {
+            return self::autoload();
+        }
+
+        if (isset(self::$fallbackClassLoader) === false) {
+            self::$fallbackClassLoader = new ClassLoader();
+            self::$fallbackClassLoader->register();
+        }
+
+        return self::$fallbackClassLoader;
     }
 
     public static function autoload(): ClassLoader

--- a/src/phpDocumentor/AutoloaderLocator.php
+++ b/src/phpDocumentor/AutoloaderLocator.php
@@ -26,13 +26,24 @@ use const JSON_THROW_ON_ERROR;
 
 final class AutoloaderLocator
 {
+    private static ClassLoader|null $classLoader;
+
+    public static function loader(): ClassLoader
+    {
+        return self::autoload();
+    }
+
     public static function autoload(): ClassLoader
     {
-        if (Phar::running(false)) {
-            return require 'phar://' . Phar::running(false) . '/vendor/autoload.php';
+        if (isset(self::$classLoader) === false) {
+            if (Phar::running(false)) {
+                self::$classLoader = require 'phar://' . Phar::running(false) . '/vendor/autoload.php';
+            } else {
+                self::$classLoader = require self::findVendorPath() . '/autoload.php';
+            }
         }
 
-        return require self::findVendorPath() . '/autoload.php';
+        return self::$classLoader;
     }
 
     /**

--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -15,6 +15,8 @@ namespace phpDocumentor\Console;
 
 use Monolog\Handler\PsrHandler;
 use Monolog\Logger;
+use phpDocumentor\Extension\ExtensionHandler;
+use phpDocumentor\Version;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\ConsoleEvents;
@@ -32,9 +34,13 @@ use function strlen;
 class Application extends BaseApplication
 {
     /** @param iterable<Command> $commands */
-    public function __construct(iterable $commands, EventDispatcher $eventDispatcher, Logger $logger)
-    {
-        parent::__construct('phpDocumentor', \phpDocumentor\Application::VERSION());
+    public function __construct(
+        iterable $commands,
+        EventDispatcher $eventDispatcher,
+        Logger $logger,
+        ExtensionHandler $extensionHandler,
+    ) {
+        parent::__construct('phpDocumentor', (new Version())->getVersion());
 
         foreach ($commands as $command) {
             $this->add($command);
@@ -48,6 +54,11 @@ class Application extends BaseApplication
             static function (ConsoleEvent $event) use ($logger): void {
                 $logger->pushHandler(new PsrHandler(new ConsoleLogger($event->getOutput())));
             },
+        );
+
+        $eventDispatcher->addListener(
+            ConsoleEvents::COMMAND,
+            [$extensionHandler, 'onBoot'],
         );
     }
 

--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -43,9 +43,11 @@ class Application extends BaseApplication
 
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        $extensionHandler = ExtensionHandler::getInstance(
-            $input->hasOption('extensions-dir') ? $input->getOption('extensions-dir') : [],
+        $extensionsDirs = $input->getParameterOption(
+            '--extensions-dir',
+            $this->getDefinition()->getOption('extensions-dir')->getDefault(),
         );
+        $extensionHandler = ExtensionHandler::getInstance($extensionsDirs);
         $containerFactory = new ContainerFactory();
         $container = $containerFactory->create(
             AutoloaderLocator::findVendorPath(),

--- a/src/phpDocumentor/Console/ContainerFactory.php
+++ b/src/phpDocumentor/Console/ContainerFactory.php
@@ -7,6 +7,7 @@ namespace phpDocumentor\Console;
 use phpDocumentor\DependencyInjection\ApplicationExtension;
 use phpDocumentor\DependencyInjection\GuidesCommandsPass;
 use phpDocumentor\DependencyInjection\ReflectionProjectFactoryStrategyPass;
+use phpDocumentor\Extension\ExtensionHandler;
 use phpDocumentor\Guides\DependencyInjection\GuidesExtension;
 use phpDocumentor\Guides\RestructuredText\DependencyInjection\ReStructuredTextExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -46,10 +47,17 @@ final class ContainerFactory
         $this->container->loadFromExtension($extension->getAlias());
     }
 
-    public function create(string $vendorDir): ContainerBuilder
-    {
+    public function create(
+        string $vendorDir,
+        ExtensionHandler $extensionHandler,
+    ): ContainerBuilder {
         $this->container->setParameter('vendor_dir', $vendorDir);
         $this->container->setParameter('kernel.project_dir', dirname(__DIR__, 3));
+
+        foreach ($extensionHandler->loadExtensions() as $extension) {
+            $this->registerExtension(new $extension());
+        }
+
         $this->container->compile();
 
         return $this->container;

--- a/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
+++ b/src/phpDocumentor/Descriptor/Builder/AssemblerFactory.php
@@ -25,6 +25,7 @@ use phpDocumentor\Descriptor\Builder\Reflector\InterfaceAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\MethodAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\NamespaceAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\PropertyAssembler;
+use phpDocumentor\Descriptor\Builder\Reflector\Reducer\MetadataReducer;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\AuthorAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\DeprecatedAssembler;
 use phpDocumentor\Descriptor\Builder\Reflector\Tags\ExampleAssembler;
@@ -144,8 +145,9 @@ class AssemblerFactory
         $argumentAssembler = new ArgumentAssembler();
 
         $descriptionReducer = new DescriptionAssemblerReducer();
+        $metadataReducer = new MetadataReducer();
 
-        $factory->register(Matcher::forType(File::class), new FileAssembler());
+        $factory->register(Matcher::forType(File::class), new FileAssembler($metadataReducer));
         $factory->register(Matcher::forType(Constant::class), new ConstantAssembler());
         $factory->register(Matcher::forType(Trait_::class), new TraitAssembler());
         $factory->register(Matcher::forType(Class_::class), new ClassAssembler());

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
@@ -49,7 +49,7 @@ class FileAssembler extends AssemblerAbstract
      *
      * @param File $data
      */
-    public function create(object $data): FileInterface
+    public function buildDescriptor(object $data): FileInterface
     {
         $fileDescriptor = new FileDescriptor($data->getHash());
         $fileDescriptor->setPackage(

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Reducer/MetadataReducer.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Reducer/MetadataReducer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Descriptor\Builder\Reflector\Reducer;
+
+use phpDocumentor\Descriptor\Builder\AssemblerReducer;
+use phpDocumentor\Descriptor\Descriptor;
+use phpDocumentor\Descriptor\Interfaces\MetadataAwareInterface;
+use phpDocumentor\Reflection\Metadata\MetaDataContainer;
+
+final class MetadataReducer implements AssemblerReducer
+{
+    public function create(object $data, Descriptor|null $descriptor = null): Descriptor|null
+    {
+        if ($data instanceof MetaDataContainer === false) {
+            return $descriptor;
+        }
+
+        if ($descriptor instanceof MetadataAwareInterface === false) {
+            return $descriptor;
+        }
+
+        $descriptor->setMetadata($data->getMetadata());
+
+        return $descriptor;
+    }
+}

--- a/src/phpDocumentor/Descriptor/DescriptorAbstract.php
+++ b/src/phpDocumentor/Descriptor/DescriptorAbstract.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Descriptor;
 use phpDocumentor\Descriptor\Filter\Filterable;
 use phpDocumentor\Descriptor\Interfaces\ElementInterface;
 use phpDocumentor\Descriptor\Interfaces\InheritsFromElement;
+use phpDocumentor\Descriptor\Interfaces\MetadataAwareInterface;
 use phpDocumentor\Descriptor\Validation\Error;
 use Stringable;
 use Webmozart\Assert\Assert;
@@ -27,9 +28,15 @@ use function substr;
 /**
  * Base class for descriptors containing the most used options.
  */
-abstract class DescriptorAbstract implements Filterable, ElementInterface, InheritsFromElement, Stringable
+abstract class DescriptorAbstract implements
+    Filterable,
+    ElementInterface,
+    InheritsFromElement,
+    Stringable,
+    MetadataAwareInterface
 {
     use Traits\HasFqsen;
+    use Traits\HasMetadata;
     use Traits\HasName;
     use Traits\HasNamespace;
     use Traits\HasPackage;

--- a/src/phpDocumentor/Descriptor/Interfaces/MetadataAwareInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/MetadataAwareInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Descriptor\Interfaces;
+
+use phpDocumentor\Reflection\Metadata\Metadata;
+
+interface MetadataAwareInterface
+{
+    /** @param Metadata[] $metadata */
+    public function setMetadata(array $metadata): void;
+
+    /** @return Metadata[] */
+    public function getMetadata(): array;
+}

--- a/src/phpDocumentor/Descriptor/Traits/HasMetadata.php
+++ b/src/phpDocumentor/Descriptor/Traits/HasMetadata.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Descriptor\Traits;
+
+use phpDocumentor\Reflection\Metadata\Metadata;
+
+trait HasMetadata
+{
+    /** @var Metadata[] */
+    private array $metadata = [];
+
+    /** @param Metadata[] $metadata */
+    public function setMetadata(array $metadata): void
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+}

--- a/src/phpDocumentor/Descriptor/Traits/HasMetadata.php
+++ b/src/phpDocumentor/Descriptor/Traits/HasMetadata.php
@@ -17,6 +17,7 @@ trait HasMetadata
         $this->metadata = $metadata;
     }
 
+    /** @return Metadata[] */
     public function getMetadata(): array
     {
         return $this->metadata;

--- a/src/phpDocumentor/Extension/DirectoryLoader.php
+++ b/src/phpDocumentor/Extension/DirectoryLoader.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use DirectoryIterator;
+use PharIo\Manifest\ManifestLoader;
+
+final class DirectoryLoader implements ExtensionLoader
+{
+    public function supports(DirectoryIterator $dir): bool
+    {
+        return $dir->isDir() && $this->findManifestFile(new DirectoryIterator($dir->getPathname())) !== null;
+    }
+
+    public function load(DirectoryIterator $dir): ExtensionInfo|null
+    {
+        $file = $this->findManifestFile($dir);
+        if ($file === null) {
+            return null;
+        }
+
+        return ExtensionInfo::fromManifest(ManifestLoader::fromFile($file->getPathName()), $file->getPath());
+    }
+
+    private function findManifestFile(DirectoryIterator $dir): DirectoryIterator|null
+    {
+        foreach ($dir as $file) {
+            if ($file->isDot()) {
+                continue;
+            }
+
+            if ($file->isFile() === false) {
+                continue;
+            }
+
+            if ($file->getFileName() !== 'manifest.xml') {
+                continue;
+            }
+
+            return $file;
+        }
+
+        return null;
+    }
+}

--- a/src/phpDocumentor/Extension/Extension.php
+++ b/src/phpDocumentor/Extension/Extension.php
@@ -1,8 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace phpDocumentor\Extension;
 
-class Extension
-{
+use Symfony\Component\DependencyInjection\Extension\Extension as BaseExtension;
 
+abstract class Extension extends BaseExtension
+{
+    /**
+     * The constructor of extensions should not be used.
+     *
+     * Extensions are loaded by the {@see ExtensionHandler}. An extension should not apply any logic in its
+     * constructor.
+     */
+    final public function __construct()
+    {
+    }
 }

--- a/src/phpDocumentor/Extension/Extension.php
+++ b/src/phpDocumentor/Extension/Extension.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace phpDocumentor\Extension;
+
+class Extension
+{
+
+}

--- a/src/phpDocumentor/Extension/Extension.php
+++ b/src/phpDocumentor/Extension/Extension.php
@@ -12,7 +12,6 @@ abstract class Extension extends BaseExtension
      * The constructor of extensions should not be used.
      *
      * Extensions are loaded by the {@see ExtensionHandler}. An extension should not apply any logic in its
-     * constructor.
      */
     final public function __construct()
     {

--- a/src/phpDocumentor/Extension/ExtensionHandler.php
+++ b/src/phpDocumentor/Extension/ExtensionHandler.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+* This file is part of phpDocumentor.
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*
+* @link https://phpdoc.org
+*/
+
+namespace phpDocumentor\Extension;
+
+use DirectoryIterator;
+use Generator;
+use Jean85\PrettyVersions;
+use PharIo\Manifest\ApplicationName;
+use phpDocumentor\AutoloaderLocator;
+use phpDocumentor\Version;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function array_filter;
+use function count;
+use function file_exists;
+
+final class ExtensionHandler
+{
+    private static ExtensionHandler|null $instance;
+
+    /** @var ExtensionInfo[] */
+    private array|null $extensions = null;
+
+    /** @var string */
+    private $extensionsDir;
+
+    /** @var ExtensionLoader[] */
+    private $loaders = [];
+
+    /** @var ExtensionInfo[] */
+    private array $invalidExtensions =  [];
+
+    /** @var Validator */
+    private $validator;
+
+    private function __construct(string $extensionsDir)
+    {
+        $this->extensionsDir = $extensionsDir;
+        $this->loaders[] = new DirectoryLoader();
+        $this->validator = new Validator(
+            new ApplicationName(PrettyVersions::getRootPackageName()),
+            new Version(),
+        );
+    }
+
+    public static function getInstance(string $extensionsDir = ''): self
+    {
+        if (isset(self::$instance) === false) {
+            self::$instance = new self($extensionsDir);
+        }
+
+        return self::$instance;
+    }
+
+    /** @return ExtensionInfo[] */
+    private function getExtensions(): array
+    {
+        if ($this->extensions !== null) {
+            return $this->extensions;
+        }
+
+        if (file_exists($this->extensionsDir) === false) {
+            $this->extensions = [];
+
+            return $this->extensions;
+        }
+
+        $extensions = [];
+        $iterator = new DirectoryIterator($this->extensionsDir);
+        foreach ($iterator as $dir) {
+            if ($dir->isDot()) {
+                continue;
+            }
+
+            foreach ($this->loaders as $loader) {
+                if (! $loader->supports($dir)) {
+                    continue;
+                }
+
+                $extensions[$dir->getPathName()] = $loader->load(new DirectoryIterator($dir->getPathName()));
+            }
+        }
+
+        $extensions = array_filter($extensions);
+        $this->extensions = array_filter($extensions, function (ExtensionInfo $extension) {
+            return $this->validator->isValid($extension);
+        });
+
+        $this->invalidExtensions = array_filter($extensions, function (ExtensionInfo $extension) {
+            return $this->validator->isValid($extension) === false;
+        });
+
+        return $this->extensions;
+    }
+
+    /** @return Generator<class-string> */
+    public function loadExtensions(): Generator
+    {
+        foreach ($this->getExtensions() as $extension) {
+            $namespace = $extension->getNamespace();
+            AutoloaderLocator::loader()->addPsr4($namespace, [$extension->getPath()]);
+
+            yield $extension->getExtensionClass();
+        }
+    }
+
+    public function onBoot(ConsoleCommandEvent $event): void
+    {
+        $io = new SymfonyStyle($event->getInput(), $event->getOutput());
+        $extensions = $this->getExtensions();
+        if (count($extensions) > 0) {
+            $io->writeln('Loaded extensions:');
+            foreach ($extensions as $extension) {
+                $io->success($extension->getName() . ':' . $extension->getVersion());
+            }
+        }
+
+        if (count($this->invalidExtensions) <= 0) {
+            return;
+        }
+
+        $io->writeln('Failed to load extensions:');
+        foreach ($this->invalidExtensions as $extension) {
+            $io->warning($extension->getName() . ':' . $extension->getVersion());
+        }
+    }
+}

--- a/src/phpDocumentor/Extension/ExtensionInfo.php
+++ b/src/phpDocumentor/Extension/ExtensionInfo.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\Manifest;
+
+use function array_pop;
+use function explode;
+use function implode;
+
+final class ExtensionInfo
+{
+    /** @var Manifest */
+    private $manifest;
+
+    /** @var string */
+    private $namespace;
+
+    /** @var string */
+    private $path;
+
+    /** @var string */
+    private $name;
+
+    private function __construct(Manifest $manifest, string $path)
+    {
+        $this->manifest = $manifest;
+        $this->path = $path;
+        foreach ($manifest->getBundledComponents() as $component) {
+            $parts = explode('\\', $component->getName());
+            $this->name = array_pop($parts);
+            $this->namespace = implode('\\', $parts) . '\\';
+            break;
+        }
+    }
+
+    public static function fromManifest(Manifest $manifest, string $path): self
+    {
+        return new self($manifest, $path);
+    }
+
+    public function getName(): string
+    {
+        return $this->manifest->getName()->asString();
+    }
+
+    public function getVersion(): string
+    {
+        return $this->manifest->getVersion()->getVersionString();
+    }
+
+    public function getExtensionClass(): string
+    {
+        return $this->namespace . $this->name;
+    }
+
+    public function getNamespace(): string
+    {
+        return $this->namespace;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getManifest(): Manifest
+    {
+        return $this->manifest;
+    }
+}

--- a/src/phpDocumentor/Extension/ExtensionLoader.php
+++ b/src/phpDocumentor/Extension/ExtensionLoader.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use DirectoryIterator;
+
+interface ExtensionLoader
+{
+    public function supports(DirectoryIterator $dir): bool;
+
+    public function load(DirectoryIterator $dir): ExtensionInfo|null;
+}

--- a/src/phpDocumentor/Extension/Validator.php
+++ b/src/phpDocumentor/Extension/Validator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\ApplicationName;
+use PharIo\Version\Version;
+use phpDocumentor\Version as ApplicationVersion;
+
+final class Validator
+{
+    private Version $applicationVersion;
+
+    public function __construct(private ApplicationName $applicationName, ApplicationVersion $applicationVersion)
+    {
+        $this->applicationVersion = new Version($applicationVersion->getExtensionVersion());
+    }
+
+    public function isValid(ExtensionInfo $extension): bool
+    {
+        return $extension->getManifest()->isExtensionFor($this->applicationName, $this->applicationVersion);
+    }
+}

--- a/src/phpDocumentor/Parser/Cache/FilesystemAdapter.php
+++ b/src/phpDocumentor/Parser/Cache/FilesystemAdapter.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Parser\Cache;
 
-use phpDocumentor\Application;
+use phpDocumentor\Version;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
 use Symfony\Component\Cache\PruneableInterface;
@@ -71,6 +71,6 @@ final class FilesystemAdapter extends AbstractAdapter implements PruneableInterf
 
     private function prefixNamespaceWithVersion(string $namespace): string
     {
-        return sprintf('%s-%s', md5(Application::VERSION()), $namespace);
+        return sprintf('%s-%s', md5((new Version())->getVersion()), $namespace);
     }
 }

--- a/src/phpDocumentor/Version.php
+++ b/src/phpDocumentor/Version.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor;
+
+use Jean85\PrettyVersions;
+use OutOfBoundsException;
+
+use function explode;
+use function file_get_contents;
+use function sprintf;
+use function strpos;
+use function trim;
+
+final class Version
+{
+    private const VERSION = '@package_version@';
+
+    /** @var string */
+    private $version;
+
+    public function __construct()
+    {
+        $this->version = $this->detectVersion();
+    }
+
+    private function detectVersion(): string
+    {
+        $version = self::VERSION;
+
+        // prevent replacing the version by the PEAR building
+        if (sprintf('%s%s%s', '@', 'package_version', '@') === self::VERSION) {
+            $version = trim(file_get_contents(__DIR__ . '/../../VERSION'));
+            // @codeCoverageIgnoreStart
+            try {
+                $packageVersion = PrettyVersions::getRootPackageVersion();
+
+                if ($packageVersion->getPrettyVersion() === $version) {
+                    return $version;
+                }
+
+                $version = sprintf(
+                    '%s-%s+%s',
+                    $version,
+                    $packageVersion->getShortVersion(),
+                    $packageVersion->getShortReference(),
+                );
+            } catch (OutOfBoundsException) {
+            }
+
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $version;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function getExtensionVersion(): string
+    {
+        if (strpos($this->version, '-') !== false) {
+            $version = explode('-', $this->version)[0];
+
+            return $version . '-dev';
+        }
+
+        return $this->version;
+    }
+}

--- a/tests/data/extensions/example/Extension.php
+++ b/tests/data/extensions/example/Extension.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Example;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\AbstractExtension;
+
+class Extension extends \Symfony\Component\DependencyInjection\Extension\Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        // TODO: Implement load() method.
+    }
+}

--- a/tests/data/extensions/example/manifest.xml
+++ b/tests/data/extensions/example/manifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phar xmlns="https://phar.io/xml/manifest/1.0">
+    <contains name="phpdocumentor/directives" version="1.0" type="extension">
+        <extension for="phpdocumentor/phpdocumentor" compatible="^3.1"/>
+    </contains>
+
+    <copyright>
+        <author name="Jaap van Otterdijk" email="jaap@phpdoc.org"/>
+        <license type="MIT" url="https://github.com/phpdocumentor/phpdocumentor-example-extension/blob/1.0.0/LICENSE"/>
+    </copyright>
+
+    <requires>
+        <php version="^8.1"/>
+    </requires>
+
+    <bundles>
+        <component name="phpDocumentor\Example\Extension" version="1.0" />
+    </bundles>
+</phar>

--- a/tests/unit/phpDocumentor/Console/ApplicationTest.php
+++ b/tests/unit/phpDocumentor/Console/ApplicationTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Console;
 
 use Monolog\Logger;
+use phpDocumentor\Extension\ExtensionHandler;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -44,6 +45,7 @@ final class ApplicationTest extends TestCase
             [(new Command('project:run'))->setCode(fn () => 2)],
             $eventDispatcher->reveal(),
             $this->prophesize(Logger::class)->reveal(),
+            ExtensionHandler::getInstance(__DIR__),
         );
         $this->feature->setAutoExit(false);
     }

--- a/tests/unit/phpDocumentor/Extension/DirectoryLoaderTest.php
+++ b/tests/unit/phpDocumentor/Extension/DirectoryLoaderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use DirectoryIterator;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \phpDocumentor\Extension\DirectoryLoader */
+final class DirectoryLoaderTest extends TestCase
+{
+    /**
+     * @covers ::supports
+     * @covers ::findManifestFile
+     */
+    public function testSupportsReturnsFalseWhenNoManifestFileFoundInEmptyDir(): void
+    {
+        $fileSystem = vfsStream::setup('extensions');
+        $fileSystem->addChild(vfsStream::newDirectory('myExtension'));
+
+        $loader = new DirectoryLoader();
+        self::assertFalse($loader->supports(new DirectoryIterator($fileSystem->url())));
+    }
+
+    /**
+     * @covers ::supports
+     * @covers ::findManifestFile
+     */
+    public function testSupportsReturnsFalseWhenNoManifestFileFound(): void
+    {
+        $fileSystem = vfsStream::setup('extensions');
+        $fileSystem->addChild(vfsStream::newFile('myExtension'));
+
+        $loader = new DirectoryLoader();
+        self::assertFalse($loader->supports(new DirectoryIterator($fileSystem->url())));
+    }
+
+    /**
+     * @covers ::supports
+     * @covers ::findManifestFile
+     */
+    public function testSupportsReturnsTrueWhenManifestFileFound(): void
+    {
+        $fileSystem = vfsStream::setup('extensions');
+        $fileSystem->addChild(vfsStream::newFile('manifest.xml'));
+
+        $loader = new DirectoryLoader();
+        self::assertTrue($loader->supports(new DirectoryIterator($fileSystem->url())));
+    }
+
+    /**
+     * @covers ::load
+     * @covers ::findManifestFile
+     */
+    public function testNotSupportedDirectoryReturnsNullOnLoad(): void
+    {
+        $fileSystem = vfsStream::setup('extensions');
+        $fileSystem->addChild(vfsStream::newFile('myExtension'));
+
+        $loader = new DirectoryLoader();
+        self::assertNull($loader->load(new DirectoryIterator($fileSystem->url())));
+    }
+
+    /**
+     * @covers ::load
+     * @covers ::findManifestFile
+     */
+    public function testExtensionIsCreatedWhenExtensionDirValid(): void
+    {
+        $fileSystem = vfsStream::copyFromFileSystem(__DIR__ . '/../../../data/extensions/example');
+
+        $loader = new DirectoryLoader();
+        $extension = $loader->load(new DirectoryIterator($fileSystem->url()));
+
+        self::assertInstanceOf(ExtensionInfo::class, $extension);
+    }
+}

--- a/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
+++ b/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
@@ -21,8 +21,10 @@ final class ExtensionHandlerTest extends TestCase
     protected function tearDown(): void
     {
         $class = new ReflectionClass(ExtensionHandler::getInstance(
-            'foo',
-            'bar',
+            [
+                'foo',
+                'bar',
+            ],
         ));
 
         $instance = $class->getProperty('instance');
@@ -39,7 +41,7 @@ final class ExtensionHandlerTest extends TestCase
 
         $extensionsDir = $root->url() . '/extensions';
 
-        $extensionHandler = ExtensionHandler::getInstance($extensionsDir);
+        $extensionHandler = ExtensionHandler::getInstance([$extensionsDir]);
 
         $manifests = iterator_to_array($extensionHandler->loadExtensions());
         self::assertCount(0, $manifests);
@@ -53,7 +55,7 @@ final class ExtensionHandlerTest extends TestCase
 
         $extensionsDir = $root->url() . '/extensions';
 
-        $extensionHandler = ExtensionHandler::getInstance($extensionsDir . '/notExisting');
+        $extensionHandler = ExtensionHandler::getInstance([$extensionsDir . '/notExisting']);
         $manifests = iterator_to_array($extensionHandler->loadExtensions());
         self::assertCount(0, $manifests);
     }
@@ -66,7 +68,7 @@ final class ExtensionHandlerTest extends TestCase
         $extensionsDir->addChild(vfsStream::newFile('somefile.txt')->withContent('ignore'));
         $root->addChild($extensionsDir);
 
-        $extensionHandler = ExtensionHandler::getInstance($extensionsDir->url());
+        $extensionHandler = ExtensionHandler::getInstance([$extensionsDir->url()]);
         $manifests = iterator_to_array($extensionHandler->loadExtensions());
         self::assertCount(0, $manifests);
     }
@@ -79,7 +81,7 @@ final class ExtensionHandlerTest extends TestCase
         vfsStream::copyFromFileSystem(__DIR__ . '/../../../data/extensions', $extensionsDir);
         $root->addChild($extensionsDir);
 
-        $extensionHandler = ExtensionHandler::getInstance($extensionsDir->url());
+        $extensionHandler = ExtensionHandler::getInstance([$extensionsDir->url()]);
         $manifests = iterator_to_array($extensionHandler->loadExtensions());
         self::assertCount(1, $manifests);
     }

--- a/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
+++ b/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
@@ -18,7 +18,7 @@ use function iterator_to_array;
  */
 final class ExtensionHandlerTest extends TestCase
 {
-    protected function tearDown(): void
+    protected function setUp(): void
     {
         $class = new ReflectionClass(ExtensionHandler::getInstance(
             [

--- a/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
+++ b/tests/unit/phpDocumentor/Extension/ExtensionHandlerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+use function iterator_to_array;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Extension\ExtensionHandler
+ * @covers ::<private>
+ * @covers ::__construct
+ * @covers ::getInstance
+ */
+final class ExtensionHandlerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $class = new ReflectionClass(ExtensionHandler::getInstance(
+            'foo',
+            'bar',
+        ));
+
+        $instance = $class->getProperty('instance');
+        $instance->setAccessible(true);
+        $instance->setValue(null, null);
+        $instance->setAccessible(false);
+    }
+
+    /** @covers ::loadExtensions */
+    public function testLoadExtensionsFromEmptyDirResultsInEmptyExtensions(): void
+    {
+        $root = vfsStream::setup();
+        $root->addChild(vfsStream::newDirectory('extensions'));
+
+        $extensionsDir = $root->url() . '/extensions';
+
+        $extensionHandler = ExtensionHandler::getInstance($extensionsDir);
+
+        $manifests = iterator_to_array($extensionHandler->loadExtensions());
+        self::assertCount(0, $manifests);
+    }
+
+    /** @covers ::loadExtensions */
+    public function testLoadExtensionsFromNonExistingDirResultsInEmptyArray(): void
+    {
+        $root = vfsStream::setup();
+        $root->addChild(vfsStream::newDirectory('extensions'));
+
+        $extensionsDir = $root->url() . '/extensions';
+
+        $extensionHandler = ExtensionHandler::getInstance($extensionsDir . '/notExisting');
+        $manifests = iterator_to_array($extensionHandler->loadExtensions());
+        self::assertCount(0, $manifests);
+    }
+
+    /** @covers ::loadExtensions */
+    public function testLoadExtensionsIgnoresNonPharFiles(): void
+    {
+        $root = vfsStream::setup();
+        $extensionsDir = vfsStream::newDirectory('extensions');
+        $extensionsDir->addChild(vfsStream::newFile('somefile.txt')->withContent('ignore'));
+        $root->addChild($extensionsDir);
+
+        $extensionHandler = ExtensionHandler::getInstance($extensionsDir->url());
+        $manifests = iterator_to_array($extensionHandler->loadExtensions());
+        self::assertCount(0, $manifests);
+    }
+
+    /** @covers ::loadExtensions */
+    public function testLoadExtensionFromDir(): void
+    {
+        $root = vfsStream::setup();
+        $extensionsDir = vfsStream::newDirectory('extensions');
+        vfsStream::copyFromFileSystem(__DIR__ . '/../../../data/extensions', $extensionsDir);
+        $root->addChild($extensionsDir);
+
+        $extensionHandler = ExtensionHandler::getInstance($extensionsDir->url());
+        $manifests = iterator_to_array($extensionHandler->loadExtensions());
+        self::assertCount(1, $manifests);
+    }
+}

--- a/tests/unit/phpDocumentor/Extension/ExtensionInfoTest.php
+++ b/tests/unit/phpDocumentor/Extension/ExtensionInfoTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\ApplicationName;
+use PharIo\Manifest\AuthorCollection;
+use PharIo\Manifest\BundledComponent;
+use PharIo\Manifest\BundledComponentCollection;
+use PharIo\Manifest\CopyrightInformation;
+use PharIo\Manifest\Extension;
+use PharIo\Manifest\License;
+use PharIo\Manifest\Manifest;
+use PharIo\Manifest\RequirementCollection;
+use PharIo\Manifest\Url;
+use PharIo\Version\AnyVersionConstraint;
+use PharIo\Version\Version;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \phpDocumentor\Extension\ExtensionInfo */
+final class ExtensionInfoTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::fromManifest
+     * @covers ::getExtensionClass
+     * @covers ::getVersion
+     * @covers ::getName
+     * @covers ::getNamespace
+     * @covers ::getPath
+     * @covers ::getManifest
+     */
+    public function testExtensionIsCreatedCorrectlyFromManifest(): void
+    {
+        $components = new BundledComponentCollection();
+        $components->add(
+            new BundledComponent(
+                'phpDocumentor\\Example\\ExampleExtension',
+                new Version('1.0.0'),
+            ),
+        );
+
+        $manifest = new Manifest(
+            new ApplicationName('phpDocumentor/example'),
+            new Version('1.0.0'),
+            new Extension(
+                new ApplicationName('phpDocumentor/phpDocumentor'),
+                new AnyVersionConstraint(),
+            ),
+            new CopyrightInformation(
+                new AuthorCollection(),
+                new License('mit', new Url('https://phpdoc.org')),
+            ),
+            new RequirementCollection(),
+            $components,
+        );
+
+        $extension = ExtensionInfo::fromManifest($manifest, 'dir');
+
+        self::assertSame('phpDocumentor/example', $extension->getName());
+        self::assertSame('1.0.0', $extension->getVersion());
+        self::assertSame('phpDocumentor\\Example\\ExampleExtension', $extension->getExtensionClass());
+        self::assertSame('phpDocumentor\\Example\\', $extension->getNamespace());
+        self::assertSame($manifest, $extension->getManifest());
+        self::assertSame('dir', $extension->getPath());
+    }
+}

--- a/tests/unit/phpDocumentor/Extension/ValidatorTest.php
+++ b/tests/unit/phpDocumentor/Extension/ValidatorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Extension;
+
+use PharIo\Manifest\ApplicationName;
+use phpDocumentor\Faker\Faker;
+use phpDocumentor\Version;
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \phpDocumentor\Extension\Validator */
+final class ValidatorTest extends TestCase
+{
+    use Faker;
+
+    /**
+     * @covers ::__construct
+     * @covers ::isValid
+     */
+    public function testValidatesExtensionFor(): void
+    {
+        $application = new ApplicationName('phpDocumentor/other');
+        $version = new Version();
+        $validator = new Validator($application, $version);
+
+        $manifest = $this->faker()->extensionManifest('1.0.0');
+        $extension = ExtensionInfo::fromManifest($manifest, '/extension');
+
+        self::assertFalse($validator->isValid($extension));
+    }
+}

--- a/tests/unit/phpDocumentor/Faker/Provider.php
+++ b/tests/unit/phpDocumentor/Faker/Provider.php
@@ -9,6 +9,17 @@ use League\Flysystem\Adapter\NullAdapter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\MountManager;
 use Mockery as m;
+use PharIo\Manifest\ApplicationName;
+use PharIo\Manifest\AuthorCollection;
+use PharIo\Manifest\BundledComponentCollection;
+use PharIo\Manifest\CopyrightInformation;
+use PharIo\Manifest\Extension;
+use PharIo\Manifest\License;
+use PharIo\Manifest\Manifest;
+use PharIo\Manifest\RequirementCollection;
+use PharIo\Manifest\Url;
+use PharIo\Version\AnyVersionConstraint;
+use PharIo\Version\Version;
 use phpDocumentor\Configuration\ApiSpecification;
 use phpDocumentor\Configuration\Source;
 use phpDocumentor\Configuration\SymfonyConfigFactory;
@@ -220,5 +231,20 @@ final class Provider extends Base
         $parts = $this->generator->words($maxDepth);
 
         return new Fqsen('\\' . implode('\\', $parts));
+    }
+
+    public function extensionManifest(string|null $extensionVersion = null): Manifest
+    {
+        return new Manifest(
+            new ApplicationName('phpDocumentor/extension'),
+            new Version($extensionVersion ?? '1.0.0'),
+            new Extension(new ApplicationName('phpDocumentor/phpDocumentor'), new AnyVersionConstraint()),
+            new CopyrightInformation(
+                new AuthorCollection(),
+                new License('MIT', new Url('https://phpdoc.org/licence')),
+            ),
+            new RequirementCollection(),
+            new BundledComponentCollection(),
+        );
     }
 }


### PR DESCRIPTION
Enable loading of phpdoc extensions. Extensions are based on symfony DI extensions. We do check the manifest.xml for compatibility to ensure we have everything needed.