### PR TITLE
Group repeated tag entries in the default template

### DIFF
--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -82,6 +82,25 @@ describe('Classes', function() {
                     .parent()
                     .should('have.attr', 'href', 'https://docs.phpdoc.org')
             });
+
+            it('Groups repeated tags under a single entry with one definition per occurrence', function () {
+                cy.get('.phpdocumentor-element.-class > .phpdocumentor-tag-list > .phpdocumentor-tag-list__entry')
+                    .as('entries')
+                    .should('have.length', 2);
+                cy.get('@entries').eq(0)
+                    .should('contain', 'link')
+                    .next('.phpdocumentor-tag-list__definition')
+                    .should('contain', 'https://wwww.phpdoc.org')
+                    .next('.phpdocumentor-tag-list__definition')
+                    .should('contain', 'docs');
+                cy.get('@entries').eq(1)
+                    .should('contain', 'since')
+                    .next('.phpdocumentor-tag-list__definition')
+                    .should('contain', '3.0')
+                    .next('.phpdocumentor-tag-list__definition')
+                    .should('contain', '3.1')
+                    .and('contain', 'Does extra stuff');
+            });
         });
     });
 

--- a/data/templates/default/components/tags.html.twig
+++ b/data/templates/default/components/tags.html.twig
@@ -1,17 +1,19 @@
 {% import 'components/macros/anchor.macro.twig' as anchor %}
-{% set tags = node.tags|filter((v,k) => k not in ['var', 'param', 'property', 'property-read', 'property-write', 'method', 'return', 'package', 'api', 'deprecated']) %}
+{% set tags = node.tags
+    |filter((v, k) => k not in ['var', 'param', 'property', 'property-read', 'property-write', 'method', 'return', 'package', 'api', 'deprecated'])
+    |filter(seriesOfTag => seriesOfTag|length > 0) %}
 
-{% if tags|length > 0 and tags|first|length > 0 %}
+{% if tags|length > 0 %}
     <h5 class="phpdocumentor-tag-list__heading" id="{{ anchor.for_element(node, 'tags') }}">
         Tags
         {{ include('components/headerlink.html.twig', {'on': node, 'at': 'tags'}, with_context = false) }}
     </h5>
     <dl class="phpdocumentor-tag-list">
-        {% for name,seriesOfTag in tags %}
+        {% for name, seriesOfTag in tags %}
+            <dt class="phpdocumentor-tag-list__entry">
+                <span class="phpdocumentor-tag__name">{{ name }}</span>
+            </dt>
             {% for tag in seriesOfTag %}
-                <dt class="phpdocumentor-tag-list__entry">
-                    <span class="phpdocumentor-tag__name">{{ name }}</span>
-                </dt>
                 <dd class="phpdocumentor-tag-list__definition">
                     {% if tag.version %}
                         <span class="phpdocumentor-tag-link">{{ tag.version }}</span>
@@ -23,11 +25,9 @@
                         <span class="phpdocumentor-tag-link">{{ tag.reference|route('class:short')|join('|')|raw }}</span>
                     {% endif %}
                     {% if tag.link %}
-                        <a class="phpdocumentor-tag-link" href="{{ tag.link }}">{% if not tag.description.empty %} {{ tag.description | description | markdown }} {% else %} {{ tag.link }} {%  endif %}</a>
-                    {% endif %}
-
-                    {% if not tag.link %}
-                         {{ include('components/description.html.twig', {'node': tag}) }}
+                        <a class="phpdocumentor-tag-link" href="{{ tag.link }}">{% if not tag.description.empty %} {{ tag.description | description | markdown }} {% else %} {{ tag.link }} {% endif %}</a>
+                    {% else %}
+                        {{ include('components/description.html.twig', {'node': tag}) }}
                     {% endif %}
                 </dd>
             {% endfor %}


### PR DESCRIPTION
In the default template, multiple occurrences of the same tag (for instance two `@since` entries or two `@link` entries on the same element) were rendered as a staircase of duplicated `<dt>name</dt><dd>value</dd>` pairs. jrfnl's mockup in issue #2230 shows a cleaner grouping under a single label per tag name; that also matches the canonical `<dl>` pattern for term-with-multiple-definitions.

- One `<dt>` per tag name, one `<dd>` per occurrence
- Pre-filter empty tag series so upstream compiler passes that keep a placeholder empty entry no longer leak an orphan `<dt>` (the previous `tags|first|length > 0` guard also hid the whole section whenever the first series was empty; that is now consistent for every series)
- Fold the `{% if tag.link %}` / `{% if not tag.link %}` pair into a single `{% if … %}{% else %}{% endif %}` while the block was being touched anyway

Adds a cypress assertion on `Marios-Pizzeria.html` confirming the grouping for both `@link` and `@since` with the exact number of entries and the first occurrence contained in the next `<dd>` sibling.

Fixes #2230