### PR TITLE
Scope Tags/Attributes anchors to the enclosing element

### DIFF
--- a/data/templates/default/components/attributes.html.twig
+++ b/data/templates/default/components/attributes.html.twig
@@ -1,9 +1,10 @@
+{% import 'components/macros/anchor.macro.twig' as anchor %}
 {% if node is attributed %}
     {% set attributes = attributes(node)|specializedAttributes|sortByVisibility %}
 
     {% if attributes is not empty %}
         <section class="phpdocumentor-attributes">
-            <h5 class="phpdocumentor-elements__header" id="attributes">
+            <h5 class="phpdocumentor-elements__header" id="{{ anchor.for_element(node, 'attributes') }}">
                 Attributes {{ include('components/headerlink.html.twig', {'on': node, 'at': 'attributes'}, with_context = false) }}
             </h5>
             {% for attribute in attributes %}

--- a/data/templates/default/components/headerlink.html.twig
+++ b/data/templates/default/components/headerlink.html.twig
@@ -1,1 +1,4 @@
-<a href="{{ link(on) ~ (at ? ('#' ~ at)) }}" class="headerlink"><i class="fas fa-link"></i></a>
+{% import 'components/macros/anchor.macro.twig' as anchor %}
+{%- set base = link(on)|split('#')|first -%}
+{%- set fragment = anchor.for_element(on, at) -%}
+<a href="{{ fragment ? base ~ '#' ~ fragment : base }}" class="headerlink"><i class="fas fa-link"></i></a>

--- a/data/templates/default/components/macros/anchor.macro.twig
+++ b/data/templates/default/components/macros/anchor.macro.twig
@@ -1,0 +1,10 @@
+{%- macro for_element(node, suffix = null) -%}
+{%- set existing = link(node)|split('#')|slice(1)|join('#') -%}
+{%- if existing and suffix -%}
+{{- existing ~ '_' ~ suffix -}}
+{%- elseif existing -%}
+{{- existing -}}
+{%- elseif suffix -%}
+{{- suffix -}}
+{%- endif -%}
+{%- endmacro -%}

--- a/data/templates/default/components/tags.html.twig
+++ b/data/templates/default/components/tags.html.twig
@@ -1,7 +1,8 @@
+{% import 'components/macros/anchor.macro.twig' as anchor %}
 {% set tags = node.tags|filter((v,k) => k not in ['var', 'param', 'property', 'property-read', 'property-write', 'method', 'return', 'package', 'api', 'deprecated']) %}
 
 {% if tags|length > 0 and tags|first|length > 0 %}
-    <h5 class="phpdocumentor-tag-list__heading" id="tags">
+    <h5 class="phpdocumentor-tag-list__heading" id="{{ anchor.for_element(node, 'tags') }}">
         Tags
         {{ include('components/headerlink.html.twig', {'on': node, 'at': 'tags'}, with_context = false) }}
     </h5>


### PR DESCRIPTION
Fixes #3734.

Tags and Attributes sub-sections rendered inside class constants, methods, properties or enum cases were sharing `id="tags"`/`id="attributes"` across the page and producing `##`-style header link hrefs like `classes/Foo.html#constant_VERSION#tags`. Route ids and header links through a shared anchor macro that scopes the suffix with the enclosing element's URL fragment (e.g. `#constant_VERSION_tags`).