### PR TITLE
Include element FQN in HTML page title

### DIFF
--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -27,7 +27,7 @@ describe('Classes', function() {
 
     describe('Synopsis', function() {
         it('Page title includes the fully qualified class name', function () {
-            cy.title().should('contain', '\\Marios\\Pizzeria');
+            cy.title().should('match', /\u00bb \\Marios\\Pizzeria$/);
         });
 
         it('Has "Pizzeria" as title', function () {

--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -27,7 +27,7 @@ describe('Classes', function() {
 
     describe('Synopsis', function() {
         it('Page title includes the fully qualified class name', function () {
-            cy.title().should('match', /\u00bb \\Marios\\Pizzeria$/);
+            cy.title().should('match', /\u00bb \\Marios\\Pizzeria\s*$/);
         });
 
         it('Has "Pizzeria" as title', function () {

--- a/cypress/integration/default/classes.spec.js
+++ b/cypress/integration/default/classes.spec.js
@@ -26,6 +26,10 @@ describe('Classes', function() {
     });
 
     describe('Synopsis', function() {
+        it('Page title includes the fully qualified class name', function () {
+            cy.title().should('contain', '\\Marios\\Pizzeria');
+        });
+
         it('Has "Pizzeria" as title', function () {
             cy.get('.phpdocumentor-content__title').contains('Pizzeria');
         });

--- a/cypress/integration/default/interfaces.spec.js
+++ b/cypress/integration/default/interfaces.spec.js
@@ -27,7 +27,7 @@ describe('Interfaces', function() {
 
     describe('Synopsis', function() {
         it('Page title includes the fully qualified interface name', function () {
-            cy.title().should('match', /\u00bb \\Marios\\Product$/);
+            cy.title().should('match', /\u00bb \\Marios\\Product\s*$/);
         });
 
         it('Has "Product" as title', function () {

--- a/cypress/integration/default/interfaces.spec.js
+++ b/cypress/integration/default/interfaces.spec.js
@@ -26,6 +26,10 @@ describe('Interfaces', function() {
     });
 
     describe('Synopsis', function() {
+        it('Page title includes the fully qualified interface name', function () {
+            cy.title().should('match', /\u00bb \\Marios\\Product$/);
+        });
+
         it('Has "Product" as title', function () {
             cy.get('.phpdocumentor-content__title').contains('Product');
         });

--- a/cypress/integration/default/namespaces.spec.js
+++ b/cypress/integration/default/namespaces.spec.js
@@ -25,6 +25,10 @@ describe('Namespaces', function() {
         it('Has "Marios" as title', function() {
             cy.get('.phpdocumentor-content__title').contains("Marios");
         });
+
+        it('Page title includes the fully qualified namespace', function() {
+            cy.title().should('contain', '\\Marios');
+        });
     });
 
     describe('Table of Contents', function() {

--- a/cypress/integration/default/namespaces.spec.js
+++ b/cypress/integration/default/namespaces.spec.js
@@ -27,7 +27,12 @@ describe('Namespaces', function() {
         });
 
         it('Page title includes the fully qualified namespace', function() {
-            cy.title().should('contain', '\\Marios');
+            cy.title().should('match', /\u00bb \\Marios$/);
+        });
+
+        it('Page title for the root namespace omits the separator', function() {
+            cy.visit('build/default/namespaces/default.html');
+            cy.title().should('not.contain', '\u00bb');
         });
     });
 

--- a/cypress/integration/default/namespaces.spec.js
+++ b/cypress/integration/default/namespaces.spec.js
@@ -27,7 +27,7 @@ describe('Namespaces', function() {
         });
 
         it('Page title includes the fully qualified namespace', function() {
-            cy.title().should('match', /\u00bb \\Marios$/);
+            cy.title().should('match', /\u00bb \\Marios\s*$/);
         });
 
         it('Page title for the root namespace omits the separator', function() {

--- a/cypress/integration/default/packages.spec.js
+++ b/cypress/integration/default/packages.spec.js
@@ -17,6 +17,10 @@ describe('Packages', function() {
             cy.get('.phpdocumentor-content__title')
                 .contains("Marios");
         });
+
+        it('Page title includes the fully qualified package name', function() {
+            cy.title().should('match', /\u00bb \\Marios$/);
+        });
     });
 
     describe('Table of Contents', function() {

--- a/cypress/integration/default/packages.spec.js
+++ b/cypress/integration/default/packages.spec.js
@@ -19,7 +19,7 @@ describe('Packages', function() {
         });
 
         it('Page title includes the fully qualified package name', function() {
-            cy.title().should('match', /\u00bb \\Marios$/);
+            cy.title().should('match', /\u00bb \\Marios\s*$/);
         });
     });
 

--- a/cypress/integration/default/traits.spec.js
+++ b/cypress/integration/default/traits.spec.js
@@ -28,7 +28,7 @@ describe('Traits', function() {
 
     describe('Synopsis', function() {
         it('Page title includes the fully qualified trait name', function () {
-            cy.title().should('match', /\u00bb \\Marios\\SharedTrait$/);
+            cy.title().should('match', /\u00bb \\Marios\\SharedTrait\s*$/);
         });
 
         it('Has "SharedTrait" as title', function () {

--- a/cypress/integration/default/traits.spec.js
+++ b/cypress/integration/default/traits.spec.js
@@ -27,6 +27,10 @@ describe('Traits', function() {
     });
 
     describe('Synopsis', function() {
+        it('Page title includes the fully qualified trait name', function () {
+            cy.title().should('match', /\u00bb \\Marios\\SharedTrait$/);
+        });
+
         it('Has "SharedTrait" as title', function () {
             cy.get('.phpdocumentor-content__title').contains('SharedTrait');
         });

--- a/data/templates/default/class.html.twig
+++ b/data/templates/default/class.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}
+    {{ project.name }} &raquo; {{ node.fullyQualifiedStructuralElementName }}
+{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 

--- a/data/templates/default/enum.html.twig
+++ b/data/templates/default/enum.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}
+    {{ project.name }} &raquo; {{ node.fullyQualifiedStructuralElementName }}
+{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 

--- a/data/templates/default/file.html.twig
+++ b/data/templates/default/file.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}
+    {{ project.name }} &raquo; {{ node.path }}
+{% endblock %}
+
 {% block content %}
     {% include('components/breadcrumbs.html.twig') %}
 

--- a/data/templates/default/indices/files.html.twig
+++ b/data/templates/default/indices/files.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}
+    {{ project.name }} &raquo; Files
+{% endblock %}
+
 {% block content %}
     <section>
         {% set orderedFiles = project.files|sort((a,b) => a.name <=> b.name) %}

--- a/data/templates/default/interface.html.twig
+++ b/data/templates/default/interface.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}
+    {{ project.name }} &raquo; {{ node.fullyQualifiedStructuralElementName }}
+{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 

--- a/data/templates/default/namespace.html.twig
+++ b/data/templates/default/namespace.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}
+    {{ project.name }}{% if node.name != '\\' %} &raquo; {{ node.fullyQualifiedStructuralElementName }}{% endif %}
+{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 

--- a/data/templates/default/package.html.twig
+++ b/data/templates/default/package.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}
+    {{ project.name }}{% if node.name != '\\' %} &raquo; {{ node.fullyQualifiedStructuralElementName }}{% endif %}
+{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 

--- a/data/templates/default/trait.html.twig
+++ b/data/templates/default/trait.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% block title %}
+    {{ project.name }} &raquo; {{ node.fullyQualifiedStructuralElementName }}
+{% endblock %}
+
 {% block content %}
     {% include 'components/breadcrumbs.html.twig' %}
 


### PR DESCRIPTION
Pages for classes, interfaces, traits, enums, namespaces, packages, files and the file index now set a descriptive `<title>`, so browser tabs, bookmarks and history can distinguish pages that share the same short name (for example several nested `Configuration` namespaces).

Refs #3016