### PR TITLE
Render Array_ without explicit key using the short form in LinkRenderer

### DIFF
--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -109,7 +109,7 @@ describe('Classes', function() {
             getTocEntry(getToc('methods', 'Methods'), 'jsonSerialize()')
                 .should('have.class', '-method')
                 .and('have.class', '-public')
-                .and('contain', ': array<string|int, mixed>'); // type including generic arguments
+                .and('contain', ': array'); // untyped array renders with the short form
         });
     });
 

--- a/cypress/integration/default/properties.spec.js
+++ b/cypress/integration/default/properties.spec.js
@@ -226,7 +226,7 @@ describe('Showing properties for a class', function() {
             it('Shows property with array type', function() {
                 getElementWithName('property', '$ingredients')
                     .find('.phpdocumentor-signature__type')
-                    .should('contain', 'array');
+                    .should('contain', 'string[]');
             });
 
             it('Shows doc comment type for array items', function() {

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/AbstractListAdapter.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/AbstractListAdapter.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
 
 use InvalidArgumentException;
+use phpDocumentor\Reflection\PseudoType;
 use phpDocumentor\Reflection\Types\AbstractList;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Collection;
+use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Iterable_;
+use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Transformer\Writer\Twig\LinkRendererInterface;
 
 use function assert;
@@ -51,11 +54,38 @@ final class AbstractListAdapter implements LinkRendererInterface
         // the above would already assert this, but phpstan and phpstorm need this
         assert($value instanceof AbstractList);
 
+        if (
+            $value instanceof Array_
+            && ! $value instanceof PseudoType
+            && $value->getOriginalKeyType() === null
+        ) {
+            return $this->renderShortArray($value, $presentation);
+        }
+
         $listType = $this->renderListType($value, $presentation);
         $keyType = $this->renderKeyType($value, $presentation);
         $valueType = $this->renderValueType($value, $presentation);
 
         return sprintf('%s&lt;%s, %s&gt;', $listType, $keyType, $valueType);
+    }
+
+    /**
+     * Renders an Array_ without an explicit key type using the short form
+     * (`value[]`, `(value)[]` or `array`), mirroring Array_::__toString().
+     */
+    private function renderShortArray(Array_ $value, string $presentation): string
+    {
+        if ($value->getValueType() instanceof Mixed_) {
+            return 'array';
+        }
+
+        $valueType = $this->renderValueType($value, $presentation);
+
+        if ($value->getValueType() instanceof Compound) {
+            return sprintf('(%s)[]', $valueType);
+        }
+
+        return sprintf('%s[]', $valueType);
     }
 
     private function renderListType(AbstractList $node, string $presentation): string

--- a/tests/integration/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
+++ b/tests/integration/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
@@ -260,7 +260,7 @@ final class LinkRendererTest extends TestCase
                     new String_()
                 ),
                 LinkRenderer::PRESENTATION_CLASS_SHORT,
-                'array&lt;string|int, string&gt;',
+                'string[]',
             ],
             'iterable with scalar only' => [
                 new Iterable_(

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/AbstractListAdapterTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/AbstractListAdapterTest.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
 use InvalidArgumentException;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\PseudoTypes\List_;
+use phpDocumentor\Reflection\PseudoTypes\NonEmptyArray;
 use phpDocumentor\Reflection\Types\AbstractList;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Boolean;
@@ -23,6 +24,7 @@ use phpDocumentor\Reflection\Types\Collection;
 use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\Mixed_;
+use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
 use phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
 use phpDocumentor\Transformer\Writer\Twig\LinkRendererInterface;
@@ -57,6 +59,12 @@ final class AbstractListAdapterTest extends TestCase
         $this->linkRenderer
             ->render(new Compound([new Boolean(), new String_()]), Argument::any())
             ->willReturn(['bool', 'string']);
+        $this->linkRenderer
+            ->render(new Object_(new Fqsen('\MyApp\User')), Argument::any())
+            ->willReturn('<a href="classes/MyApp-User.html">\MyApp\User</a>');
+        $this->linkRenderer
+            ->render(new Array_(new String_()), Argument::any())
+            ->willReturn('string[]');
 
         $this->adapter = new AbstractListAdapter(
             $this->linkRenderer->reveal(),
@@ -88,11 +96,23 @@ final class AbstractListAdapterTest extends TestCase
         return [
             'Array with undefined key nor value' => [
                 new Array_(),
-                'array&lt;string|int, mixed&gt;',
+                'array',
             ],
             'Array with undefined key and string value' => [
                 new Array_(new String_()),
-                'array&lt;string|int, string&gt;',
+                'string[]',
+            ],
+            'Array with undefined key and a value rendered as an array of boolean and string' => [
+                new Array_(new Compound([new Boolean(), new String_()])),
+                '(bool|string)[]',
+            ],
+            'Array of linked objects keeps the link in the short form' => [
+                new Array_(new Object_(new Fqsen('\MyApp\User'))),
+                '<a href="classes/MyApp-User.html">\MyApp\User</a>[]',
+            ],
+            'Nested array of strings renders as string[][]' => [
+                new Array_(new Array_(new String_())),
+                'string[][]',
             ],
             'Array with integer key, and a value that is rendered as an array of boolean and string' => [
                 new Array_(new Compound([new Boolean(), new String_()]), new Integer()),
@@ -105,6 +125,10 @@ final class AbstractListAdapterTest extends TestCase
             'List with undefined key nor value' => [
                 new List_(),
                 'array&lt;int, mixed&gt;',
+            ],
+            'NonEmptyArray with undefined key and string value keeps long form' => [
+                new NonEmptyArray(new String_()),
+                'array&lt;string|int, string&gt;',
             ],
             'Collection with string value' => [
                 new Collection(new Fqsen('\MyAwesome\Collection'), new String_()),


### PR DESCRIPTION
Fixes #3322.

When rendering an Array_ type that has no explicit key type (for example `string[]`), the `AbstractListAdapter` now produces the same short form as `Array_::__toString()` (`string[]`, `(A|B)[]`, or `array`) instead of `array<string|int, string>`.

Plain `Array_` only: pseudo-types (`List_`, `NonEmptyList`, `NonEmptyArray`) keep their current rendering, and explicit keys (`array<int, T>`) still use the long form.