### PR TITLE
Fix Psalm issue

### DIFF
--- a/src/phpDocumentor/Descriptor/Traits/ImplementsInterfaces.php
+++ b/src/phpDocumentor/Descriptor/Traits/ImplementsInterfaces.php
@@ -49,6 +49,7 @@ trait ImplementsInterfaces
         return $this->implements;
     }
 
+    /** @return Collection<InterfaceInterface|Fqsen> */
     public function getInterfacesIncludingInherited(): Collection
     {
         $interfaces = $this->getInterfaces();


### PR DESCRIPTION
Currently Psalm reports the following issue on `master`:

> Error: src/phpDocumentor/Descriptor/Traits/ImplementsInterfaces.php:52:56: LessSpecificImplementedReturnType: The inherited return type 'phpDocumentor\Descriptor\Collection<phpDocumentor\Descriptor\Interfaces\InterfaceInterface|phpDocumentor\Reflection\Fqsen>' for phpDocumentor\Descriptor\Interfaces\ClassInterface::getInterfacesIncludingInherited is more specific than the implemented return type for phpDocumentor\Descriptor\Traits\ImplementsInterfaces::getinterfacesincludinginherited 'phpDocumentor\Descriptor\Collection' (see https://psalm.dev/166)

This PR should fix this by declaring a more specific return type for this method.