### PR TITLE
Fix settings:list and --list-settings not working

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -80,6 +80,7 @@ services:
 
     phpDocumentor\Console\Command\Project\ListSettingsCommand:
         tags: [ { name: 'console.command' } ]
+        public: true
 
     phpDocumentor\Descriptor\Builder\AssemblerFactory:
         class: 'phpDocumentor\Descriptor\Builder\AssemblerFactory'


### PR DESCRIPTION
Currently, the `settings:list` command is not being loaded by the CLI application, which also impacts the `--list-settings` flag to be not useable. This PR fixes this.