### PR TITLE
Add support for custom twig extensions

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -202,6 +202,7 @@ services:
     phpDocumentor\Transformer\Writer\Twig\EnvironmentFactory:
       arguments:
         $guidesTemplateBasePath: '%phpdoc.guides.base_template_paths%'
+        $extensions: !tagged_iterator { tag: 'twig.extension' }
 
     phpDocumentor\Transformer\Writer\Collection:
         arguments: [!tagged_iterator { tag: 'phpdoc.transformer.writer' }]

--- a/docs/features/extensions/examples/Twig/Extension.php
+++ b/docs/features/extensions/examples/Twig/Extension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyExtension\Twig;
+
+use phpDocumentor\Extension\Extension as BaseExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class Extension extends BaseExtension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $container->addDefinitions([
+            (new Definition(MyExtension::class))->addTag('twig.extension'),
+        ]);
+    }
+}

--- a/docs/features/extensions/examples/Twig/MyExtension.php
+++ b/docs/features/extensions/examples/Twig/MyExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyExtension\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class MyExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('rot13', function ($string) {
+                return str_rot13($string);
+            })
+        ];
+    }
+
+}

--- a/docs/features/extensions/examples/Twig/manifest.xml
+++ b/docs/features/extensions/examples/Twig/manifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phar xmlns="https://phar.io/xml/manifest/1.0">
+    <contains name="MyExtension/Twig" version="1.0" type="extension">
+        <extension for="phpdocumentor/phpdocumentor" compatible="^3.4"/>
+    </contains>
+
+    <copyright>
+        <author name="You" email="you@example.com"/>
+        <license type="MIT" url="https://github.com/phpdocumentor/phpdocumentor-example-extension/blob/1.0.0/LICENSE"/>
+    </copyright>
+
+    <requires>
+        <php version="^8.1"/>
+    </requires>
+
+    <bundles>
+        <component name="MyExtension\Twig\Extension" version="1.0" />
+    </bundles>
+</phar>

--- a/docs/features/extensions/include.rst.txt
+++ b/docs/features/extensions/include.rst.txt
@@ -1,0 +1,3 @@
+.. warning::
+
+    This feature is still under development and only available in the nightly docker builds.

--- a/docs/features/extensions/index.rst
+++ b/docs/features/extensions/index.rst
@@ -2,16 +2,14 @@
 Extensions
 ##########
 
-.. warning::
-
-    This feature is still under development and only available in the nightly docker builds.
+.. include:: include.rst.txt
 
 **********
 Installing
 **********
 
 PhpDocumentor can be extended with additional functionality by installing extensions. By default the application
-will search for an extensions folder in the ``.phpdoc`` folder in your working directory.
+will search for an ``extensions``` folder in the ``.phpdoc`` folder in your working directory.
 
 Supported extension styles:
 
@@ -25,17 +23,21 @@ Once extensions are correctly loaded phpDocumentor will print a message in the c
     Failed to load extensions:
     [WARNING] phpdocumentor/invalid:1.0.0
 
-Extensions are validated before they are acually loaded. If an extension is invalid it will not be loaded and a warning
+Extensions are validated before they are actually loaded. If an extension is invalid it will not be loaded and a warning
 will be printed in the console. Like in the example above. To load an extension it must be valid and compatible with
 the current version of phpDocumentor. Extension developers must specify the phpDocumentor version they are compatible
 with in the manifest file.
+
+.. _setup-extension:
 
 ************************
 Write your own extension
 ************************
 
 To write your own extension you need to create a folder in the extensions folder with the name of your extension.
-In this folder you need to create a manifest file called ``manifest.xml``. This file contains the information:
+In our example we use :code:`Example` as the name of our extension. The namespace of your extension is free to choose.
+
+First you need to create a manifest file called ``manifest.xml``. This file contains the extension information:
 
 .. code-block:: xml
 
@@ -83,6 +85,11 @@ Services that are registered in the application can be used in the extension.
 Extension points
 ----------------
 
-phpDocumentor does not have real extension points. But we have defined some common locations that can be used to extend
-the application. Depending on the type of extension you are writing you can use them.
+phpDocumentor does not have real extension points right now. As the extensions feature is under development extensions
+might break without warning.
 
+.. toctree::
+   :caption: Common use-cases
+   :titlesonly:
+
+   twig-extension

--- a/docs/features/extensions/twig-extension.rst
+++ b/docs/features/extensions/twig-extension.rst
@@ -1,0 +1,35 @@
+##############
+Twig extension
+##############
+
+.. include:: include.rst.txt
+
+phpDocumentor uses `twig <https://twig.symfony.com/>`_ for most rendering of the output. Twig gives us the flexibility
+we need and allows you to customize just what you need in a template. For more advanced use-cases twig supports
+`extensions <https://twig.symfony.com/doc/3.x/advanced.html>`_, these give you more options to write custom behavior
+that impacts the output of phpDocumentor.
+
+.. note::
+    read first :ref:`how to setup<setup-extension>` an phpDocumentor extension before you continue this guide.
+
+Now you have setup your phpDocumentor extension it is time to create a twig extension. In our example we will add
+a custom `filter <https://twig.symfony.com/doc/3.x/advanced.html#filters>` which can be used in a template to transform text.
+We can do this by creating a class like this:
+
+.. include:: ./examples/Twig/MyExtension.php
+    :code: php
+
+Register the twig extension
+---------------------------
+
+A twig extension needs to be registered in phpDocumentor before you can use it in your templates. To do so we need
+to add a new definition in the service container. With the tag :code:`twig.extension`
+
+.. include:: ./examples/Twig/Extension.php
+    :code: php
+
+Using the filter
+----------------
+
+Once your phpDocumentor extension is ready you can start using it in your template. This works for complete custom templates
+as well for :ref:`small overwrites <template-replace-component>`.

--- a/docs/features/theming/custom-styling.rst
+++ b/docs/features/theming/custom-styling.rst
@@ -60,6 +60,8 @@ that we provide, or add your own. To see which things you can override, you can 
 source code and look for any file ending in ``.css.twig``. In phpDocumentor, we aim to use a component based
 architecture using separate twig files for objects and components; so be sure to check out these folders.
 
+.. _template-replace-component:
+
 *************************************
 Replacing whole objects or components
 *************************************

--- a/docs/guides/templates/twig.rst
+++ b/docs/guides/templates/twig.rst
@@ -1,9 +1,9 @@
 Using Twig
 ==========
 
-phpDocumentor provides the `Twig 2.x engine`_ as a rendering engine for templates.
+phpDocumentor provides the `Twig 3.x engine`_ as a rendering engine for templates.
 
-.. _Twig 2.x engine: https://twig.symfony.com/doc/2.x/
+.. _Twig 3.x engine: https://twig.symfony.com/doc/3.x/
 
 Configuration
 -------------

--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -30,6 +30,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 use function getcwd;
+use function is_array;
 use function sprintf;
 
 class Application extends BaseApplication
@@ -45,6 +46,11 @@ class Application extends BaseApplication
             '--extensions-dir',
             $this->getDefinition()->getOption('extensions-dir')->getDefault(),
         );
+
+        if (! is_array($extensionsDirs)) {
+            $extensionsDirs = [$extensionsDirs];
+        }
+
         $extensionHandler = ExtensionHandler::getInstance($extensionsDirs);
         $containerFactory = new ContainerFactory();
         $container = $containerFactory->create(
@@ -101,11 +107,9 @@ class Application extends BaseApplication
                 new InputOption(
                     'extensions-dir',
                     null,
-                    InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                    InputOption::VALUE_OPTIONAL,
                     'extensions directory to load extensions from',
-                    [
-                        getcwd() . '/.phpdoc/extensions',
-                    ],
+                    getcwd() . '/.phpdoc/extensions',
                 ),
                 new InputOption('log', null, InputOption::VALUE_OPTIONAL, 'Log file to write to'),
             ],

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactoryTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/EnvironmentFactoryTest.php
@@ -50,15 +50,17 @@ final class EnvironmentFactoryTest extends TestCase
         $this->factory = new EnvironmentFactory(
             new LinkRenderer($this->router->reveal(), new HtmlFormatter()),
             $markDownConverter->reveal(),
-            new AssetsExtension(
-                new TestLogger(),
-                $this->prophesize(NodeRenderer::class)->reveal(),
-                $this->prophesize(DocumentNameResolverInterface::class)->reveal(),
-                $this->prophesize(UrlGeneratorInterface::class)->reveal(),
-            ),
-            new UmlExtension([], 'plantuml'),
             $relativePathToRootConverter,
             new PathBuilder($this->router->reveal(), $relativePathToRootConverter),
+            [
+                new AssetsExtension(
+                    new TestLogger(),
+                    $this->prophesize(NodeRenderer::class)->reveal(),
+                    $this->prophesize(DocumentNameResolverInterface::class)->reveal(),
+                    $this->prophesize(UrlGeneratorInterface::class)->reveal(),
+                ),
+                new UmlExtension([], 'plantuml'),
+            ],
             ['./data/templates'],
         );
     }


### PR DESCRIPTION
Extensions are a new concept in phpDocumentor, this is the first use-case to be completed. Twig extensions allow our users to implement custom twig filters for their template.