### PR TITLE
Adopt reflection 6.6.0 for source line info in parse errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "phpdocumentor/guides-markdown": "^1.7",
         "phpdocumentor/guides-restructured-text": "^1.7",
         "phpdocumentor/json-path": "^0.2.1",
-        "phpdocumentor/reflection": "^6.5.0",
+        "phpdocumentor/reflection": "^6.6.0",
         "phpdocumentor/reflection-common": "^2.0",
         "phpdocumentor/reflection-docblock": "^5.4",
         "phpdocumentor/type-resolver": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e6a73307f062ff938d738512a692a50",
+    "content-hash": "ffac355d036d03c38c1f008ccc1c6a92",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -1990,16 +1990,16 @@
         },
         {
             "name": "phpdocumentor/reflection",
-            "version": "6.5.0",
+            "version": "6.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/Reflection.git",
-                "reference": "70ad4ae38901a1c71623d29192983274671e9113"
+                "reference": "c8d36446027506a005103d57265ba5ea56beabfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/70ad4ae38901a1c71623d29192983274671e9113",
-                "reference": "70ad4ae38901a1c71623d29192983274671e9113",
+                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/c8d36446027506a005103d57265ba5ea56beabfc",
+                "reference": "c8d36446027506a005103d57265ba5ea56beabfc",
                 "shasum": ""
             },
             "require": {
@@ -2056,9 +2056,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpDocumentor/Reflection/issues",
-                "source": "https://github.com/phpDocumentor/Reflection/tree/6.5.0"
+                "source": "https://github.com/phpDocumentor/Reflection/tree/6.6.0"
             },
-            "time": "2026-04-10T12:00:48+00:00"
+            "time": "2026-04-12T18:07:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -7727,7 +7727,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -7740,9 +7740,9 @@
         "ext-simplexml": "*",
         "ext-xml": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/phpDocumentor/Parser/Middleware/ErrorHandlingMiddleware.php
+++ b/src/phpDocumentor/Parser/Middleware/ErrorHandlingMiddleware.php
@@ -43,7 +43,6 @@ final class ErrorHandlingMiddleware implements Middleware
                 '  Unable to parse file "' . $filename . '", an error was detected: ' . $e->getMessage(),
                 LogLevel::ALERT,
             );
-            $this->log('  -- Found in ' . $e->getFile() . ' at line ' . $e->getLine(), LogLevel::NOTICE);
             $this->log('  ' . $e->getTraceAsString(), LogLevel::DEBUG);
         }
 

--- a/tests/unit/phpDocumentor/Parser/Middleware/ErrorHandlingMiddlewareTest.php
+++ b/tests/unit/phpDocumentor/Parser/Middleware/ErrorHandlingMiddlewareTest.php
@@ -74,11 +74,6 @@ final class ErrorHandlingMiddlewareTest extends TestCase
             '  Unable to parse file "' . __FILE__ . '", an error was detected: this is a test',
             [],
         )->shouldBeCalled();
-        $logger->log(
-            LogLevel::NOTICE,
-            Argument::containingString('  -- Found in '),
-            [],
-        )->shouldBeCalled();
         $logger->log(LogLevel::DEBUG, Argument::any(), [])->shouldBeCalled();
 
         $middleware = new ErrorHandlingMiddleware($logger->reveal());


### PR DESCRIPTION
Fixes #3537. Follow-up to @jaapio's review — the line/file context now lives in `phpDocumentor/Reflection 6.6.0` (via `NodesFactory`), so this PR is reduced to:

- bump `phpdocumentor/reflection` to `^6.6.0`
- drop the middleware's walking logic (superseded by the wrapped exception message)
- drop the NOTICE log that used to point at phpDocumentor internals rather than the offending source file

Thanks a lot for the guidance on the right place to host this fix!