### PR TITLE
fix: installation document alias not working when directory has a space

### DIFF
--- a/docs/getting-started/installing.rst
+++ b/docs/getting-started/installing.rst
@@ -37,7 +37,7 @@ To run phpDocumentor using docker, the following should suffice::
 
 As a convenience, you can alias_ this command so that you can use it from any folder easily::
 
-   $ alias phpdoc="docker run --rm -v $(pwd):/data phpdoc/phpdoc:3"
+   $ alias phpdoc="docker run --rm -v '$(pwd):/data' phpdoc/phpdoc:3"
 
 After doing that, you can simply call ``phpdoc`` from any location. This may also help with following the examples
 in this documentation as we assume you have a command called ``phpdoc`` available globally.


### PR DESCRIPTION
This PR will solve [Issue #3794](https://github.com/phpDocumentor/phpDocumentor/issues/3794)
the details can be found in the issue

@jaapio I've created the PR, just let me know if u got any feedback
thank you 👍

## Changes
replacing installation document alias
```shell
$ alias phpdoc="docker run --rm -v $(pwd):/data phpdoc/phpdoc:3"
```

with a new one to support the directory that has space
```shell
$ alias phpdoc="docker run --rm -v '$(pwd):/data' phpdoc/phpdoc:3"
```