### PR TITLE
Changing GitHub Action entrypoint format

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,4 +15,4 @@
   runs:
     using: 'docker'
     image: 'Dockerfile'
-    entrypoint: ["/opt/phpdoc/bin/githubaction"]
+    entrypoint: '/opt/phpdoc/bin/githubaction'


### PR DESCRIPTION
The entrypoint format in `action.yml` was wrong, which would cause this error when trying to use it in an workflow:

 ```
Error: phpDocumentor/phpDocumentor/master/action.yml (Line: 18, Col: 17): A sequence was not expected
Error: System.ArgumentException: Unexpected type 'SequenceToken' encountered while reading 'entrypoint'. The type 'StringToken' was expected.
   at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertString(TemplateToken value, String objectDescription)
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Failed to load phpDocumentor/phpDocumentor/master/action.yml
```