### PR TITLE
trait.html.twig: Fix deprecated constant(s)

### DIFF
--- a/data/templates/default/trait.html.twig
+++ b/data/templates/default/trait.html.twig
@@ -43,7 +43,7 @@
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for constant in constants|sortByVisibility %}
-                        <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                        <li class="{% if constant.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                     {% endfor %}
                 </ul>
             </li>


### PR DESCRIPTION
The only difference (ignore white spaces) between trait.html.twig and class.html.twig is this test.

To test `constants.deprecated` instead of `constant.deprecated` is highly suspicious.

`constants.deprecated` seems to be always `NULL`.

With `constant.deprecated` the CSS class `-deprecated` is applied when needed on "On this page" items.