### PR TITLE
update the trusted GPG key when using phive

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ There are 4 ways to install phpDocumentor:
 
 ### Using Phive
 
-`$ phive install phpDocumentor --trust-gpg-keys 8AC0BAA79732DD42`
+`$ phive install phpDocumentor --trust-gpg-keys 6DA3ACC4991FFAE5`
 
 For more information about phive have a look at their [website](https://phar.io/).
 Now you have phpDocumentor installed, it can be executed like this:


### PR DESCRIPTION
This PR updates the trusted GPG key in README when using `phive`.

Closes #3873