### PR TITLE
Fix wrong value for visibility option in XSD

### DIFF
--- a/data/xsd/phpdoc.xsd
+++ b/data/xsd/phpdoc.xsd
@@ -28,7 +28,7 @@
             <xs:enumeration value="public"/>
             <xs:enumeration value="protected"/>
             <xs:enumeration value="private"/>
-            <xs:enumeration value="hidden"/>
+            <xs:enumeration value="internal"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
The phpDocumentor command line helper says, that the parameter `visibility` allows the following values:

`api`, `public`, `protected`, `private`, `internal`.

But the configuration XSD enumerates the following values as valid options:

`api`, `public`, `protected`, `private`, `hidden`.

So `internal` is missing from the XSD and using `hidden` actually leads to an error.

This pull requests fixes this issue by replacing `hidden` with `internal` in the XSD.

(I already opened a pull request for this issue [#3663], but that was marked as "merged" although is wasn't.)