### PR TITLE
[DOCS] add @final tag to reference

### DIFF
--- a/docs/references/phpdoc/tags/final.rst
+++ b/docs/references/phpdoc/tags/final.rst
@@ -1,0 +1,67 @@
+@final
+======
+
+The `@final` decorator is used to denote that the associated *Structural Element* is final,
+are not allowed to extend or override the *Structural Element* in a child element.
+
+This tag can only be used on the following *Structural Elements*:
+
+- ``method``
+- ``constant``
+- ``class``
+
+Syntax
+------
+
+.. code-block::
+
+    @final [description]
+
+Description
+-----------
+
+In some situations the language construct ``final`` cannot be used by the implementing
+library where the functionality of the library prevents elements from being final. For
+example when proxy patterns are applied. In these cases the ``@final`` tag can be used to
+indicate that the element should be treated as final.
+
+The optional description is used to provide a more detailed explanation of why the element
+is marked as final.
+
+IDE's and other tools can use this information to show an error when such an element is
+extended or overridden.
+
+Effects in phpDocumentor
+------------------------
+
+*Structural Elements* that are marked as ``@final`` will be displayed
+as such in the generated documentation. The same way as the ``final`` keyword.
+
+Example
+-------
+
+.. code-block:: php
+
+    /**
+     * @final should not be extended by consuming code.
+     */
+    class Service
+    {
+        public function method()
+        {
+        }
+    }
+
+Example of a method marked as final:
+
+.. code-block:: php
+
+    class Service
+    {
+        /**
+         * @final
+         */
+        public function method()
+        {
+        }
+    }

--- a/docs/references/phpdoc/tags/final.rst
+++ b/docs/references/phpdoc/tags/final.rst
@@ -43,7 +43,7 @@ Example
 .. code-block:: php
 
     /**
-     * @final should not be extended by consuming code.
+     * @final since version X.y.
      */
     class Service
     {

--- a/docs/references/phpdoc/tags/param.rst
+++ b/docs/references/phpdoc/tags/param.rst
@@ -8,7 +8,7 @@ Syntax
 
 .. code-block::
 
-    @param [<Type>] [name] [<description>]
+    @param [<Type>] [...]$[name] [<description>]
 
 Description
 -----------
@@ -17,7 +17,8 @@ With the ``@param`` tag it is possible to document the :doc:`Type <../types>`
 and the intent of a single `argument of a function or method`_. When provided
 it MAY contain a :doc:`Type <../types>` to indicate what is expected. The name
 of the argument MUST be present so that it is clear which argument this tag
-relates to.
+relates to. The variadic operator ``...`` MAY be used to indicate that the
+argument is variadic.
 
 The description is OPTIONAL yet RECOMMENDED, for instance, in case of
 complicated structures, such as associative arrays.


### PR DESCRIPTION
We do see the @final tag being used in may projects to make it more clear what the intention of the tag is this has been added to the tag reference.

The actual behavior will be implemented in phpdocumentor in a later stadium.

refs #3737 