### PR TITLE
Fix typo to make it uniform to the rest of the docs

### DIFF
--- a/docs/references/phpdoc/tags/var.rst
+++ b/docs/references/phpdoc/tags/var.rst
@@ -13,7 +13,7 @@ Syntax
 
 .. code-block::
 
-    @var ["Type"] [element_name] [<description>]
+    @var [Type] [element name] [<description>]
 
 Description
 -----------


### PR DESCRIPTION
The docs of all other tags use `[Type]` without parenthesis and spaces instead of undercores.