### PR TITLE
Add support for PHP 8.3 typed class constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "phpdocumentor/guides-markdown": "^1.7",
         "phpdocumentor/guides-restructured-text": "^1.7",
         "phpdocumentor/json-path": "^0.2.1",
-        "phpdocumentor/reflection": "^6.4.4",
+        "phpdocumentor/reflection": "^6.5.0",
         "phpdocumentor/reflection-common": "^2.0",
         "phpdocumentor/reflection-docblock": "^5.4",
         "phpdocumentor/type-resolver": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf19f7d1f3cdc7d5b6da9cccf7875adc",
+    "content-hash": "4e6a73307f062ff938d738512a692a50",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -1990,16 +1990,16 @@
         },
         {
             "name": "phpdocumentor/reflection",
-            "version": "6.4.4",
+            "version": "6.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/Reflection.git",
-                "reference": "5e5db15b34e6eae755cb97beaa7fe076ae9e8d4c"
+                "reference": "70ad4ae38901a1c71623d29192983274671e9113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/5e5db15b34e6eae755cb97beaa7fe076ae9e8d4c",
-                "reference": "5e5db15b34e6eae755cb97beaa7fe076ae9e8d4c",
+                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/70ad4ae38901a1c71623d29192983274671e9113",
+                "reference": "70ad4ae38901a1c71623d29192983274671e9113",
                 "shasum": ""
             },
             "require": {
@@ -2056,9 +2056,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpDocumentor/Reflection/issues",
-                "source": "https://github.com/phpDocumentor/Reflection/tree/6.4.4"
+                "source": "https://github.com/phpDocumentor/Reflection/tree/6.5.0"
             },
-            "time": "2025-11-25T21:21:18+00:00"
+            "time": "2026-04-10T12:00:48+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/ConstantAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/ConstantAssembler.php
@@ -41,6 +41,11 @@ class ConstantAssembler extends AssemblerAbstract
         $constantDescriptor->setName($data->getName());
         $constantDescriptor->setValue($data->getValue(false));
         $constantDescriptor->setFinal($data->isFinal());
+
+        if ($data->getType()) {
+            $constantDescriptor->setType($data->getType());
+        }
+
         // Reflection library formulates namespace as global but this is not wanted for phpDocumentor itself
 
         $separatorLength = ! str_contains((string) $data->getFqsen(), '::') ? 1 : 2;

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/ConstantAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/ConstantAssemblerTest.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Php\Constant;
 use phpDocumentor\Reflection\Php\Expression;
+use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 
@@ -135,5 +136,38 @@ DOCBLOCK,
         self::assertSame('\\' . $namespace, $descriptor->getNamespace());
         self::assertSame($pi, (string) $descriptor->getValue());
         self::assertEquals(new Visibility(VisibilityModifier::PUBLIC), $descriptor->getVisibility());
+    }
+
+    public function testCreateTypedConstantDescriptorFromReflector(): void
+    {
+        $type = new String_();
+        $constantReflector = new Constant(
+            new Fqsen('\MyClass::MY_CONST'),
+            null,
+            new Expression("'hello'"),
+            null,
+            null,
+            null,
+            false,
+            $type,
+        );
+
+        $descriptor = $this->fixture->create($constantReflector);
+
+        self::assertSame('MY_CONST', $descriptor->getName());
+        self::assertEquals($type, $descriptor->getType());
+    }
+
+    public function testCreateUntypedConstantDescriptorHasNullType(): void
+    {
+        $constantReflector = new Constant(
+            new Fqsen('\MyClass::MY_CONST'),
+            null,
+            new Expression("'hello'"),
+        );
+
+        $descriptor = $this->fixture->create($constantReflector);
+
+        self::assertNull($descriptor->getType());
     }
 }


### PR DESCRIPTION
## Summary

Wire the native type from PHP 8.3 typed class constants into the `ConstantDescriptor`, so it is available for rendering in templates.

- Pass the type from the reflection `Constant` to the descriptor in `ConstantAssembler`, following the same pattern used by `PropertyAssembler`
- The HTML template already displays `node.type` for constants, so typed constants will render their native type automatically

When a native type is present, it takes precedence over `@var` docblock annotations (consistent with how PHP itself treats type declarations).

Depends on phpDocumentor/Reflection#736.

Fixes #3721