### PR TITLE
docs: clarify @package separator characters

### DIFF
--- a/docs/references/phpdoc/tags/package.rst
+++ b/docs/references/phpdoc/tags/package.rst
@@ -53,9 +53,13 @@ organized in their own sidebar section.
 
 .. note::
 
-    Aside from the backslash (``\``), phpDocumentor also allows the
-    underscore (``_``) and dot (``.``) as separators for compatibility
-    with existing projects. Despite this the backslash is RECOMMENDED
+    Aside from the backslash (``\``), phpDocumentor also accepts the
+    underscore (``_``), dot (``.``), hyphen (``-``) and square brackets
+    (``[``, ``]``) as separators for compatibility with existing projects.
+    They are treated as equivalent to the backslash and cannot be part
+    of a level name: ``@package PSR_Documentation_API`` is interpreted
+    as the three levels ``PSR``, ``Documentation`` and ``API``, not as
+    a single top-level name. Despite this the backslash is RECOMMENDED
     as separator.
 
 Examples
@@ -66,6 +70,16 @@ Examples
 
     /**
      * @package PSR\Documentation\API
+     */
+
+The following DocBlock is equivalent to ``@package PSR\Documentation\API``
+because the underscore is interpreted as a separator:
+
+.. code-block:: php
+   :linenos:
+
+    /**
+     * @package PSR_Documentation_API
      */
 
 .. _Namespaces: https://www.php.net/language.namespaces


### PR DESCRIPTION
The current reference lists only `_` and `.` as alternative separators, and the legacy manual example (`applies_to_bluh`) suggests `_` can be part of a level name. In practice `PackageTreeBuilder::normalizePackageName` converts `.`, `_`, `-`, `[` and `]` into backslashes unconditionally, so `applies_to_bluh` is three levels.

Extend the note with the full list and an explicit example so the reference matches the implementation.

Fixes #3668