### PR TITLE
Fix issue with inheritance order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,13 +112,13 @@ unit-test integration-test functional-test:
 
 .PHONY: e2e-test
 e2e-test: node_modules/.bin/cypress build/default/index.html build/clean/index.html
-	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:10.3.0
+	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:13.8.1
 
 cypress/integration/default/%.spec.js: node_modules/.bin/cypress build/default/index.html .RUN_ALWAYS
-	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:10.3.0 -s $@
+	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:13.8.1 -s $@
 
 cypress/integration/clean/%.spec.js: node_modules/.bin/cypress build/clean/index.html .RUN_ALWAYS
-	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:10.3.0 -s $@
+	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:13.8.1 -s $@
 
 .PHONY: composer-require-checker
 composer-require-checker:

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "league/uri": "^6.7",
         "league/uri-interfaces": "^2.0",
         "monolog/monolog": "^2.9",
-        "nikic/php-parser": "^4.19",
+        "nikic/php-parser": "^5.0",
         "phar-io/manifest": "^2.0",
         "phar-io/version": "^3.2",
         "phpdocumentor/flyfinder": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e9b29cf9c19b96388b66afd87bca339",
+    "content-hash": "963ba869144c4c36338077928f5e75fd",
     "packages": [
         {
             "name": "cypresslab/php-curry",
@@ -1436,25 +1436,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.1",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -1462,7 +1464,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1486,9 +1488,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
             },
-            "time": "2024-03-17T08:10:35+00:00"
+            "time": "2024-03-05T20:51:40+00:00"
         },
         {
             "name": "parsica-php/parsica",
@@ -2011,16 +2013,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/Reflection.git",
-                "reference": "aee9e26834c520eb53644f77015cd4d37df2d358"
+                "reference": "05240bf3e4786081c99d91537c8a5b8b088fcd34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/aee9e26834c520eb53644f77015cd4d37df2d358",
-                "reference": "aee9e26834c520eb53644f77015cd4d37df2d358",
+                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/05240bf3e4786081c99d91537c8a5b8b088fcd34",
+                "reference": "05240bf3e4786081c99d91537c8a5b8b088fcd34",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "~4.14",
+                "nikic/php-parser": "~4.18 || ^5.0",
                 "php": "8.1.*|8.2.*|8.3.*",
                 "phpdocumentor/reflection-common": "^2.1",
                 "phpdocumentor/reflection-docblock": "^5",
@@ -2036,12 +2038,11 @@
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-php-parser": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
-                "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.18.0",
-                "squizlabs/php_codesniffer": "^3.8",
-                "vimeo/psalm": "^5.0"
+                "phpunit/phpunit": "^10.0",
+                "psalm/phar": "^5.24",
+                "rector/rector": "^1.0.0",
+                "squizlabs/php_codesniffer": "^3.8"
             },
             "default-branch": true,
             "type": "library",
@@ -2072,7 +2073,7 @@
                 "issues": "https://github.com/phpDocumentor/Reflection/issues",
                 "source": "https://github.com/phpDocumentor/Reflection/tree/6.x"
             },
-            "time": "2024-01-05T08:10:26+00:00"
+            "time": "2024-05-07T15:16:45+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,7 +6,6 @@ module.exports = defineConfig({
         supportFile: false,
         specPattern: "**/*.spec.js",
         retries: 2,
-        videoUploadOnPasses: false,
         defaultCommandTimeout: 10000
     }
 })

--- a/cypress/integration/default/methods.spec.js
+++ b/cypress/integration/default/methods.spec.js
@@ -319,3 +319,46 @@ describe('Showing methods for an interface', function() {
         })
     });
 });
+
+describe('Showing methods for class with parent', function() {
+    beforeEach(function () {
+        cy.visit('build/default/classes/Marios-Pizza-Toppings-Pepperoni.html');
+    });
+
+    describe('Synopsis', function() {
+        it('Show the name', function () {
+            getElementWithName('method', 'publiclyAvailable()')
+                .should('be.visible');
+        });
+
+        it('Show the file name where the method points to parent class', function () {
+            getElementWithName('method', 'availableToAll()')
+                .find('.phpdocumentor-element-found-in__file')
+                .contains('a', 'Topping.php')
+                .find('abbr')
+                .should('have.attr', 'title', 'src/Pizza/Topping.php');
+        });
+
+        it('Links to the file documentation wherein the method points to parrent class', function () {
+            getElementWithName('method', 'availableToAll()')
+                .find('.phpdocumentor-element-found-in__file')
+                .contains('a', 'Topping.php')
+                .should('have.attr', 'href', 'files/src-pizza-topping.html');
+        });
+
+        it('Show the file name where the method points to current class', function () {
+            getElementWithName('method', 'publiclyAvailable()')
+                .find('.phpdocumentor-element-found-in__file')
+                .contains('a', 'Pepperoni.php')
+                .find('abbr')
+                .should('have.attr', 'title', 'src/Pizza/Toppings/Pepperoni.php');
+        });
+
+        it('Links to the file documentation wherein the method points to current class', function () {
+            getElementWithName('method', 'publiclyAvailable()')
+                .find('.phpdocumentor-element-found-in__file')
+                .contains('a', 'Pepperoni.php')
+                .should('have.attr', 'href', 'files/src-pizza-toppings-pepperoni.html');
+        });
+    });
+});

--- a/data/examples/MariosPizzeria/src/Pizza/Toppings/Pepperoni.php
+++ b/data/examples/MariosPizzeria/src/Pizza/Toppings/Pepperoni.php
@@ -8,5 +8,8 @@ use Marios\Pizza\Topping;
 
 final class Pepperoni extends Topping
 {
+    public function publiclyAvailable()
+    {
 
+    }
 }

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -245,16 +245,16 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
                 'methods',
                 static function (DescriptorAbstract $descriptor): Collection {
                     $methods = new Collection();
-                    if (method_exists($descriptor, 'getInheritedMethods')) {
-                        $methods = $methods->merge($descriptor->getInheritedMethods());
+                    if (method_exists($descriptor, 'getMethods')) {
+                        $methods = $methods->merge($descriptor->getMethods());
                     }
 
                     if (method_exists($descriptor, 'getMagicMethods')) {
                         $methods = $methods->merge($descriptor->getMagicMethods());
                     }
 
-                    if (method_exists($descriptor, 'getMethods')) {
-                        $methods = $methods->merge($descriptor->getMethods());
+                    if (method_exists($descriptor, 'getInheritedMethods')) {
+                        $methods = $methods->merge($descriptor->getInheritedMethods());
                     }
 
                     return $methods;
@@ -264,16 +264,16 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
                 'properties',
                 static function (DescriptorAbstract $descriptor): Collection {
                     $properties = new Collection();
-                    if (method_exists($descriptor, 'getInheritedProperties')) {
-                        $properties = $properties->merge($descriptor->getInheritedProperties());
+                    if (method_exists($descriptor, 'getProperties')) {
+                        $properties = $properties->merge($descriptor->getProperties());
                     }
 
                     if (method_exists($descriptor, 'getMagicProperties')) {
                         $properties = $properties->merge($descriptor->getMagicProperties());
                     }
 
-                    if (method_exists($descriptor, 'getProperties')) {
-                        $properties = $properties->merge($descriptor->getProperties());
+                    if (method_exists($descriptor, 'getInheritedProperties')) {
+                        $properties = $properties->merge($descriptor->getInheritedProperties());
                     }
 
                     return $properties;
@@ -283,16 +283,16 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
                 'constants',
                 static function (DescriptorAbstract $descriptor): Collection {
                     $constants = new Collection();
-                    if (method_exists($descriptor, 'getInheritedConstants')) {
-                        $constants = $constants->merge($descriptor->getInheritedConstants());
+                    if (method_exists($descriptor, 'getConstants')) {
+                        $constants = $constants->merge($descriptor->getConstants());
                     }
 
                     if (method_exists($descriptor, 'getMagicConstants')) {
                         $constants = $constants->merge($descriptor->getMagicConstants());
                     }
 
-                    if (method_exists($descriptor, 'getConstants')) {
-                        $constants = $constants->merge($descriptor->getConstants());
+                    if (method_exists($descriptor, 'getInheritedConstants')) {
+                        $constants = $constants->merge($descriptor->getInheritedConstants());
                     }
 
                     return $constants;
@@ -312,12 +312,12 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
                 'attributes',
                 static function (DescriptorAbstract $descriptor): Collection {
                     $attributes = new Collection();
-                    if (method_exists($descriptor, 'getInheritedAttributes')) {
-                        $attributes = $attributes->merge($descriptor->getInheritedAttributes());
-                    }
-
                     if (method_exists($descriptor, 'getAttributes')) {
                         $attributes = $attributes->merge($descriptor->getAttributes());
+                    }
+
+                    if (method_exists($descriptor, 'getInheritedAttributes')) {
+                        $attributes = $attributes->merge($descriptor->getInheritedAttributes());
                     }
 
                     return $attributes;


### PR DESCRIPTION
Methods were merged in the wrong order, we want methods to be used from the current class if they exist, if they are inherited from a parent class the method should be shown as implemented in the parent.

The aditional changes are fixing cypress locally and solving php 8.3 compatibility.