### PR TITLE
Introducing phpDocumentor Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ phpDocumentor supports the following:
 * *Docblock over types*, docblocks can be more explicit about types not all formats are supported by native php.
 * *Shows any tag*, some tags add additional functionality to phpDocumentor (such as @link).
 * *Low memory usage*, peak memory usage for small projects is less than 20MB, medium projects 40MB, and large frameworks 100MB.
-to 80% on top of the mentioned processing speed increase above.
+* *Incremental parsing*, if you kept the Structure file from a previous run, you get an additional performance boost of up
   to 80% on top of the mentioned processing speed increase above.
 * *Easy template building*, if you want to make a branding you only have to call 1 task and edit 3 files.
 * *Two-step process*, phpDocumentor first generates a cache with your application structure before creating the output.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Packagist Version](https://img.shields.io/packagist/v/phpdocumentor/phpdocumentor?label=packagist%20stable)
 ![Packagist Pre Release Version](https://img.shields.io/packagist/vpre/phpdocumentor/phpdocumentor?label=packagist%20unstable)
 [![Downloads](https://img.shields.io/packagist/dm/phpDocumentor/phpDocumentor.svg)](https://packagist.org/packages/phpDocumentor/phpDocumentor)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20phpDocumentor%20Guru-006BFF)](https://gurubase.io/g/phpdocumentor)
 
 
 phpDocumentor
@@ -54,7 +55,7 @@ phpDocumentor supports the following:
 * *Docblock over types*, docblocks can be more explicit about types not all formats are supported by native php.
 * *Shows any tag*, some tags add additional functionality to phpDocumentor (such as @link).
 * *Low memory usage*, peak memory usage for small projects is less than 20MB, medium projects 40MB, and large frameworks 100MB.
-* *Incremental parsing*, if you kept the Structure file from a previous run, you get an additional performance boost of up
+to 80% on top of the mentioned processing speed increase above.
   to 80% on top of the mentioned processing speed increase above.
 * *Easy template building*, if you want to make a branding you only have to call 1 task and edit 3 files.
 * *Two-step process*, phpDocumentor first generates a cache with your application structure before creating the output.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [phpDocumentor Guru](https://gurubase.io/g/phpdocumentor) to Gurubase. phpDocumentor Guru uses the data from this repo and data from the [docs](https://docs.phpdoc.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "phpDocumentor Guru", which highlights that phpDocumentor now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable phpDocumentor Guru in Gurubase, just let me know that's totally fine.
