### PR TITLE
Reintroduce multicommand interface

### DIFF
--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -57,7 +57,7 @@ class Application extends BaseApplication
             $this->add($container->get($id));
         }
 
-        $this->setDefaultCommand('project:run', true);
+        $this->setDefaultCommand('project:run', false);
 
         $eventDispatcher = $container->get(EventDispatcher::class);
         $logger = $container->get(LoggerInterface::class);
@@ -110,6 +110,15 @@ class Application extends BaseApplication
                 new InputOption('log', null, InputOption::VALUE_OPTIONAL, 'Log file to write to'),
             ],
         );
+    }
+
+    protected function getCommandName(InputInterface $input): string|null
+    {
+        if ($input->getFirstArgument() === null) {
+            return 'run';
+        }
+
+        return $input->getFirstArgument();
     }
 
     /**


### PR DESCRIPTION
With some refactoring in the past we removed some complex code to guess the name of the command. By now it's easier to do that in symfony so we just overwrite the method returning the command name.

fixes #3725 