### PR TITLE
Clarify $this keyword usage in PHPDoc types

### DIFF
--- a/docs/guides/types.rst
+++ b/docs/guides/types.rst
@@ -124,8 +124,11 @@ static
     An object of the class where this value was consumed, if inherited it will represent the child class. (see late
     static binding in the PHP manual).
 
-$this
-    This exact object instance, usually used to denote a fluent interface.
+.. note::
+
+   The ``$this`` keyword is not a formal type in the PHPDoc Standard but is
+   supported by phpDocumentor in ``@return`` tags to denote fluent interfaces.
+   See the :doc:`../references/phpdoc/tags/return` reference for details.
 
 Arrays
 ------

--- a/docs/references/phpdoc/tags/return.rst
+++ b/docs/references/phpdoc/tags/return.rst
@@ -39,9 +39,9 @@ The ``$this`` keyword
 ~~~~~~~~~~~~~~~~~~~~~
 
 In addition to the regular :doc:`Types <../types>`, the ``@return`` tag accepts
-``$this`` as a pseudo-type to denote that the method returns the current object
+the ``$this`` keyword to denote that the method returns the current object
 instance itself. It is commonly used to document `fluent interfaces`_ where
-every setter returns ``$this`` so that calls can be chained:
+setters may return ``$this`` so that calls can be chained:
 
 .. code-block:: php
    :linenos:
@@ -58,7 +58,7 @@ every setter returns ``$this`` so that calls can be chained:
 Unlike ``self`` (an instance of the class where the method is declared) and
 ``static`` (an instance of the late-static-bound class), ``$this`` specifically
 refers to the exact instance on which the method was called, which is the
-semantic most IDEs rely on to offer auto-completion on chained calls.
+semantics most IDEs rely on to offer auto-completion on chained calls.
 
 The ``$this`` notation is only meaningful in the context of a ``@return`` tag;
 using it in other tags or types is not part of the PHPDoc Standard.

--- a/docs/references/phpdoc/tags/return.rst
+++ b/docs/references/phpdoc/tags/return.rst
@@ -35,6 +35,34 @@ individual project, MAY be:
 This tag MUST NOT occur more than once in a PHPDoc and is limited to
 *Structural Elements* of type method or function.
 
+The ``$this`` keyword
+~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the regular :doc:`Types <../types>`, the ``@return`` tag accepts
+``$this`` as a pseudo-type to denote that the method returns the current object
+instance itself. It is commonly used to document `fluent interfaces`_ where
+every setter returns ``$this`` so that calls can be chained:
+
+.. code-block:: php
+   :linenos:
+
+    /**
+     * @return $this
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+Unlike ``self`` (an instance of the class where the method is declared) and
+``static`` (an instance of the late-static-bound class), ``$this`` specifically
+refers to the exact instance on which the method was called, which is the
+semantic most IDEs rely on to offer auto-completion on chained calls.
+
+The ``$this`` notation is only meaningful in the context of a ``@return`` tag;
+using it in other tags or types is not part of the PHPDoc Standard.
+
 Effects in phpDocumentor
 ------------------------
 
@@ -75,3 +103,4 @@ Function can return either of two types:
     }
 
 .. _return value of functions or methods: https://www.php.net/functions.returning-values
+.. _fluent interfaces: https://en.wikipedia.org/wiki/Fluent_interface


### PR DESCRIPTION
Fixes #1896.

Removes the `$this` entry from the Supported Types guide (it is not a formal PHPDoc type) and moves the explanation to the `@return` tag reference, where `$this` is actually meaningful for fluent interfaces.

Direction agreed with @jaapio in the issue thread.