### PR TITLE
fix: typo in CI docs

### DIFF
--- a/docs/guides/continuous-integration.rst
+++ b/docs/guides/continuous-integration.rst
@@ -1,11 +1,11 @@
 =====================
-Continues Integration
+Continuous Integration
 =====================
 
-Just like any other application component your documentation can be build automatically using a continues
-integration service. This is a great way to ensure that your documentation is always up to date and that
+Just like any other application component your documentation can be build automatically using a continuous
+continuous service. This is a great way to ensure that your documentation is always up to date and that
 it is build correctly. This chapter will show you how to use phpDocumentor in combination with different
-continues integration services.
+continuous integration services.
 
 GitHub Actions
 ==============

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -8,4 +8,4 @@ Guides
    docblocks
    types
    inheritance
-   continues-integration
+   continuous-integration


### PR DESCRIPTION
Replaces "continues" with "continuous" in the CI docs including a filename refactor.