### PR TITLE
Remove note about future v3 release

### DIFF
--- a/docs/internals/project-management.rst
+++ b/docs/internals/project-management.rst
@@ -13,9 +13,7 @@ Project Management
 Release schedule
 ----------------
 
-While writing this document, the team has no set release schedule as it is focusing on getting phpDocumentor 3 released.
-This version includes significant architectural changes; meaning that it is highly unpredictable when it can be
-released. As soon as phpDocumentor 3 is released, the team can review and change how they can setup a release schedule.
+TODO: The team can review and change how they can setup a release schedule.
 
 Workflows
 ---------


### PR DESCRIPTION
We can merge this now.

And then later we can do even better by creating a new release policy.