### PR TITLE
Remove dangling Related topics link from the Inheritance guide

### DIFF
--- a/docs/guides/inheritance.rst
+++ b/docs/guides/inheritance.rst
@@ -120,8 +120,3 @@ that overridden method:
 As with classes, each of the above will only be inherited if the redefined method's DocBlock does not have the
 element that is to be inherited. So, for example, if the DocBlock of the redefined method has a summary then it will
 not receive the overridden method's summary.
-
-Related topics
---------------
-
-* :doc:`../references/phpdoc/inline-tags/inheritdoc`, for a full description of the ``@inheritDoc`` inline tag.


### PR DESCRIPTION
Fixes #3038.

The sole entry pointed to `inline-tags/inheritdoc`, which is just a "contents have not been written yet" placeholder. The `{@inheritDoc}` tag is already fully described earlier in the same guide.