### PR TITLE
[DOCS] Fix generating-documentation.rst

### DIFF
--- a/docs/getting-started/generating-documentation.rst
+++ b/docs/getting-started/generating-documentation.rst
@@ -34,7 +34,7 @@ For example:
 
 .. code-block:: shell-session
 
-    $ phpdoc -d ./src -t ./docs/api
+    $ phpdoc run -d ./src -t ./docs/api
 
 What the above example does, is scan all files in the ``src`` directory and its subdirectories, perform
 an analysis and generate a website containing the documentation in the folder ``docs/api``. If you want,


### PR DESCRIPTION
You need to add `run` or `project:run` in order to generate documentation.