### PR TITLE
Fix crash when tag body contains URL-encoded characters

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/AuthorAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/AuthorAssembler.php
@@ -19,6 +19,8 @@ use phpDocumentor\Descriptor\Tag\AuthorDescriptor;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\Tags\Author;
 
+use function str_replace;
+
 /**
  * Constructs a new descriptor from the Reflector for an `@author` tag.
  *
@@ -37,7 +39,10 @@ class AuthorAssembler extends AssemblerAbstract
     protected function buildDescriptor(object $data): AuthorDescriptor
     {
         $tag = new AuthorDescriptor($data->getName());
-        $tag->setDescription(new DescriptionDescriptor(new Description((string) $data), []));
+        $tag->setDescription(new DescriptionDescriptor(
+            new Description(str_replace('%', '%%', (string) $data)),
+            [],
+        ));
 
         return $tag;
     }

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ExampleAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/ExampleAssembler.php
@@ -23,6 +23,8 @@ use phpDocumentor\Reflection\DocBlock\ExampleFinder;
 use phpDocumentor\Reflection\DocBlock\Tags\Example;
 use Webmozart\Assert\Assert;
 
+use function str_replace;
+
 /**
  * This class collects data from the example tag definition of the Reflection library, tries to find the correlating
  * example file on disk and creates a complete Descriptor from that.
@@ -54,7 +56,10 @@ class ExampleAssembler extends AssemblerAbstract
         $descriptor->setFilePath($data->getFilePath());
         $descriptor->setStartingLine($data->getStartingLine());
         $descriptor->setLineCount($data->getLineCount());
-        $descriptor->setDescription(new DescriptionDescriptor(new Description($data->getDescription() ?? ''), []));
+        $descriptor->setDescription(new DescriptionDescriptor(
+            new Description(str_replace('%', '%%', $data->getDescription() ?? '')),
+            [],
+        ));
         $descriptor->setExample($this->finder->find($data));
 
         return $descriptor;

--- a/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/InvalidTagAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/Tags/InvalidTagAssembler.php
@@ -12,6 +12,7 @@ use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 
 use function sprintf;
+use function str_replace;
 
 /** @extends AssemblerAbstract<TagDescriptor, InvalidTag> */
 final class InvalidTagAssembler extends AssemblerAbstract
@@ -19,7 +20,10 @@ final class InvalidTagAssembler extends AssemblerAbstract
     public function create(object $data): TagDescriptor
     {
         $descriptor = new TagDescriptor($data->getName());
-        $descriptor->setDescription(new DescriptionDescriptor(new Description((string) $data), []));
+        $descriptor->setDescription(new DescriptionDescriptor(
+            new Description(str_replace('%', '%%', (string) $data)),
+            [],
+        ));
         $descriptor->getErrors()->add(
             new Error(
                 'ERROR',

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/InvalidTagAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/InvalidTagAssemblerTest.php
@@ -33,8 +33,11 @@ final class InvalidTagAssemblerTest extends TestCase
         ));
 
         self::assertSame('see', $tag->getName());
-        // The description body template must escape % to %% so that vsprintf does not
-        // interpret URL-encoded sequences like %20 as format specifiers.
-        self::assertStringContainsString('%%20', $tag->getDescription()->getBodyTemplate());
+        // Rendering the description must not throw a ValueError from vsprintf
+        // interpreting URL-encoded sequences like %20 as format specifiers.
+        self::assertStringContainsString(
+            'LDAP%20Result%20Codes',
+            (string) $tag->getDescription(),
+        );
     }
 }

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/InvalidTagAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/Tags/InvalidTagAssemblerTest.php
@@ -23,4 +23,18 @@ final class InvalidTagAssemblerTest extends TestCase
             $tag->getErrors()[0]->getCode(),
         );
     }
+
+    public function testCreateWithUrlEncodedBody(): void
+    {
+        $assembler = new InvalidTagAssembler();
+        $tag = $assembler->create(InvalidTag::create(
+            'LDAP-Error-Code https://ldapwiki.com/wiki/Wiki.jsp?page=LDAP%20Result%20Codes',
+            'see',
+        ));
+
+        self::assertSame('see', $tag->getName());
+        // The description body template must escape % to %% so that vsprintf does not
+        // interpret URL-encoded sequences like %20 as format specifiers.
+        self::assertStringContainsString('%%20', $tag->getDescription()->getBodyTemplate());
+    }
 }


### PR DESCRIPTION
## Summary

When a tag is invalid (e.g. `@see` with a non-FQSEN reference like `LDAP-Error-Code`), the `InvalidTagAssembler` creates a `Description` directly from the raw tag body. If the body contains URL-encoded sequences like `%20`, `vsprintf` interprets them as format specifiers and throws a `ValueError`.

`DescriptionFactory::create()` already escapes `%` to `%%` for this exact reason (line 81), but the assemblers that bypass the factory and call `new Description(...)` directly were missing the same escaping.

This escapes `%` to `%%` in `InvalidTagAssembler`, `AuthorAssembler`, and `ExampleAssembler`.

## How to reproduce

```php
/**
 * @see LDAP-Error-Code https://ldapwiki.com/wiki/Wiki.jsp?page=LDAP%20Result%20Codes
 */
```

Generates:
```
[ValueError] The arguments array must contain 2 items, 0 given
```

Fixes #3891