### PR TITLE
Fix deprecated condition referencing the collection variable

### DIFF
--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -103,6 +103,25 @@ describe('Classes', function() {
             getEntryIn('Methods', 'order()').should('exist');
             getEntryIn('Methods', 'doOrder()').should('exist');
         });
+        it('omits the class attribute on non-deprecated entries', function() {
+            getEntryIn('Methods', 'jsonSerialize()').should('not.have.attr', 'class');
+        });
+        it('marks deprecated entries with the -deprecated class', function() {
+            getEntryIn('Methods', 'doOldOrder()').should('have.class', '-deprecated');
+        });
+    });
+
+    describe('Table of Contents links', function() {
+        it('omits the class attribute on a regular method link', function() {
+            cy.get('.phpdocumentor-table-of-contents__entry')
+                .contains('a', 'jsonSerialize()')
+                .should('not.have.attr', 'class');
+        });
+        it('marks a deprecated method link with the -deprecated class', function() {
+            cy.get('.phpdocumentor-table-of-contents__entry')
+                .contains('a', 'doOldOrder()')
+                .should('have.class', '-deprecated');
+        });
     });
 
     describe('Applying a trait', function() {

--- a/data/templates/clean/class.html.twig
+++ b/data/templates/clean/class.html.twig
@@ -65,7 +65,7 @@
 
 								{% if public_methods|length > 0 %}
 									{% for method in public_methods %}
-										<a href="{{ method|route('url') }}" class="{{ method.deprecated ? 'deprecated' }}">{{ method.name }}</a><br/>
+										<a href="{{ method|route('url') }}"{% if method.deprecated %} class="deprecated"{% endif %}>{{ method.name }}</a><br/>
 									{% endfor %}
 								{% else %}
 									<em>No public methods found</em>
@@ -81,7 +81,7 @@
 
 								{% if public_properties|length > 0 %}
 									{% for property in public_properties %}
-										<a href="{{ property|route('url') }}" class="{{ property.deprecated ? 'deprecated' }}">{{ property.name }}</a><br/>
+										<a href="{{ property|route('url') }}"{% if property.deprecated %} class="deprecated"{% endif %}>{{ property.name }}</a><br/>
 									{% endfor %}
 								{% else %}
 									<em>No public properties found</em>
@@ -97,7 +97,7 @@
 
 								{% if public_constants|length > 0 %}
 									{% for constant in public_constants %}
-										<a href="{{ constant|route('url') }}" class="{{ constant.deprecated ? 'deprecated' }}">{{ constant.name }}</a><br/>
+										<a href="{{ constant|route('url') }}"{% if constant.deprecated %} class="deprecated"{% endif %}>{{ constant.name }}</a><br/>
 									{% endfor %}
 								{% else %}
 									<em>No public constants found</em>
@@ -115,7 +115,7 @@
 
 								{% if protected_methods|length > 0 %}
 									{% for method in protected_methods %}
-										<a href="{{ method|route('url') }}" class="{{ method.deprecated ? 'deprecated' }}">{{ method.name }}</a><br/>
+										<a href="{{ method|route('url') }}"{% if method.deprecated %} class="deprecated"{% endif %}>{{ method.name }}</a><br/>
 									{% endfor %}
 								{% else %}
 									<em>No protected methods found</em>
@@ -131,7 +131,7 @@
 
 								{% if protected_properties|length > 0 %}
 									{% for property in protected_properties %}
-										<a href="{{ property|route('url') }}" class="{{ property.deprecated ? 'deprecated' }}">{{ property.name }}</a><br/>
+										<a href="{{ property|route('url') }}"{% if property.deprecated %} class="deprecated"{% endif %}>{{ property.name }}</a><br/>
 									{% endfor %}
 								{% else %}
 									<em>No protected properties found</em>
@@ -147,7 +147,7 @@
 
 								{% if protected_constants|length > 0 %}
 									{% for constant in protected_constants %}
-										<a href="{{ constant|route('url') }}" class="{{ constant.deprecated ? 'deprecated' }}">{{ constant.name }}</a><br/>
+										<a href="{{ constant|route('url') }}"{% if constant.deprecated %} class="deprecated"{% endif %}>{{ constant.name }}</a><br/>
 									{% endfor %}
 								{% else %}
 									<em>No protected constants found</em>
@@ -165,7 +165,7 @@
 
 								{% if private_methods|length > 0 %}
 									{% for method in private_methods %}
-										<a href="{{ method|route('url') }}" class="{{ method.deprecated ? 'deprecated' }}">{{ method.name }}</a><br/>
+										<a href="{{ method|route('url') }}"{% if method.deprecated %} class="deprecated"{% endif %}>{{ method.name }}</a><br/>
 									{% endfor %}
 								{% else %}
 									<em>No private methods found</em>
@@ -181,7 +181,7 @@
 
 								{% if private_properties|length > 0 %}
 									{% for property in private_properties %}
-										<a href="{{ property|route('url') }}" class="{{ property.deprecated ? 'deprecated' }}">{{ property.name }}</a><br/>
+										<a href="{{ property|route('url') }}"{% if property.deprecated %} class="deprecated"{% endif %}>{{ property.name }}</a><br/>
 									{% endfor %}
 								{% else %}
 									<em>No private properties found</em>
@@ -197,7 +197,7 @@
 
 								{% if private_constants|length > 0 %}
 									{% for constant in private_constants %}
-										<a href="{{ constant|route('url') }}" class="{{ constant.deprecated ? 'deprecated' }}">{{ constant.name }}</a><br/>
+										<a href="{{ constant|route('url') }}"{% if constant.deprecated %} class="deprecated"{% endif %}>{{ constant.name }}</a><br/>
 									{% endfor %}
 								{% else %}
 									<em>No private constants found</em>

--- a/data/templates/default/class.html.twig
+++ b/data/templates/default/class.html.twig
@@ -42,7 +42,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li class="{% if constant.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li{% if constant.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -53,7 +53,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for property in properties|sortByVisibility %}
-                            <li class="{% if property.deprecated %}-deprecated{% endif %}"><a href="{{ link(property) }}">${{ property.name }}</a></li>
+                            <li{% if property.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(property) }}">${{ property.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -64,7 +64,7 @@
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for method in methods|sortByVisibility %}
-                        <li class="{% if method.deprecated %}-deprecated{% endif %}"><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                        <li{% if method.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(method) }}">{{ method.name }}()</a></li>
                     {% endfor %}
                 </ul>
             </li>

--- a/data/templates/default/components/menu.html.twig
+++ b/data/templates/default/components/menu.html.twig
@@ -1,13 +1,13 @@
 {% if depth == 1 %}
 <h4 class="phpdocumentor-sidebar__root-namespace">
-    <a href="{{ entry.url }}" class="{{ destinationPath|trim('/', 'left') == entry.url ? '-active' }}">{{ entry.title | shortFQSEN }}</a>
+    <a href="{{ entry.url }}"{% if destinationPath|trim('/', 'left') == entry.url %} class="-active"{% endif %}>{{ entry.title | shortFQSEN }}</a>
 </h4>
 {% endif %}
 {% if entry.children.count > 0 %}
     <ul class="phpdocumentor-list">
         {% for child in entry.children %}
             <li>
-                <a href="{{ child.url }}" class="{{ destinationPath|trim('/', 'left') == child.url ? '-active' }}">{{ child.title | shortFQSEN }}</a>
+                <a href="{{ child.url }}"{% if destinationPath|trim('/', 'left') == child.url %} class="-active"{% endif %}>{{ child.title | shortFQSEN }}</a>
                 {{ toc(child, 'components/menu.html.twig', maxDepth, depth) }}
             </li>
         {% endfor %}

--- a/data/templates/default/components/table-of-contents-entry.html.twig
+++ b/data/templates/default/components/table-of-contents-entry.html.twig
@@ -1,5 +1,5 @@
 <dt class="phpdocumentor-table-of-contents__entry -{{ type }} -{{ node.visibility }}">
-    <a class="{% if node.deprecated %}-deprecated{% endif %}" href="{{ link(node) }}">{{ node is property ? '$' }}{{ node.name }}{{ node is method or node is function ? '()' }}</a>
+    <a{% if node.deprecated %} class="-deprecated"{% endif %} href="{{ link(node) }}">{{ node is property ? '$' }}{{ node.name }}{{ node is method or node is function ? '()' }}</a>
     <span>
         {% if node is constant %}&nbsp;= {{ node.value }}{% endif %}
         {% if node is enumCase %}{% if node.value %}&nbsp;= {{ node.value }}{% endif %}{% endif %}

--- a/data/templates/default/enum.html.twig
+++ b/data/templates/default/enum.html.twig
@@ -43,7 +43,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for case in cases %}
-                            <li class="{% if case.deprecated %}-deprecated{% endif %}"><a href="{{ link(case) }}">{{ case.name }}</a></li>
+                            <li{% if case.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(case) }}">{{ case.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -54,7 +54,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for method in methods|sortByVisibility %}
-                            <li class="{% if method.deprecated %}-deprecated{% endif %}"><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                            <li{% if method.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(method) }}">{{ method.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/file.html.twig
+++ b/data/templates/default/file.html.twig
@@ -61,7 +61,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li{% if constants.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li{% if constant.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/file.html.twig
+++ b/data/templates/default/file.html.twig
@@ -61,7 +61,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li{% if constants.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -72,7 +72,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for function in functions|sortByVisibility %}
-                            <li class="{% if function.deprecated %}-deprecated{% endif %}"><a href="{{ link(function) }}">{{ function.name }}()</a></li>
+                            <li{% if function.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(function) }}">{{ function.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/interface.html.twig
+++ b/data/templates/default/interface.html.twig
@@ -45,7 +45,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li{% if constants.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li{% if constant.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/interface.html.twig
+++ b/data/templates/default/interface.html.twig
@@ -34,7 +34,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for method in methods|sortByVisibility %}
-                            <li class="{% if method.deprecated %}-deprecated{% endif %}"><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                            <li{% if method.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(method) }}">{{ method.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -45,7 +45,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li{% if constants.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/namespace.html.twig
+++ b/data/templates/default/namespace.html.twig
@@ -55,7 +55,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li{% if constants.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -66,7 +66,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for function in functions|sortByVisibility %}
-                            <li class="{% if function.deprecated %}-deprecated{% endif %}"><a href="{{ link(function) }}">{{ function.name }}()</a></li>
+                            <li{% if function.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(function) }}">{{ function.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/namespace.html.twig
+++ b/data/templates/default/namespace.html.twig
@@ -55,7 +55,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li{% if constants.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li{% if constant.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/package.html.twig
+++ b/data/templates/default/package.html.twig
@@ -55,7 +55,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li class="{% if constants.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li{% if constants.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>
@@ -66,7 +66,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for function in functions|sortByVisibility %}
-                            <li class="{% if function.deprecated %}-deprecated{% endif %}"><a href="{{ link(function) }}">{{ function.name }}()</a></li>
+                            <li{% if function.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(function) }}">{{ function.name }}()</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/package.html.twig
+++ b/data/templates/default/package.html.twig
@@ -55,7 +55,7 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                         {% for constant in constants|sortByVisibility %}
-                            <li{% if constants.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                            <li{% if constant.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/data/templates/default/trait.html.twig
+++ b/data/templates/default/trait.html.twig
@@ -43,7 +43,7 @@
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for constant in constants|sortByVisibility %}
-                        <li class="{% if constant.deprecated %}-deprecated{% endif %}"><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
+                        <li{% if constant.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(constant) }}">{{ constant.name }}</a></li>
                     {% endfor %}
                 </ul>
             </li>
@@ -53,7 +53,7 @@
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for property in properties|sortByVisibility %}
-                        <li class="{% if property.deprecated %}-deprecated{% endif %}"><a href="{{ link(property) }}">${{ property.name }}</a></li>
+                        <li{% if property.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(property) }}">${{ property.name }}</a></li>
                     {% endfor %}
                 </ul>
             </li>
@@ -63,7 +63,7 @@
             <li>
                 <ul class="phpdocumentor-list -clean">
                     {% for method in methods|sortByVisibility %}
-                        <li class="{% if method.deprecated %}-deprecated{% endif %}"><a href="{{ link(method) }}">{{ method.name }}()</a></li>
+                        <li{% if method.deprecated %} class="-deprecated"{% endif %}><a href="{{ link(method) }}">{{ method.name }}()</a></li>
                     {% endfor %}
                 </ul>
             </li>


### PR DESCRIPTION
In the On This Page listing for top-level / interface-level constants, four templates tested `{% if constants.deprecated %}` where the loop variable is `constant` (singular):

- `data/templates/default/file.html.twig`
- `data/templates/default/interface.html.twig`
- `data/templates/default/namespace.html.twig`
- `data/templates/default/package.html.twig`

`Collection` exposes no `deprecated` accessor, so the condition was always falsy and a deprecated top-level constant silently rendered without the `-deprecated` class. The equivalent listings in `class.html.twig`, `trait.html.twig` and `enum.html.twig` already use the loop variable, so the fix just aligns these four.

Sits on top of #4094 so the line context lines up with the already-queued class-attribute cleanup. Fine to merge in either order — the changes are orthogonal — though #4094 → this PR reads more naturally in a follow-up review.