### PR TITLE
[FEATURE] filter empty namespace

### DIFF
--- a/src/phpDocumentor/Compiler/ApiDocumentation/Pass/FilterEmptyNamespaces.php
+++ b/src/phpDocumentor/Compiler/ApiDocumentation/Pass/FilterEmptyNamespaces.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Compiler\ApiDocumentation\Pass;
+
+use phpDocumentor\Compiler\ApiDocumentation\ApiDocumentationPass;
+use phpDocumentor\Descriptor\ApiSetDescriptor;
+use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Descriptor\Interfaces\NamespaceInterface;
+use phpDocumentor\Pipeline\Attribute\Stage;
+
+#[Stage(
+    'phpdoc.pipeline.api_documentation.compile',
+    2000,
+    'Filter empty namespaces',
+)]
+final class FilterEmptyNamespaces extends ApiDocumentationPass
+{
+    protected function process(ApiSetDescriptor $subject): ApiSetDescriptor
+    {
+        /** @var Collection<NamespaceInterface> $index */
+        $index = $subject->getIndex('namespaces');
+        $namespace = $subject->getNamespace();
+
+        $this->checkForEmptyChildren($namespace, $namespace->getChildren(), $index);
+
+        return $subject;
+    }
+
+    /**
+     * @param Collection<NamespaceInterface> $namespaces
+     * @param Collection<NamespaceInterface> $index
+     */
+    private function checkForEmptyChildren(
+        NamespaceInterface $namespace,
+        Collection $namespaces,
+        Collection $index,
+    ): void {
+        foreach ($namespace->getChildren() as $childNamespace) {
+            $this->checkForEmptyChildren($childNamespace, $namespace->getChildren(), $index);
+        }
+
+        if (! $namespace->isEmpty()) {
+            return;
+        }
+
+        $index->offsetUnset((string) $namespace->getFullyQualifiedStructuralElementName());
+        $namespaces->offsetUnset($namespace->getName());
+    }
+}

--- a/src/phpDocumentor/Descriptor/Interfaces/NamespaceInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/NamespaceInterface.php
@@ -22,4 +22,9 @@ interface NamespaceInterface extends ElementInterface, ContainerInterface, Child
 {
     /** @return Collection<NamespaceInterface> */
     public function getChildren(): Collection;
+
+    /**
+     * Returns true when the namespace is empty.
+     */
+    public function isEmpty(): bool;
 }

--- a/src/phpDocumentor/Descriptor/NamespaceDescriptor.php
+++ b/src/phpDocumentor/Descriptor/NamespaceDescriptor.php
@@ -234,4 +234,18 @@ class NamespaceDescriptor extends DescriptorAbstract implements Interfaces\Names
     {
         $this->enums = $enums;
     }
+
+    /**
+     * Returns true when the namespace is empty.
+     */
+    public function isEmpty(): bool
+    {
+        return $this->classes->count() === 0
+            && $this->constants->count() === 0
+            && $this->functions->count() === 0
+            && $this->interfaces->count() === 0
+            && $this->traits->count() === 0
+            && $this->enums->count() === 0
+            && $this->children->count() === 0;
+    }
 }

--- a/tests/unit/phpDocumentor/Compiler/ApiDocumentation/Pass/FilterEmptyNamespaceTest.php
+++ b/tests/unit/phpDocumentor/Compiler/ApiDocumentation/Pass/FilterEmptyNamespaceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Compiler\ApiDocumentation\Pass;
+
+use phpDocumentor\Descriptor\NamespaceDescriptor;
+use phpDocumentor\Faker\Faker;
+use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
+
+final class FilterEmptyNamespaceTest extends TestCase
+{
+    use Faker;
+
+    public function testEmptyNamespaceIsRemovedFromTree(): void
+    {
+        $parentNamespace = new NamespaceDescriptor();
+        $parentNamespace->setName('Parent');
+        $parentNamespace->setFullyQualifiedStructuralElementName(new Fqsen('\Parent'));
+
+        $childNamespace = new NamespaceDescriptor();
+        $childNamespace->setName('Child');
+        $childNamespace->setFullyQualifiedStructuralElementName(new Fqsen('\Parent\Child'));
+        $parentNamespace->addChild($childNamespace);
+        $parentNamespace->getClasses()->set('Class1', self::faker()->classDescriptor(new Fqsen('\Parent\Class1')));
+
+        $apiSet = self::faker()->apiSetDescriptor();
+        $apiSet->setNamespace($parentNamespace);
+
+        $fixture = new FilterEmptyNamespaces();
+        $fixture($apiSet);
+
+        $this->assertCount(0, $apiSet->getNamespace()->getChildren());
+    }
+}


### PR DESCRIPTION
Namespaces that are completely empty after filtering elements are now hidden from the documentation. This mostly happens when a namespace only contains internal elements. As we filter those by default empty namespaces are the result. This makes it more confusing to browse the docs.

If a tree of namespaces is empty all parent namespaces are also include.