### PR TITLE
Feat: Add filter for var tags on groups

### DIFF
--- a/data/examples/MariosPizzeria/src/Pizza.php
+++ b/data/examples/MariosPizzeria/src/Pizza.php
@@ -56,6 +56,12 @@ final readonly class Pizza implements Product
      */
     private bool $alwaysTrue = true;
 
+    /**
+     * Properties for NewTest.
+     *
+     * @var float $property1 OneProp
+     * @var float $property2 TwoProp
+     */
     private float $property1, $property2, $property3;
 
     public function getName(): string

--- a/src/phpDocumentor/Compiler/ApiDocumentation/Pass/VarTagModifier.php
+++ b/src/phpDocumentor/Compiler/ApiDocumentation/Pass/VarTagModifier.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Compiler\ApiDocumentation\Pass;
+
+use phpDocumentor\Compiler\ApiDocumentation\ApiDocumentationPass;
+use phpDocumentor\Descriptor\ApiSetDescriptor;
+use phpDocumentor\Descriptor\ClassDescriptor;
+use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\EnumDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ConstantInterface;
+use phpDocumentor\Descriptor\Interfaces\PropertyInterface;
+use phpDocumentor\Descriptor\Tag\VarDescriptor;
+use phpDocumentor\Descriptor\TagDescriptor;
+use phpDocumentor\Descriptor\TraitDescriptor;
+
+use function array_values;
+
+final class VarTagModifier extends ApiDocumentationPass
+{
+    public function getDescription(): string
+    {
+        return 'Filter named var tags for property and constant groups';
+    }
+
+    protected function process(ApiSetDescriptor $subject): ApiSetDescriptor
+    {
+        foreach ($subject->getIndex('classes')->filter(ClassDescriptor::class) as $class) {
+            foreach ($class->getConstants() as $constant) {
+                $this->filterVarTags($constant);
+            }
+
+            foreach ($class->getProperties() as $property) {
+                $this->filterVarTags($property);
+            }
+        }
+
+        foreach ($subject->getIndex('traits')->filter(TraitDescriptor::class) as $class) {
+            foreach ($class->getConstants() as $constant) {
+                $this->filterVarTags($constant);
+            }
+
+            foreach ($class->getProperties() as $property) {
+                $this->filterVarTags($property);
+            }
+        }
+
+        foreach ($subject->getIndex('enums')->filter(EnumDescriptor::class) as $class) {
+            foreach ($class->getConstants() as $constant) {
+                $this->filterVarTags($constant);
+            }
+        }
+
+        return $subject;
+    }
+
+    private function filterVarTags(ConstantInterface|PropertyInterface $descriptor): void
+    {
+        $tags = $descriptor->getTags()->fetch('var', Collection::fromClassString(TagDescriptor::class));
+
+        foreach ($tags->filter(VarDescriptor::class) as $index => $tag) {
+            if ($tag->getVariableName() === '') {
+                continue;
+            }
+
+            if ($tag->getVariableName() === $descriptor->getName()) {
+                continue;
+            }
+
+            unset($tags[$index]);
+        }
+
+        $descriptor->getTags()['var'] = new Collection(array_values($tags->getAll()));
+    }
+}

--- a/src/phpDocumentor/Descriptor/EnumDescriptor.php
+++ b/src/phpDocumentor/Descriptor/EnumDescriptor.php
@@ -30,6 +30,7 @@ use phpDocumentor\Reflection\Type;
 final class EnumDescriptor extends DescriptorAbstract implements EnumInterface
 {
     use Traits\ImplementsInterfaces;
+    use Traits\HasConstants;
     use Traits\HasMethods;
     use Traits\UsesTraits;
 

--- a/src/phpDocumentor/Descriptor/Interfaces/EnumInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/EnumInterface.php
@@ -65,4 +65,10 @@ interface EnumInterface extends ElementInterface, TypeInterface
      * @return Collection<TraitInterface|Fqsen>
      */
     public function getUsedTraits(): Collection;
+
+    /** @param Collection<ConstantInterface> $constants */
+    public function setConstants(Collection $constants): void;
+
+    /** @return Collection<ConstantInterface> */
+    public function getConstants(): Collection;
 }

--- a/tests/unit/phpDocumentor/Compiler/ApiDocumentation/Pass/VarTagModifierTest.php
+++ b/tests/unit/phpDocumentor/Compiler/ApiDocumentation/Pass/VarTagModifierTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Compiler\ApiDocumentation\Pass;
+
+use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Faker\Faker;
+use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
+
+final class VarTagModifierTest extends TestCase
+{
+    use Faker;
+
+    public function testVarTagWithoutNameIsNotFiltered(): void
+    {
+        $constantDescriptor = $this->faker()->constantDescriptor(new Fqsen('\\MyClass::MY_CONSTANT'));
+        $constantDescriptor->getTags()->set('var', new Collection([$this->faker()->varTagDescriptor()]));
+
+        $classDescriptor = $this->faker()->classDescriptor(new Fqsen('\\MyClass'));
+        $classDescriptor->setConstants(new Collection([$constantDescriptor]));
+
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $apiSetDescriptor->getIndex('classes')->set('\\MyClass', $classDescriptor);
+
+        $subject = new VarTagModifier();
+        $subject($apiSetDescriptor);
+
+        self::assertCount(1, $constantDescriptor->getTags()['var']);
+    }
+
+    public function testVarTagWithNameIsFilteredWhenNotMatching(): void
+    {
+        $constantDescriptor = $this->faker()->constantDescriptor(new Fqsen('\\MyClass::MY_CONSTANT'));
+        $constantDescriptor->getTags()->set('var', new Collection([$this->faker()->varTagDescriptor('OTHER_CONST')]));
+
+        $classDescriptor = $this->faker()->classDescriptor(new Fqsen('\\MyClass'));
+        $classDescriptor->setConstants(new Collection([$constantDescriptor]));
+
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $apiSetDescriptor->getIndex('classes')->set('\\MyClass', $classDescriptor);
+
+        $subject = new VarTagModifier();
+        $subject($apiSetDescriptor);
+
+        self::assertCount(0, $constantDescriptor->getTags()['var']);
+    }
+
+    public function testVarTagWithNameIsNotFilteredWhenNameMatches(): void
+    {
+        $constantDescriptor = $this->faker()->constantDescriptor(new Fqsen('\\MyClass::MY_CONSTANT'));
+        $constantDescriptor->getTags()->set('var', new Collection([$this->faker()->varTagDescriptor('MY_CONSTANT')]));
+
+        $classDescriptor = $this->faker()->classDescriptor(new Fqsen('\\MyClass'));
+        $classDescriptor->setConstants(new Collection([$constantDescriptor]));
+
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $apiSetDescriptor->getIndex('classes')->set('\\MyClass', $classDescriptor);
+
+        $subject = new VarTagModifier();
+        $subject($apiSetDescriptor);
+
+        self::assertCount(1, $constantDescriptor->getTags()['var']);
+    }
+
+    public function testVarTagForClassPropertiesAreFiltered(): void
+    {
+        $propertyDescriptor = $this->faker()->propertyDescriptor(new Fqsen('\\MyClass::$myProperty'));
+        $propertyDescriptor->getTags()->set('var', new Collection([
+            $this->faker()->varTagDescriptor('$foo'),
+            $this->faker()->varTagDescriptor('myProperty'),
+        ]));
+
+        $classDescriptor = $this->faker()->classDescriptor(new Fqsen('\\MyClass'));
+        $classDescriptor->setProperties(new Collection([$propertyDescriptor]));
+
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $apiSetDescriptor->getIndex('classes')->set('\\MyClass', $classDescriptor);
+
+        $subject = new VarTagModifier();
+        $subject($apiSetDescriptor);
+
+        self::assertCount(1, $propertyDescriptor->getTags()['var']);
+    }
+
+    public function testVarTagsForEnumConstantsAreFiltered(): void
+    {
+        $constantDescriptor = $this->faker()->constantDescriptor(new Fqsen('\\MyEnum::MY_CONSTANT'));
+        $constantDescriptor->getTags()->set('var', new Collection([
+            $this->faker()->varTagDescriptor('$foo'),
+            $this->faker()->varTagDescriptor('MY_CONSTANT'),
+        ]));
+
+        $enumDescriptor = $this->faker()->enumDescriptor(new Fqsen('\\MyEnum'));
+        $enumDescriptor->setConstants(new Collection([$constantDescriptor]));
+
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $apiSetDescriptor->getIndex('enums')->set('\\MyEnum', $enumDescriptor);
+
+        $subject = new VarTagModifier();
+        $subject($apiSetDescriptor);
+
+        self::assertCount(1, $constantDescriptor->getTags()['var']);
+    }
+
+    public function testVarTagsForTraitConstantsAreFiltered(): void
+    {
+        $constantDescriptor = $this->faker()->constantDescriptor(new Fqsen('\\MyTrait::MY_CONSTANT'));
+        $constantDescriptor->getTags()->set('var', new Collection([
+            $this->faker()->varTagDescriptor('$foo'),
+            $this->faker()->varTagDescriptor('MY_CONSTANT'),
+        ]));
+
+        $traitDescriptor = $this->faker()->traitDescriptor(new Fqsen('\\MyTrait'));
+        $traitDescriptor->setConstants(new Collection([$constantDescriptor]));
+
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $apiSetDescriptor->getIndex('traits')->set('\\MyTrait', $traitDescriptor);
+
+        $subject = new VarTagModifier();
+        $subject($apiSetDescriptor);
+
+        self::assertCount(1, $constantDescriptor->getTags()['var']);
+    }
+
+    public function testVarTagsForTraitPropertiesAreFiltered(): void
+    {
+        $propertyDescriptor = $this->faker()->propertyDescriptor(new Fqsen('\\MyTrait::$myProperty'));
+        $propertyDescriptor->getTags()->set('var', new Collection([
+            $this->faker()->varTagDescriptor('$foo'),
+            $this->faker()->varTagDescriptor('myProperty'),
+        ]));
+
+        $traitDescriptor = $this->faker()->traitDescriptor(new Fqsen('\\MyTrait'));
+        $traitDescriptor->setProperties(new Collection([$propertyDescriptor]));
+
+        $apiSetDescriptor = $this->faker()->apiSetDescriptor();
+        $apiSetDescriptor->getIndex('traits')->set('\\MyTrait', $traitDescriptor);
+
+        $subject = new VarTagModifier();
+        $subject($apiSetDescriptor);
+
+        self::assertCount(1, $propertyDescriptor->getTags()['var']);
+    }
+}

--- a/tests/unit/phpDocumentor/Faker/Provider.php
+++ b/tests/unit/phpDocumentor/Faker/Provider.php
@@ -26,11 +26,22 @@ use phpDocumentor\Configuration\SymfonyConfigFactory;
 use phpDocumentor\Descriptor\ApiSetDescriptor;
 use phpDocumentor\Descriptor\ClassDescriptor;
 use phpDocumentor\Descriptor\Collection as DescriptorCollection;
+use phpDocumentor\Descriptor\ConstantDescriptor;
 use phpDocumentor\Descriptor\DocumentationSetDescriptor;
+use phpDocumentor\Descriptor\EnumDescriptor;
 use phpDocumentor\Descriptor\FileDescriptor;
 use phpDocumentor\Descriptor\GuideSetDescriptor;
+use phpDocumentor\Descriptor\Interfaces\ClassInterface;
+use phpDocumentor\Descriptor\Interfaces\ConstantInterface;
+use phpDocumentor\Descriptor\Interfaces\EnumInterface;
+use phpDocumentor\Descriptor\Interfaces\PropertyInterface;
+use phpDocumentor\Descriptor\Interfaces\TraitInterface;
 use phpDocumentor\Descriptor\NamespaceDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor;
+use phpDocumentor\Descriptor\PropertyDescriptor;
+use phpDocumentor\Descriptor\Tag\VarDescriptor;
+use phpDocumentor\Descriptor\TagDescriptor;
+use phpDocumentor\Descriptor\TraitDescriptor;
 use phpDocumentor\Descriptor\VersionDescriptor;
 use phpDocumentor\Dsn;
 use phpDocumentor\Parser\FlySystemFactory;
@@ -217,13 +228,57 @@ final class Provider extends Base
         return $rootNamespace;
     }
 
-    public function classDescriptor(Fqsen $fqsen): ClassDescriptor
+    public function classDescriptor(Fqsen $fqsen): ClassInterface
     {
         $classDescriptor = new ClassDescriptor();
         $classDescriptor->setName($fqsen->getName());
         $classDescriptor->setFullyQualifiedStructuralElementName($fqsen);
 
         return $classDescriptor;
+    }
+
+    public function enumDescriptor(Fqsen $fqsen): EnumInterface
+    {
+        $enumDescriptor = new EnumDescriptor();
+        $enumDescriptor->setName($fqsen->getName());
+        $enumDescriptor->setFullyQualifiedStructuralElementName($fqsen);
+
+        return $enumDescriptor;
+    }
+
+    public function traitDescriptor(Fqsen $fqsen): TraitInterface
+    {
+        $traitDescriptor = new TraitDescriptor();
+        $traitDescriptor->setName($fqsen->getName());
+        $traitDescriptor->setFullyQualifiedStructuralElementName($fqsen);
+
+        return $traitDescriptor;
+    }
+
+    public function constantDescriptor(Fqsen $fqsen): ConstantInterface
+    {
+        $constantDescriptor = new ConstantDescriptor();
+        $constantDescriptor->setName($fqsen->getName());
+        $constantDescriptor->setFullyQualifiedStructuralElementName($fqsen);
+
+        return $constantDescriptor;
+    }
+
+    public function propertyDescriptor(Fqsen $param): PropertyInterface
+    {
+        $propertyDescriptor = new PropertyDescriptor();
+        $propertyDescriptor->setName($param->getName());
+        $propertyDescriptor->setFullyQualifiedStructuralElementName($param);
+
+        return $propertyDescriptor;
+    }
+
+    public function varTagDescriptor(string $variableName = ''): TagDescriptor
+    {
+        $varTag = new VarDescriptor('var');
+        $varTag->setVariableName($variableName);
+
+        return $varTag;
     }
 
     public function fqsen($maxDepth = 3): Fqsen


### PR DESCRIPTION
We do allow multiple var tags in a docblock, this is usefull when multiple properties or constants are defined in the same line. This patch will introduce filtering by variable name on those tags. this will allow users to define multiple var tags and reference specific properties or constants to document them.

fixes: #2441 
fixes: #885