### PR TITLE
Update composer.json for json-path to be compatible with PHP 8.2 and PHP 8.3

### DIFF
--- a/incubator/json-path/composer.json
+++ b/incubator/json-path/composer.json
@@ -20,9 +20,9 @@
         }
     ],
     "require": {
-        "php": "7.4|8.0.*|8.1.*",
+        "php": "8.1.*|8.2.*|8.3.*",
         "parsica-php/parsica": "^0.8.1",
-        "symfony/property-access": "^5.4|^6.0"
+        "symfony/property-access": "^5.4|^6.4|^7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
Thank you for your developing!

This PR updates composer.json for json-path to be compatible with PHP 8.2 and PHP 8.3.
Related: https://github.com/phpDocumentor/json-path/pull/1

Thank you.