### PR TITLE
Add support for #[Deprecated]

### DIFF
--- a/data/templates/default/class.html.twig
+++ b/data/templates/default/class.html.twig
@@ -42,7 +42,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li class="{% if constant.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -53,7 +53,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for property in properties|sortByVisibility %}
-                            <li><a href="{{ link(property) }}">${{ property.name }}<a href="{{ link(node) }}"></li>
+                            <li class="{% if property.deprecated %}-deprecated{% endif %}"><a href="{{ link(property) }}">${{ property.name }}</li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -64,7 +64,7 @@
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for method in methods|sortByVisibility %}
-                        <li><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                        <li class="{% if method.deprecated %}-deprecated{% endif %}"><a href="{{ link(method) }}">{{ method.name }}()</a></li>
                     {% endfor %}
                 </ul>
             </li>

--- a/data/templates/default/components/attributes.html.twig
+++ b/data/templates/default/components/attributes.html.twig
@@ -1,4 +1,4 @@
-{% set attributes = attributes(node)|sortByVisibility %}
+{% set attributes = attributes(node)|specializedAttributes|sortByVisibility %}
 
 {% if attributes is not empty %}
     <section class="phpdocumentor-attributes">

--- a/data/templates/default/components/constant.html.twig
+++ b/data/templates/default/components/constant.html.twig
@@ -6,6 +6,7 @@
 
     {{ include('components/element-found-in.html.twig', {'node': constant}) }}
     {{ include('components/summary.html.twig', {'node': constant}) }}
+    {{ include('components/deprecation.html.twig', {'node': constant}) }}
     {{ include('components/constant-signature.html.twig', {'node': constant}) }}
 
     {{ include('components/description.html.twig', {'node': constant}) }}

--- a/data/templates/default/components/deprecation.html.twig
+++ b/data/templates/default/components/deprecation.html.twig
@@ -1,0 +1,10 @@
+{% if node.deprecated %}
+    {% for deprecation in node.deprecations %}
+        <div class="phpdocumentor-admonition">
+        <svg class="phpdocumentor-admonition__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
+            <article>
+                {{ deprecation.description|description|markdown}}
+            </article>
+        </div>
+    {% endfor %}
+{% endif %}

--- a/data/templates/default/components/element-header.html.twig
+++ b/data/templates/default/components/element-header.html.twig
@@ -1,4 +1,5 @@
 {{ include('components/summary.html.twig') }}
+{{ include('components/deprecation.html.twig') }}
 {{ include('components/description.html.twig') }}
 {{ include('components/tags.html.twig', {node: node}) }}
 {{ include('components/attributes.html.twig') }}

--- a/data/templates/default/components/enum-case.html.twig
+++ b/data/templates/default/components/enum-case.html.twig
@@ -10,6 +10,7 @@
     </h4>
     {{ include('components/element-found-in.html.twig', {'node': case}) }}
     {{ include('components/summary.html.twig', {'node': case}) }}
+    {{ include('components/deprecation.html.twig', {'node': case}) }}
     {{ include('components/description.html.twig', {'node': case}) }}
     {{ include('components/description.html.twig', {'node': case.var[0]}) }}
     {{ include ('components/tags.html.twig', {'node': case}) }}

--- a/data/templates/default/components/function.html.twig
+++ b/data/templates/default/components/function.html.twig
@@ -5,6 +5,7 @@
     </h4>
     {{ include('components/element-found-in.html.twig', {'node': function}) }}
     {{ include('components/summary.html.twig', {'node': function}) }}
+    {{ include('components/deprecation.html.twig', {'node': function}) }}
     {{ include('components/method-signature.html.twig', {'node': function}) }}
     {{ include('components/description.html.twig', {'node': function}) }}
     {{ include('components/method-arguments.html.twig', {'node': function}) }}

--- a/data/templates/default/components/method.html.twig
+++ b/data/templates/default/components/method.html.twig
@@ -20,6 +20,7 @@
         {{ include('components/label.html.twig', {name: 'API', value: 'Yes'}, with_context = false) }}
     {% endif %}
     </div>
+    {{ include('components/deprecation.html.twig', {'node': method}) }}
     {{ include('components/description.html.twig', {'node': method}) }}
     {{ include('components/method-arguments.html.twig', {'node': method}) }}
     {{ include('components/tags.html.twig', {'node': method }) }}

--- a/data/templates/default/components/on-this-page.css.twig
+++ b/data/templates/default/components/on-this-page.css.twig
@@ -52,4 +52,8 @@
         word-break: break-all;
         line-height: normal;
     }
+
+    .phpdocumentor-on-this-page__content li.-deprecated {
+        text-decoration: line-through;
+    }
 }

--- a/data/templates/default/components/property.html.twig
+++ b/data/templates/default/components/property.html.twig
@@ -19,6 +19,7 @@
     </h4>
     {{ include('components/element-found-in.html.twig', {'node': property}) }}
     {{ include('components/summary.html.twig', {'node': property}) }}
+    {{ include('components/deprecation.html.twig', {'node': property}) }}
     {{ include('components/property-signature.html.twig', {'node': property}) }}
     {{ include('components/description.html.twig', {'node': property}) }}
     {{ include('components/description.html.twig', {'node': property.var[0]}) }}

--- a/data/templates/default/components/table-of-contents-entry.html.twig
+++ b/data/templates/default/components/table-of-contents-entry.html.twig
@@ -1,5 +1,5 @@
 <dt class="phpdocumentor-table-of-contents__entry -{{ type }} -{{ node.visibility }}">
-    <a href="{{ link(node) }}">{{ node is property ? '$' }}{{ node.name }}{{ node is method or node is function ? '()' }}</a>
+    <a class="{% if node.deprecated %}-deprecated{% endif %}" href="{{ link(node) }}">{{ node is property ? '$' }}{{ node.name }}{{ node is method or node is function ? '()' }}</a>
     <span>
         {% if node is constant %}&nbsp;= {{ node.value }}{% endif %}
         {% if node is enumCase %}{% if node.value %}&nbsp;= {{ node.value }}{% endif %}{% endif %}

--- a/data/templates/default/components/table-of-contents.css.twig
+++ b/data/templates/default/components/table-of-contents.css.twig
@@ -13,6 +13,10 @@
     flex: 0 1 auto;
 }
 
+.phpdocumentor-table-of-contents .phpdocumentor-table-of-contents__entry > a.-deprecated {
+    text-decoration: line-through;
+}
+
 .phpdocumentor-table-of-contents .phpdocumentor-table-of-contents__entry > span {
     flex: 1;
     white-space: nowrap;

--- a/data/templates/default/components/tags.html.twig
+++ b/data/templates/default/components/tags.html.twig
@@ -1,4 +1,4 @@
-{% set tags = node.tags|filter((v,k) => k not in ['var', 'param', 'property', 'property-read', 'property-write', 'method', 'return', 'package', 'api']) %}
+{% set tags = node.tags|filter((v,k) => k not in ['var', 'param', 'property', 'property-read', 'property-write', 'method', 'return', 'package', 'api', 'deprecated']) %}
 
 {% if tags|length > 0 and tags|first|length > 0 %}
     <h5 class="phpdocumentor-tag-list__heading" id="tags">

--- a/data/templates/default/enum.html.twig
+++ b/data/templates/default/enum.html.twig
@@ -38,7 +38,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for case in cases %}
-                            <li><a href="{{ link(case) }}">{{ case.name }}</a></li>
+                            <li class="{% if case.deprecated %}-deprecated{% endif %}"><a href="{{ link(case) }}">{{ case.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -49,7 +49,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for method in methods|sortByVisibility %}
-                            <li><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                            <li class="{% if method.deprecated %}-deprecated{% endif %}"><a href="{{ link(method) }}">{{ method.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/file.html.twig
+++ b/data/templates/default/file.html.twig
@@ -56,7 +56,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -67,7 +67,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for function in functions|sortByVisibility %}
-                            <li><a href="{{ link(function) }}">{{ function.name }}()</a></li>
+                            <li class="{% if function.deprecated %}-deprecated{% endif %}"><a href="{{ link(function) }}">{{ function.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/interface.html.twig
+++ b/data/templates/default/interface.html.twig
@@ -34,7 +34,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for method in methods|sortByVisibility %}
-                            <li><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                            <li class="{% if method.deprecated %}-deprecated{% endif %}"><a href="{{ link(method) }}">{{ method.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -45,7 +45,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/namespace.html.twig
+++ b/data/templates/default/namespace.html.twig
@@ -55,7 +55,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -66,7 +66,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for function in functions|sortByVisibility %}
-                            <li><a href="{{ link(function) }}">{{ function.name }}()</a></li>
+                            <li class="{% if function.deprecated %}-deprecated{% endif %}"><a href="{{ link(function) }}">{{ function.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/package.html.twig
+++ b/data/templates/default/package.html.twig
@@ -55,7 +55,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -66,7 +66,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for function in functions|sortByVisibility %}
-                            <li><a href="{{ link(function) }}">{{ function.name }}()</a></li>
+                            <li class="{% if function.deprecated %}-deprecated{% endif %}"><a href="{{ link(function) }}">{{ function.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/reports/deprecated.html.twig
+++ b/data/templates/default/reports/deprecated.html.twig
@@ -41,11 +41,11 @@
                         <th class="phpdocumentor-heading">Reason</th>
                     </tr>
                     {% for element in deprecatedElements|filter(el => el.file == file) %}
-                        {% for tag in element.tags.deprecated %}
+                        {% for deprecation in element.deprecations %}
                             <tr>
                                 <td class="phpdocumentor-cell">{{ element.line }}</td>
                                 <td class="phpdocumentor-cell">{{ element|route}}</td>
-                                <td class="phpdocumentor-cell">{{ tag.description | description | markdown }}</td>
+                                <td class="phpdocumentor-cell">{{ deprecation.description | description | markdown }}</td>
                             </tr>
                         {% endfor %}
                     {% endfor %}

--- a/data/templates/default/trait.html.twig
+++ b/data/templates/default/trait.html.twig
@@ -43,7 +43,7 @@
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for constant in constants|sortByVisibility %}
-                        <li><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                        <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                     {% endfor %}
                 </ul>
             </li>
@@ -53,7 +53,7 @@
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for property in properties|sortByVisibility %}
-                        <li><a href="{{ link(property) }}">${{ property.name }}</a></li>
+                        <li class="{% if property.deprecated %}-deprecated{% endif %}"><a href="{{ link(property) }}">${{ property.name }}</a></li>
                     {% endfor %}
                 </ul>
             </li>
@@ -63,7 +63,7 @@
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for method in methods|sortByVisibility %}
-                        <li><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                        <li class="{% if method.deprecated %}-deprecated{% endif %}"><a href="{{ link(method) }}">{{ method.name }}()</a></li>
                     {% endfor %}
                 </ul>
             </li>

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,18 +32,17 @@
             </errorLevel>
         </UndefinedMagicMethod>
 
+        <UndefinedMethod>
+            <errorLevel type="suppress">
+                <file name="src/phpDocumentor/Descriptor/Traits/CanBeDeprecated.php"/>
+            </errorLevel>
+        </UndefinedMethod>
+
         <UnusedVariable>
             <errorLevel type="suppress">
                 <file name="src/phpDocumentor/Transformer/Writer/Twig/Extension.php" />
             </errorLevel>
         </UnusedVariable>
-
-        <UndefinedInterfaceMethod>
-            <errorLevel type="suppress">
-                <!-- not sure what's going on here -->
-                <referencedMethod name="League\Flysystem\FilesystemInterface::find"/>
-            </errorLevel>
-        </UndefinedInterfaceMethod>
 
         <InvalidArgument>
             <errorLevel type="suppress">
@@ -66,13 +65,6 @@
         This could be removed when https://youtrack.jetbrains.com/issue/WI-47158 will be resolved
         or if we decide PHPStorm autocompletion is not needed -->
         <UnnecessaryVarAnnotation errorLevel="suppress" />
-
-        <InvalidThrow>
-            <errorLevel type="suppress">
-                <!-- An interface of exception that does not implements Throwable -->
-                <referencedClass name="Psr\Cache\InvalidArgumentException"/>
-            </errorLevel>
-        </InvalidThrow>
 
         <InvalidExtendClass>
             <errorLevel type="suppress">
@@ -105,11 +97,6 @@
 
         <InvalidReturnStatement>
             <errorLevel type="suppress">
-                <!-- Discussed here #2271-->
-                <file name="src/phpDocumentor/Descriptor/ClassDescriptor.php"/>
-                <file name="src/phpDocumentor/Descriptor/PropertyDescriptor.php"/>
-                <!-- Linker & LinkRenderer works with a lot of types and transform each of them individually. They'll have to be refactored -->
-                <file name="src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer.php"/>
                 <file name="src/phpDocumentor/Compiler/ApiDocumentation/Linker/Linker.php"/>
             </errorLevel>
         </InvalidReturnStatement>
@@ -123,13 +110,6 @@
                 <file name="src/phpDocumentor/Compiler/ApiDocumentation/Linker/Linker.php"/>
             </errorLevel>
         </InvalidReturnType>
-
-        <UnusedMethodCall>
-            <errorLevel type="suppress">
-                <!-- Psalm think the call is unused. Don't know why -->
-                <referencedMethod name="Webmozart\Assert\Mixin::nullOrIsInstanceOf"/>
-            </errorLevel>
-        </UnusedMethodCall>
 
         <MoreSpecificImplementedParamType>
             <errorLevel type="suppress">
@@ -147,11 +127,5 @@
                 <file name="src/phpDocumentor/Descriptor/Builder/Reflector/Tags/InvalidTagAssembler.php" />
             </errorLevel>
         </InvalidCast>
-
-        <UndefinedFunction>
-            <errorLevel type="suppress">
-                <referencedFunction name="str_starts_with" />
-            </errorLevel>
-        </UndefinedFunction>
     </issueHandlers>
 </psalm>

--- a/src/phpDocumentor/Descriptor/DescriptorAbstract.php
+++ b/src/phpDocumentor/Descriptor/DescriptorAbstract.php
@@ -46,6 +46,7 @@ abstract class DescriptorAbstract implements
     use Traits\IsInFile;
     use Traits\HasErrors;
     use Traits\HasInheritance;
+    use Traits\CanBeDeprecated;
 
     /**
      * Initializes this descriptor.

--- a/src/phpDocumentor/Descriptor/Traits/CanBeDeprecated.php
+++ b/src/phpDocumentor/Descriptor/Traits/CanBeDeprecated.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Descriptor\Traits;
+
+use phpDocumentor\Descriptor\DocBlock\DescriptionDescriptor;
+use phpDocumentor\Descriptor\Interfaces\AttributedInterface;
+use phpDocumentor\Descriptor\Tag\DeprecatedDescriptor;
+use phpDocumentor\Descriptor\ValueObjects\Deprecation;
+use phpDocumentor\Reflection\DocBlock\Description;
+
+use function array_map;
+use function trim;
+
+trait CanBeDeprecated
+{
+    /**
+     * Checks whether this element is deprecated.
+     */
+    public function isDeprecated(): bool
+    {
+        return $this->isDeprecatedByTag() || $this->isDeprecatedByAttribute();
+    }
+
+    private function isDeprecatedByTag(): bool
+    {
+        return isset($this->tags['deprecated']);
+    }
+
+    /**
+     * @phpstan-assert-if-true AttributedInterface $this
+     * @psalm-assert-if-true AttributedInterface $this`[
+     */
+    private function isDeprecatedByAttribute(): bool
+    {
+        if ($this instanceof AttributedInterface) {
+            foreach ($this->getAttributes() as $attribute) {
+                if ((string) $attribute->getFullyQualifiedStructuralElementName() === '\Deprecated') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /** @return Deprecation[] */
+    public function getDeprecations(): array
+    {
+        $deprecations = [];
+        if ($this->isDeprecatedByTag()) {
+            /** @var DeprecatedDescriptor[] $tags */
+            $tags = $this->getTags()->get('deprecated')->getAll();
+            $deprecations = array_map(
+                static function (DeprecatedDescriptor $tag): Deprecation {
+                    return new Deprecation($tag->getDescription(), $tag->getVersion());
+                },
+                $tags,
+            );
+        }
+
+        if ($this->isDeprecatedByAttribute()) {
+            foreach ($this->getAttributes() as $attribute) {
+                if ((string) $attribute->getFullyQualifiedStructuralElementName() !== '\Deprecated') {
+                    continue;
+                }
+
+                $deprecations[] = new Deprecation(
+                    new DescriptionDescriptor(
+                        $this->createDescription(
+                            ($attribute->getArguments()['message'] ?? $attribute->getArguments()[0])?->getValue(),
+                        ),
+                        [],
+                    ),
+                    $attribute->getArguments()['since'] ?? $attribute->getArguments()[1]?->getValue(),
+                );
+            }
+        }
+
+        return $deprecations;
+    }
+
+    private function createDescription(string|null $param): Description
+    {
+        if ($param === null) {
+            return new Description('', []);
+        }
+
+        return new Description(
+            trim($param, '\''),
+            [],
+        );
+    }
+}

--- a/src/phpDocumentor/Descriptor/Traits/HasTags.php
+++ b/src/phpDocumentor/Descriptor/Traits/HasTags.php
@@ -114,12 +114,4 @@ trait HasTags
 
         return new Collection();
     }
-
-    /**
-     * Checks whether this element is deprecated.
-     */
-    public function isDeprecated(): bool
-    {
-        return isset($this->tags['deprecated']);
-    }
 }

--- a/src/phpDocumentor/Descriptor/ValueObjects/Deprecation.php
+++ b/src/phpDocumentor/Descriptor/ValueObjects/Deprecation.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Descriptor\ValueObjects;
+
+use phpDocumentor\Descriptor\DocBlock\DescriptionDescriptor;
+
+final class Deprecation
+{
+    public function __construct(private DescriptionDescriptor $description, private string|null $version = null)
+    {
+    }
+
+    public function getDescription(): DescriptionDescriptor
+    {
+        return $this->description;
+    }
+
+    public function getVersion(): string|null
+    {
+        return $this->version;
+    }
+}

--- a/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/Extension.php
@@ -17,6 +17,7 @@ use ArrayIterator;
 use InvalidArgumentException;
 use League\CommonMark\ConverterInterface;
 use League\Uri\Uri;
+use phpDocumentor\Descriptor\AttributeDescriptor;
 use phpDocumentor\Descriptor\Collection;
 use phpDocumentor\Descriptor\Descriptor;
 use phpDocumentor\Descriptor\DescriptorAbstract;
@@ -59,6 +60,7 @@ use Twig\TwigTest;
 use Webmozart\Assert\Assert;
 
 use function array_unshift;
+use function in_array;
 use function ltrim;
 use function method_exists;
 use function sprintf;
@@ -398,6 +400,21 @@ final class Extension extends AbstractExtension implements ExtensionInterface, G
                     }
 
                     return $fqsenOrTitle;
+                },
+            ),
+            'specializedAttributes' => new TwigFilter(
+                'specializedAttributes',
+                static function (Collection $attributes): Collection {
+                    $filtered = Collection::fromClassString(AttributeDescriptor::class);
+                    foreach ($attributes as $attribute) {
+                        if (in_array((string) $attribute->getFullyQualifiedStructuralElementName(), ['\Deprecated'])) {
+                            continue;
+                        }
+
+                        $filtered->add($attribute);
+                    }
+
+                    return $filtered;
                 },
             ),
         ];


### PR DESCRIPTION
The new attribut was added in php 8.4 and we no now read it as a normal docblock item. This way our users can use the new attribute to deprecate their methods, classes and properties and use those in the documentation as well.

To make deprecations better visual they are new having their own component which will make it possible to customize the way deprecations are shown.