### PR TITLE
Add option disable packages from menu

### DIFF
--- a/data/xsd/phpdoc.xsd
+++ b/data/xsd/phpdoc.xsd
@@ -91,6 +91,7 @@
             <xs:element name="examples" type="pd:sourceType" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
         <xs:attribute name="format" type="xs:string" default="php" />
+        <xs:attribute name="ignore-packages" type="xs:boolean" default="false"/>
     </xs:complexType>
 
     <xs:complexType name="rstGuideType">

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -11,7 +11,7 @@
     </paths>
     <version number="3.0.0">
         <folder>latest</folder>
-        <api>
+        <api ignore-packages="true">
             <source dsn=".">
                 <path>src</path>
             </source>

--- a/src/phpDocumentor/Compiler/ApiDocumentation/Pass/PackageTreeBuilder.php
+++ b/src/phpDocumentor/Compiler/ApiDocumentation/Pass/PackageTreeBuilder.php
@@ -56,6 +56,10 @@ final class PackageTreeBuilder extends ApiDocumentationPass
 
     protected function process(ApiSetDescriptor $subject): ApiSetDescriptor
     {
+        if ($subject->getSettings()->ignorePackages()) {
+            return $subject;
+        }
+
         $package = $subject->getPackage();
         Assert::isInstanceOf($package, PackageInterface::class);
 

--- a/src/phpDocumentor/Configuration/ApiSpecification.php
+++ b/src/phpDocumentor/Configuration/ApiSpecification.php
@@ -51,6 +51,7 @@ final class ApiSpecification implements ArrayAccess
         private Source|null $examples,
         private string $encoding,
         private bool $validate,
+        private bool $ignorePackages,
     ) {
     }
 
@@ -81,6 +82,7 @@ final class ApiSpecification implements ArrayAccess
                 : null,
             $api['encoding'],
             $api['validate'],
+            $api['ignore-packages'],
         );
     }
 
@@ -106,6 +108,7 @@ final class ApiSpecification implements ArrayAccess
             null,
             'utf8',
             false,
+            false,
         );
     }
 
@@ -126,7 +129,12 @@ final class ApiSpecification implements ArrayAccess
     /** @return string[] */
     public function getIgnoredTags(): array
     {
-        return $this->ignoreTags;
+        $tags =  $this->ignoreTags;
+        if ($this->ignorePackages) {
+            $tags[] = 'package';
+        }
+
+        return $tags;
     }
 
     public function calculateVisiblity(): int
@@ -173,5 +181,10 @@ final class ApiSpecification implements ArrayAccess
     public function source(): Source
     {
         return $this->source;
+    }
+
+    public function ignorePackages(): bool
+    {
+        return $this->ignorePackages;
     }
 }

--- a/src/phpDocumentor/Configuration/Definition/Version3.php
+++ b/src/phpDocumentor/Configuration/Definition/Version3.php
@@ -45,7 +45,8 @@ use function var_export;
  *     examples?: array{dsn: string, paths: array<string>},
  *     include-source: bool,
  *     validate: bool,
- *     visibility: non-empty-array<array-key, string>
+ *     visibility: non-empty-array<array-key, string>,
+ *     ignore-packages: bool
  * }
  * @psalm-type ConfigurationMap = array{
  *     configVersion: string,
@@ -244,6 +245,10 @@ final class Version3 implements ConfigurationInterface, Normalizable
                         ->info('In which language is your code written?')
                         ->values(['php'])
                         ->defaultValue('php')
+                    ->end()
+                    ->booleanNode('ignore-packages')
+                        ->info('Whether to ignore packages in the documentation')
+                        ->defaultFalse()
                     ->end()
                     ->arrayNode('visibilities')
                         ->prototype('enum')

--- a/tests/unit/phpDocumentor/Configuration/Definition/Version3Test.php
+++ b/tests/unit/phpDocumentor/Configuration/Definition/Version3Test.php
@@ -195,6 +195,7 @@ final class Version3Test extends TestCase
                             'markers' => ['markers' => ['TODO', 'FIXME']],
                             'ignore-tags' => ['ignore_tags' => []],
                             'output' => '.',
+                            'ignore-packages' => false,
                         ],
                     ],
                     'guides' => [],


### PR DESCRIPTION
Packages are an optional tag, and not used in every project. The new setting makes is possible to disable the packages in the config.

fixes #3750