### PR TITLE
Add CSS background colour for body

### DIFF
--- a/data/templates/default/css/base.css.twig
+++ b/data/templates/default/css/base.css.twig
@@ -13,6 +13,7 @@
 /* Base Styles
 -------------------------------------------------- */
 body {
+    background-color: #fff;
     color: var(--text-color);
     font-family: var(--font-primary);
     font-size: var(--text-md);


### PR DESCRIPTION
As text is defined, but background was not.
Most developers assume every browser has the same default colors, e.g. white for background.
But actually users can alter those colors, and only changing one color will end up in a hard to read result.

Therefore the background color is now explicitly set to the expected white defaults.

Resolves #3679