### PR TITLE
Checking if the template location was provided before parsing it

### DIFF
--- a/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
+++ b/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
@@ -87,7 +87,7 @@ final class PathNormalizingMiddleware implements MiddlewareInterface
 
         /** @var array{name: string, location?: ?Path, parameters?: array<string, mixed>} $template */
         foreach ($configuration['phpdocumentor']['templates'] as $key => $template) {
-            if (!isset($template['location'])) {
+            if (isset($template['location']) === false) {
                 continue;
             }
 

--- a/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
+++ b/src/phpDocumentor/Configuration/PathNormalizingMiddleware.php
@@ -87,6 +87,10 @@ final class PathNormalizingMiddleware implements MiddlewareInterface
 
         /** @var array{name: string, location?: ?Path, parameters?: array<string, mixed>} $template */
         foreach ($configuration['phpdocumentor']['templates'] as $key => $template) {
+            if (!isset($template['location'])) {
+                continue;
+            }
+
             $location = $template['location'];
             if ($location instanceof Path && SymfonyPath::isAbsolute((string) $location) === false) {
                 $location = new Path($configPath . '/' . $location);


### PR DESCRIPTION
Checking if the `location` was provided before normalizing the path, in order to fix the error below.

```shell
$ phpdoc --template=default 
PHP Warning:  Undefined array key "location" in src/phpDocumentor/Configuration/PathNormalizingMiddleware.php on line 90
PHP Stack trace:
PHP   1. {main}() bin/phpdoc:0
PHP   2. Symfony\Component\Console\Application->run($input = *uninitialized*, $output = *uninitialized*) bin/phpdoc:14
```

