### PR TITLE
Docs: fix link in generating-documentation.rst

### DIFF
--- a/docs/getting-started/generating-documentation.rst
+++ b/docs/getting-started/generating-documentation.rst
@@ -1,7 +1,7 @@
 Generating documentation
 ========================
 
-After you have :ref:`installed<installing>` phpDocumentor you can use the ``phpdoc`` command to generate
+After you have :ref:`installed<Installation>` phpDocumentor you can use the ``phpdoc`` command to generate
 your documentation.
 
 Throughout this documentation we expect that the ``phpdoc`` command is available; thus whenever we ask you


### PR DESCRIPTION
It was linking to https://docs.phpdoc.org/guide/features/extensions/index.html#installing (which is irrelevant), instead of https://docs.phpdoc.org/guide/getting-started/installing.html#installation.