### PR TITLE
GH Actions: fix up action runner version

### DIFF
--- a/.github/workflows/phar/action.yaml
+++ b/.github/workflows/phar/action.yaml
@@ -32,7 +32,7 @@ runs:
         key: ${{ inputs.key }}
 
     - name: Cache extensions
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.cache-env.outputs.dir }}
         key: ${{ steps.cache-env.outputs.key }}
@@ -51,7 +51,7 @@ runs:
     - name: Install Composer dependencies & cache dependencies
       env:
         COMPOSER_MIRROR_PATH_REPOS: 1
-      uses: "ramsey/composer-install@v2"
+      uses: "ramsey/composer-install@v3"
       with:
         composer-options: --optimize-autoloader
         # Bust the cache at least once a month - output format: YYYY-MM-DD.
@@ -66,7 +66,7 @@ runs:
     - name: Install Composer dependencies & cache dependencies
       env:
         COMPOSER_MIRROR_PATH_REPOS: 1
-      uses: "ramsey/composer-install@v2"
+      uses: "ramsey/composer-install@v3"
       with:
         composer-options: --optimize-autoloader
         # Bust the cache at least once a month - output format: YYYY-MM-DD.


### PR DESCRIPTION
Looks like dependabot doesn't take subdirectories of the `.github/workflows` directory into account when creating updates for the GH action runners.

Not sure how to fix that, but this PR at least fixes the outdated versions (before things break due to Node 16 no longer being supported).