### PR TITLE
Small improvements to guide rendering

### DIFF
--- a/data/templates/default/components/class-title.html.twig
+++ b/data/templates/default/components/class-title.html.twig
@@ -29,7 +29,7 @@
 
     {% if node.usedTraits is not empty %}
         <span class="phpdocumentor-element__extends">
-            Uses
+            uses
             {% for trait in node.usedTraits %}
                 {{ trait|route('class:short') }}{% if not loop.last %}, {% endif %}
             {% endfor %}

--- a/data/templates/default/components/enum-title.html.twig
+++ b/data/templates/default/components/enum-title.html.twig
@@ -29,7 +29,7 @@
 
     {% if node.usedTraits is not empty %}
         <span class="phpdocumentor-element__extends">
-            Uses
+            uses
             {% for trait in node.usedTraits %}
                 {{ trait|route('class:short') }}{% if not loop.last %}, {% endif %}
             {% endfor %}

--- a/data/templates/default/components/property.html.twig
+++ b/data/templates/default/components/property.html.twig
@@ -22,5 +22,5 @@
     {{ include('components/property-signature.html.twig', {'node': property}) }}
     {{ include('components/description.html.twig', {'node': property}) }}
     {{ include('components/description.html.twig', {'node': property.var[0]}) }}
-    {{ include ('components/tags.html.twig', {'node': property}) }}
+    {{ include('components/tags.html.twig', {'node': property}) }}
 </article>

--- a/data/templates/default/components/sidebar.html.twig
+++ b/data/templates/default/components/sidebar.html.twig
@@ -5,8 +5,8 @@
 <aside class="phpdocumentor-column -three phpdocumentor-sidebar">
     {% for version in project.versions %}
         {% for toc in version.tableOfContents %}
-            <h2 class="phpdocumentor-sidebar__category-header">{{ toc.name }}</h2>
         <section class="phpdocumentor-sidebar__category -{{ toc.name|lower }}">
+            <h2 class="phpdocumentor-sidebar__category-header">{{ toc.name|title }}</h2>
                 {% for root in toc.roots %}
                     {{ toc(root, 'components/menu.html.twig', 1) }}
                 {% endfor %}

--- a/data/templates/default/components/sidebar.html.twig
+++ b/data/templates/default/components/sidebar.html.twig
@@ -5,8 +5,8 @@
 <aside class="phpdocumentor-column -three phpdocumentor-sidebar">
     {% for version in project.versions %}
         {% for toc in version.tableOfContents %}
-        <section class="phpdocumentor-sidebar__category">
             <h2 class="phpdocumentor-sidebar__category-header">{{ toc.name }}</h2>
+        <section class="phpdocumentor-sidebar__category -{{ toc.name|lower }}">
                 {% for root in toc.roots %}
                     {{ toc(root, 'components/menu.html.twig', 1) }}
                 {% endfor %}
@@ -14,7 +14,7 @@
         {% endfor %}
     {% endfor %}
 
-    <section class="phpdocumentor-sidebar__category">
+    <section class="phpdocumentor-sidebar__category -reports">
         <h2 class="phpdocumentor-sidebar__category-header">Reports</h2>
         {% if project.settings.custom['graphs.enabled'] %}
         <h3 class="phpdocumentor-sidebar__root-package"><a href="graphs/classes.html">Class Diagram</a></h3>
@@ -24,7 +24,7 @@
         <h3 class="phpdocumentor-sidebar__root-package"><a href="reports/markers.html">Markers</a></h3>
     </section>
 
-    <section class="phpdocumentor-sidebar__category">
+    <section class="phpdocumentor-sidebar__category -indices">
         <h2 class="phpdocumentor-sidebar__category-header">Indices</h2>
         <h3 class="phpdocumentor-sidebar__root-package"><a href="indices/files.html">Files</a></h3>
     </section>

--- a/data/templates/default/components/trait-title.html.twig
+++ b/data/templates/default/components/trait-title.html.twig
@@ -2,7 +2,7 @@
     {{ node.name }}
     {% if node.usedTraits is not empty %}
         <span class="phpdocumentor-trait__extends">
-            Uses
+            uses
             {% for trait in node.usedTraits %}
                 {{ trait|route('trait:short') }}{% if not loop.last %}, {% endif %}
             {% endfor %}

--- a/data/templates/default/objects/lists.css.twig
+++ b/data/templates/default/objects/lists.css.twig
@@ -16,7 +16,7 @@ div.phpdocumentor-list > ul,
 ol.phpdocumentor-list,
 ul.phpdocumentor-list {
     margin-top: 0;
-    padding-left: var(--spacing-md);
+    padding-left: var(--spacing-lg);
     margin-bottom: var(--spacing-sm);
 }
 


### PR DESCRIPTION
This fixes a few issues with rendering, especially for guides:

- The default left padding for list items is `var(--spacing-md)` which unfortunately looks awful, because it gives all list bullet points a small negative indentation compared to text paragraphs. I've therefore increased the left padding to `var(--spacing-lg)` which looks a lot better in my opinion.
- By default the guide section in the sidebar is named "documentation" (with a lowercase first letter) while all other sections have an uppercase first letter. To unify the look and feel I've added twig's [`title`](https://twig.symfony.com/doc/2.x/filters/title.html) filter to the `sidebar.html.twig` template. Now all section headers start with uppercase letters.
- I also unified the "implements", "extends" and "uses" statements for classes, traits and enums, because all of them were lowercase except for "Uses". I've now changed that to lowercase as well.
- All sidebar sections got an additional unique class assigned to them. In default configuration this does nothing, but it allows for example easy custom re-ordering of the sections by simple CSS (using `display: flex;` and `flex-direction: column;` on the sidebar itself and `order: X;` on each section).

There is one more major annoyance in the rendering of guides which I couldn't fix because I am not an expert with how RST rendering works:

- For the API documentation the header hierarchy for content starts with `h2`, but for guides it always starts with `h1`, which makes it very hard to have the same look and feel for both. I didn't find any way to tell RST to make the highest hierarchy heading a `h2` instead of `h1`.