### PR TITLE
Magic element filter

### DIFF
--- a/docs/references/phpdoc/tags/method.rst
+++ b/docs/references/phpdoc/tags/method.rst
@@ -44,7 +44,7 @@ Effects in phpDocumentor
 
 *Structural Elements* of type *class* or *interface* tagged with the ``@method``
 tag will show an extra method in their method listing matching the data
-provided with this tag.
+provided with this tag. Native methods always take precedence over methods defined with this tag.
 
 Examples
 --------

--- a/docs/references/phpdoc/tags/property.rst
+++ b/docs/references/phpdoc/tags/property.rst
@@ -42,7 +42,8 @@ Effects in phpDocumentor
 
 *Structural Elements* of type *class* or *trait* tagged with the
 ``@property``, ``@property-read`` or ``@property-write`` tag will show an extra
-property in their property listing matching the data provided with this tag.
+property in their property listing matching the data provided with this tag. Native properties
+always take precedence over properties defined with this tag.
 
 
 Examples
@@ -102,6 +103,19 @@ in order to implement a "magic", read-only ``$full_name`` property:
                 return "{$this->first_name} {$this->last_name}";
             }
         }
+    }
+
+The :code:`@property-write` is ignored by phpDocumentor as the native php property is defined.
+
+.. code-block:: php
+   :linenos:
+
+   /**
+    * @property-write mix $full_name
+    */
+    class User
+    {
+        public string $full_name;
     }
 
 

--- a/src/phpDocumentor/Descriptor/EnumDescriptor.php
+++ b/src/phpDocumentor/Descriptor/EnumDescriptor.php
@@ -66,35 +66,6 @@ final class EnumDescriptor extends DescriptorAbstract implements EnumInterface
         return $inheritedMethods;
     }
 
-    /** @return Collection<MethodInterface> */
-    public function getMagicMethods(): Collection
-    {
-        $methodTags = $this->getTags()->fetch('method', new Collection())->filter(Tag\MethodDescriptor::class);
-
-        $methods = Collection::fromInterfaceString(MethodInterface::class);
-
-        foreach ($methodTags as $methodTag) {
-            $method = new MethodDescriptor();
-            $method->setName($methodTag->getMethodName());
-            $method->setDescription($methodTag->getDescription());
-            $method->setStatic($methodTag->isStatic());
-            $method->setParent($this);
-            $method->setReturnType($methodTag->getResponse()->getType());
-            $method->setHasReturnByReference($methodTag->getHasReturnByReference());
-
-            $returnTags = $method->getTags()->fetch('return', new Collection());
-            $returnTags->add($methodTag->getResponse());
-
-            foreach ($methodTag->getArguments() as $name => $argument) {
-                $method->addArgument($name, $argument);
-            }
-
-            $methods->add($method);
-        }
-
-        return $methods;
-    }
-
     /** @inheritDoc */
     public function setPackage($package): void
     {

--- a/src/phpDocumentor/Descriptor/TraitDescriptor.php
+++ b/src/phpDocumentor/Descriptor/TraitDescriptor.php
@@ -13,15 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Descriptor;
 
-use InvalidArgumentException;
-use phpDocumentor\Descriptor\Interfaces\MethodInterface;
-use phpDocumentor\Descriptor\Interfaces\PropertyInterface;
-use phpDocumentor\Descriptor\Tag\ReturnDescriptor;
-use phpDocumentor\Descriptor\Validation\Error;
-
-use function ltrim;
-use function sprintf;
-
 /**
  * Descriptor representing a Trait.
  *
@@ -35,73 +26,4 @@ class TraitDescriptor extends DescriptorAbstract implements Interfaces\TraitInte
     use Traits\HasMethods;
     use Traits\UsesTraits;
     use Traits\HasConstants;
-
-    /** @return Collection<MethodInterface> */
-    public function getMagicMethods(): Collection
-    {
-        /** @var Collection<Tag\MethodDescriptor> $methodTags */
-        $methodTags = $this->getTags()->fetch('method', new Collection());
-
-        $methods = Collection::fromInterfaceString(MethodInterface::class);
-
-        /** @var Tag\MethodDescriptor $methodTag */
-        foreach ($methodTags as $methodTag) {
-            $method = new MethodDescriptor();
-            $method->setName($methodTag->getMethodName());
-            $method->setDescription($methodTag->getDescription());
-            $method->setStatic($methodTag->isStatic());
-            $method->setParent($this);
-            $method->setReturnType($methodTag->getResponse()->getType());
-            $method->setHasReturnByReference($methodTag->getHasReturnByReference());
-
-            /** @var Collection<ReturnDescriptor> $returnTags */
-            $returnTags = $method->getTags()->fetch('return', new Collection());
-            $returnTags->add($methodTag->getResponse());
-
-            foreach ($methodTag->getArguments() as $name => $argument) {
-                $method->addArgument($name, $argument);
-            }
-
-            $methods->add($method);
-        }
-
-        return $methods;
-    }
-
-    /** @return Collection<PropertyInterface> */
-    public function getMagicProperties(): Collection
-    {
-        $tags = $this->getTags();
-        /** @var Collection<Tag\PropertyDescriptor> $propertyTags */
-        $propertyTags = $tags->fetch('property', new Collection())->filter(Tag\PropertyDescriptor::class)
-            ->merge($tags->fetch('property-read', new Collection())->filter(Tag\PropertyDescriptor::class))
-            ->merge($tags->fetch('property-write', new Collection())->filter(Tag\PropertyDescriptor::class));
-
-        $properties = Collection::fromInterfaceString(PropertyInterface::class);
-
-        /** @var Tag\PropertyDescriptor $propertyTag */
-        foreach ($propertyTags as $propertyTag) {
-            $property = new PropertyDescriptor();
-            $property->setName(ltrim($propertyTag->getVariableName(), '$'));
-            $property->setDescription($propertyTag->getDescription());
-            $property->setType($propertyTag->getType());
-            try {
-                $property->setParent($this);
-                $properties->add($property);
-            } catch (InvalidArgumentException $e) {
-                $this->errors->add(
-                    new Error(
-                        'ERROR',
-                        sprintf(
-                            'Property name is invalid %s',
-                            $e->getMessage(),
-                        ),
-                        null,
-                    ),
-                );
-            }
-        }
-
-        return $properties;
-    }
 }

--- a/tests/unit/phpDocumentor/Descriptor/MagicPropertyContainerTests.php
+++ b/tests/unit/phpDocumentor/Descriptor/MagicPropertyContainerTests.php
@@ -30,7 +30,7 @@ trait MagicPropertyContainerTests
         $expected->setParent($this->fixture);
 
         self::assertEquals(
-            new Collection([$expected]),
+            new Collection(['variableName' => $expected]),
             $magicProperties,
         );
     }


### PR DESCRIPTION
The getMagic* methods will now return an assoc collection. Which prevents overwriting the native methods with a tag. This makes it also impossible to define a method twice using a tag. 

fixes #3716 