### PR TITLE
feat: open rendered SVGs in separate tab/window onclick

### DIFF
--- a/data/templates/default/components/uml.css.twig
+++ b/data/templates/default/components/uml.css.twig
@@ -1,0 +1,3 @@
+.phpdocumentor-uml-diagram svg {
+    cursor: zoom-in;
+}

--- a/data/templates/default/components/uml.js.twig
+++ b/data/templates/default/components/uml.js.twig
@@ -1,0 +1,17 @@
+function openSvg(svg) {
+    // convert to a valid XML source
+    const as_text = new XMLSerializer().serializeToString(svg);
+    // store in a Blob
+    const blob = new Blob([as_text], { type: "image/svg+xml" });
+    // create an URI pointing to that blob
+    const url = URL.createObjectURL(blob);
+    const win = open(url);
+    // so the Garbage Collector can collect the blob
+    win.onload = (evt) => URL.revokeObjectURL(url);
+};
+
+
+var svgs = document.querySelectorAll(".phpdocumentor-uml-diagram svg");
+for( var i=0,il = svgs.length; i< il; i ++ ) {
+    svgs[i].onclick = (evt) => openSvg(evt.target);
+}

--- a/data/templates/default/css/template.css.twig
+++ b/data/templates/default/css/template.css.twig
@@ -18,3 +18,4 @@
 {% include 'components/class-graph.css.twig' %}
 {% include 'components/tag-list.css.twig' %}
 {% include 'css/custom.css.twig' %}
+{% include 'components/uml.css.twig' %}

--- a/data/templates/default/js/template.js.twig
+++ b/data/templates/default/js/template.js.twig
@@ -1,1 +1,2 @@
 {% include 'components/on-this-page.js.twig' %}
+{% include 'components/uml.js.twig' %}


### PR DESCRIPTION
added a small bit of JS & CSS:  

- CSS to change the cursor to `zoom-in` on hover
- JS to open the SVG in a new window/tab onclick