### PR TITLE
Implement trait uses trait

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ ARGS ?=
 .DOCKER_COMPOSE_RUN = ${.USER} docker compose run --rm
 .PHP = docker run --user=$(shell id -u):$(shell id -g) -it --rm -v${CURDIR}:/data -w /data php:8.1
 
+CYPRESS_VERSION = 14.4.0
+
 .PHONY: help
 help:
 	@echo "      _           ____                                        _              ";
@@ -107,13 +109,13 @@ unit-test integration-test functional-test:
 
 .PHONY: e2e-test
 e2e-test: node_modules/.bin/cypress build/default/index.html build/clean/index.html
-	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:13.8.1
+	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:${CYPRESS_VERSION}
 
 cypress/integration/default/%.spec.js: node_modules/.bin/cypress build/default/index.html .RUN_ALWAYS
-	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:13.8.1 -s $@
+	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:${CYPRESS_VERSION} -s $@
 
 cypress/integration/clean/%.spec.js: node_modules/.bin/cypress build/clean/index.html .RUN_ALWAYS
-	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:13.8.1 -s $@
+	docker run -it --rm -eCYPRESS_CACHE_FOLDER="/e2e/var/cache/.cypress" -v ${CURDIR}:/e2e -w /e2e cypress/included:${CYPRESS_VERSION} -s $@
 
 .PHONY: composer-require-checker
 composer-require-checker:

--- a/cypress/integration/default/traits.spec.js
+++ b/cypress/integration/default/traits.spec.js
@@ -117,4 +117,90 @@ describe('Traits', function() {
             });
         });
     });
+
+    describe('Traits using other traits', function() {
+        beforeEach(function(){
+            cy.visit('build/default/classes/Marios-PizzaToppingTrait.html');
+        });
+
+        describe('Methods', function() {
+            it('Shows methods inherited from used trait', function() {
+                // Check that the Table of Contents includes methods from the trait
+                getTocEntry(getToc('methods', 'Methods'), 'getSauceType()')
+                    .should('exist')
+                    .and('have.class', '-method')
+                    .and('have.class', '-public');
+            });
+
+            it.skip('Indicates which trait a method came from', function() {
+                // Ensure the method shows where it was inherited from
+                getTocEntry(getToc('methods', 'Methods'), 'getSauceType()')
+                    .find('.phpdocumentor-table-of-contents__entry__trait')
+                    .should('contain', 'PizzaSauceTrait');
+            });
+
+            it.skip('Links to the trait from which a method was inherited', function() {
+                // Ensure the trait name links to that trait's documentation
+                getTocEntry(getToc('methods', 'Methods'), 'getSauceType()')
+                    .find('.phpdocumentor-table-of-contents__entry__trait a')
+                    .should('have.attr', 'href', 'classes/Marios-PizzaSauceTrait.html');
+            });
+        });
+
+        describe('Properties', function() {
+            it('Shows properties inherited from used trait', function() {
+                // Check that the Table of Contents includes properties from the trait
+                getTocEntry(getToc('properties', 'Properties'), 'sauceType')
+                    .should('exist')
+                    .and('have.class', '-property')
+                    .and('have.class', '-protected');
+            });
+
+            it.skip('Indicates which trait a property came from', function() {
+                // Ensure the property shows where it was inherited from
+                getTocEntry(getToc('properties', 'Properties'), 'sauceType')
+                    .find('.phpdocumentor-table-of-contents__entry__trait')
+                    .should('contain', 'PizzaSauceTrait');
+            });
+
+            it.skip('Links to the trait from which a property was inherited', function() {
+                // Ensure the trait name links to that trait's documentation
+                getTocEntry(getToc('properties', 'Properties'), 'sauceType')
+                    .find('.phpdocumentor-table-of-contents__entry__trait a')
+                    .should('have.attr', 'href', 'classes/Marios-PizzaSauceTrait.html');
+            });
+        });
+
+        describe('Constants', function() {
+            beforeEach(function(){
+                // First, let's check if we can see a trait's constants in the documentation
+                cy.visit('build/default/classes/Marios-SharedTrait.html');
+                // Then let's create a copy of this test file to check at runtime
+                cy.visit('build/default/classes/Marios-PizzaToppingTrait.html');
+            });
+
+            it('Shows constants inherited from used trait', function() {
+                // Check that the Table of Contents includes constants from the trait
+                getTocEntry(getToc('constants', 'Constants'), 'SAUCE_VERSION')
+                    .should('exist')
+                    .and('have.class', '-constant')
+                    .and('have.class', '-public');
+            });
+
+            it.skip('Indicates which trait a constant came from', function() {
+                // Ensure the constant shows where it was inherited from
+                getTocEntry(getToc('constants', 'Constants'), 'SAUCE_VERSION')
+                    .find('.phpdocumentor-table-of-contents__entry__trait')
+                    .should('contain', 'PizzaSauceTrait');
+            });
+
+            it.skip('Links to the trait from which a constant was inherited', function() {
+                // Ensure the trait name links to that trait's documentation
+                getTocEntry(getToc('constants', 'Constants'), 'SAUCE_VERSION')
+                    .find('.phpdocumentor-table-of-contents__entry__trait a')
+                    .should('have.attr', 'href', 'classes/Marios-PizzaSauceTrait.html');
+            });
+        });
+
+    });
 });

--- a/data/examples/MariosPizzeria/src/PizzaSauceTrait.php
+++ b/data/examples/MariosPizzeria/src/PizzaSauceTrait.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Marios;
+/**
+ * PizzaSauceTrait provides basic saucing functionality for pizzas.
+ *
+ * This trait is used to demonstrate the bug where phpDocumentor doesn't document
+ * traits that are used by other traits.
+ */
+trait PizzaSauceTrait
+{
+    /**
+     * Version of the sauce recipe
+     */
+    public const SAUCE_VERSION = '1.0';
+
+    protected string $sauceType = 'Tomato';
+
+    public function getSauceType(): string
+    {
+        return $this->sauceType;
+    }
+
+    protected function applySauce(string $sauceAmount): string
+    {
+        return "Applied {$sauceAmount} of {$this->sauceType} sauce to the base";
+    }
+}

--- a/data/examples/MariosPizzeria/src/PizzaToppingTrait.php
+++ b/data/examples/MariosPizzeria/src/PizzaToppingTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Marios;
+
+/**
+ * PizzaToppingTrait demonstrates a trait that uses another trait.
+ *
+ * This trait uses PizzaSauceTrait to showcase the bug in phpDocumentor
+ * where traits used by other traits are not properly documented.
+ */
+trait PizzaToppingTrait
+{
+    use PizzaSauceTrait;
+
+    protected array $toppings = ['Cheese', 'Mushroom', 'Pepperoni'];
+
+    public function getToppings(): array
+    {
+        return $this->toppings;
+    }
+
+    public function preparePizza(string $size): string
+    {
+        // Using the applySauce method from PizzaSauceTrait
+        $base = $this->applySauce($size);
+        $toppingsStr = implode(', ', $this->toppings);
+
+        return "{$base} and topped with {$toppingsStr}";
+    }
+}

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/TraitAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/TraitAssembler.php
@@ -18,6 +18,7 @@ use phpDocumentor\Descriptor\Interfaces\TraitInterface;
 use phpDocumentor\Descriptor\MethodDescriptor;
 use phpDocumentor\Descriptor\PropertyDescriptor;
 use phpDocumentor\Descriptor\TraitDescriptor;
+use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Constant;
 use phpDocumentor\Reflection\Php\Method;
 use phpDocumentor\Reflection\Php\Property;
@@ -58,6 +59,7 @@ class TraitAssembler extends AssemblerAbstract
         $this->addConstants($data->getConstants(), $traitDescriptor);
         $this->addProperties($data->getProperties(), $traitDescriptor);
         $this->addMethods($data->getMethods(), $traitDescriptor);
+        $this->addUses($data->getUsedTraits(), $traitDescriptor);
 
         return $traitDescriptor;
     }
@@ -113,6 +115,19 @@ class TraitAssembler extends AssemblerAbstract
 
             $methodDescriptor->setParent($traitDescriptor);
             $traitDescriptor->getMethods()->set($methodDescriptor->getName(), $methodDescriptor);
+        }
+    }
+
+    /**
+     * Registers traits used by this trait.
+     *
+     * @param Fqsen[] $usedTraits
+     */
+    protected function addUses(array $usedTraits, TraitInterface $traitDescriptor): void
+    {
+        $traits = $traitDescriptor->getUsedTraits();
+        foreach ($usedTraits as $traitFqsen) {
+            $traits->set((string) $traitFqsen, $traitFqsen);
         }
     }
 }

--- a/src/phpDocumentor/Descriptor/ClassDescriptor.php
+++ b/src/phpDocumentor/Descriptor/ClassDescriptor.php
@@ -18,7 +18,6 @@ use phpDocumentor\Descriptor\Interfaces\AttributedInterface;
 use phpDocumentor\Descriptor\Interfaces\ClassInterface;
 use phpDocumentor\Descriptor\Interfaces\MethodInterface;
 use phpDocumentor\Descriptor\Interfaces\PropertyInterface;
-use phpDocumentor\Descriptor\Interfaces\TraitInterface;
 use phpDocumentor\Descriptor\Validation\Error;
 use phpDocumentor\Reflection\Fqsen;
 
@@ -55,28 +54,6 @@ class ClassDescriptor extends DescriptorAbstract implements Interfaces\ClassInte
     public function isReadOnly(): bool
     {
         return $this->readOnly;
-    }
-
-    /** @return Collection<MethodInterface> */
-    public function getInheritedMethods(): Collection
-    {
-        $inheritedMethods = Collection::fromInterfaceString(MethodInterface::class);
-
-        foreach ($this->getUsedTraits() as $trait) {
-            if (! $trait instanceof TraitInterface) {
-                continue;
-            }
-
-            $inheritedMethods = $inheritedMethods->merge($trait->getMethods());
-        }
-
-        if (! $this->getParent() instanceof self) {
-            return $inheritedMethods;
-        }
-
-        $inheritedMethods = $inheritedMethods->merge($this->getParent()->getMethods());
-
-        return $inheritedMethods->merge($this->getParent()->getInheritedMethods());
     }
 
     /** @return Collection<MethodInterface> */

--- a/src/phpDocumentor/Descriptor/Interfaces/TraitInterface.php
+++ b/src/phpDocumentor/Descriptor/Interfaces/TraitInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Descriptor\Interfaces;
 
 use phpDocumentor\Descriptor\Collection;
+use phpDocumentor\Reflection\Fqsen;
 
 /**
  * Public interface definition for object representing traits.
@@ -75,4 +76,18 @@ interface TraitInterface extends ElementInterface, TypeInterface, AttributedInte
      * Returns the file associated with the parent class or trait.
      */
     public function getFile(): FileInterface|null;
+
+    /**
+     * Sets all traits used by this trait.
+     *
+     * @param Collection<TraitInterface|Fqsen> $usedTraits
+     */
+    public function setUsedTraits(Collection $usedTraits): void;
+
+    /**
+     * Returns all traits used by this trait.
+     *
+     * @return Collection<TraitInterface|Fqsen>
+     */
+    public function getUsedTraits(): Collection;
 }

--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -37,12 +37,6 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
     use Traits\HasConstants;
 
     /** @return Collection<MethodInterface> */
-    public function getInheritedMethods(): Collection
-    {
-        return Collection::fromInterfaceString(MethodInterface::class);
-    }
-
-    /** @return Collection<MethodInterface> */
     public function getMagicMethods(): Collection
     {
         /** @var Collection<Tag\MethodDescriptor> $methodTags */
@@ -72,12 +66,6 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
         }
 
         return $methods;
-    }
-
-    /** @return Collection<PropertyInterface> */
-    public function getInheritedProperties(): Collection
-    {
-        return Collection::fromInterfaceString(PropertyInterface::class);
     }
 
     /** @return Collection<PropertyInterface> */

--- a/src/phpDocumentor/Descriptor/Traits/HasProperties.php
+++ b/src/phpDocumentor/Descriptor/Traits/HasProperties.php
@@ -19,6 +19,8 @@ use phpDocumentor\Descriptor\Interfaces\ClassInterface;
 use phpDocumentor\Descriptor\Interfaces\PropertyInterface;
 use phpDocumentor\Descriptor\Interfaces\TraitInterface;
 
+use function method_exists;
+
 trait HasProperties
 {
     /** @var Collection<PropertyInterface> $properties References to properties defined in this class. */
@@ -53,7 +55,7 @@ trait HasProperties
     {
         $inheritedProperties = Collection::fromInterfaceString(PropertyInterface::class);
 
-        if ($this instanceof ClassInterface) {
+        if (method_exists($this, 'getUsedTraits')) {
             foreach ($this->getUsedTraits() as $trait) {
                 if (! $trait instanceof TraitInterface) {
                     continue;
@@ -63,7 +65,11 @@ trait HasProperties
             }
         }
 
-        if ($this instanceof ChildInterface && $this->getParent() instanceof ClassInterface === false) {
+        if ($this instanceof ChildInterface === false) {
+            return $inheritedProperties;
+        }
+
+        if ($this->getParent() instanceof ClassInterface === false) {
             return $inheritedProperties;
         }
 


### PR DESCRIPTION
Traits were not completely covered, so
traits using traits were missing. I moved
some common used code to traits in our descriptors to make sure we have a shared implementation when possible.

fixes #3820