### PR TITLE
Drop file pages emptied by the @ignore tag (FileAssembler)

### DIFF
--- a/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
+++ b/src/phpDocumentor/Descriptor/Builder/Reflector/FileAssembler.php
@@ -49,7 +49,7 @@ class FileAssembler extends AssemblerAbstract
      *
      * @param File $data
      */
-    public function buildDescriptor(object $data): FileInterface
+    public function buildDescriptor(object $data): FileInterface|null
     {
         $fileDescriptor = new FileDescriptor($data->getHash());
         $fileDescriptor->setPackage(
@@ -77,7 +77,35 @@ class FileAssembler extends AssemblerAbstract
         $this->addInterfaces($data->getInterfaces(), $fileDescriptor);
         $this->addTraits($data->getTraits(), $fileDescriptor);
 
+        // If every documented element of the file was filtered out (for example because each
+        // class, function or constant carries an @ignore tag) the file would otherwise keep
+        // a dedicated page and appear in the files index with its full source. Drop it so
+        // @ignore is honoured consistently at file level too.
+        if ($this->hadDocumentedElements($data) && $this->isEffectivelyEmpty($fileDescriptor)) {
+            return null;
+        }
+
         return $fileDescriptor;
+    }
+
+    private function hadDocumentedElements(File $data): bool
+    {
+        return $data->getConstants() !== []
+            || $data->getFunctions() !== []
+            || $data->getClasses() !== []
+            || $data->getInterfaces() !== []
+            || $data->getTraits() !== []
+            || $data->getEnums() !== [];
+    }
+
+    private function isEffectivelyEmpty(FileInterface $fileDescriptor): bool
+    {
+        return $fileDescriptor->getConstants()->count() === 0
+            && $fileDescriptor->getFunctions()->count() === 0
+            && $fileDescriptor->getClasses()->count() === 0
+            && $fileDescriptor->getInterfaces()->count() === 0
+            && $fileDescriptor->getTraits()->count() === 0
+            && $fileDescriptor->getEnums()->count() === 0;
     }
 
     /**

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/FileAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/FileAssemblerTest.php
@@ -19,6 +19,8 @@ use phpDocumentor\Descriptor\PackageDescriptor;
 use phpDocumentor\Descriptor\ProjectDescriptor\Settings;
 use phpDocumentor\Descriptor\ProjectDescriptorBuilder;
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Php\Class_;
 use phpDocumentor\Reflection\Php\File;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -81,6 +83,28 @@ DOCBLOCK,
         //$this->assertSame($this->defaultPackage, $descriptor->getPackage());
     }
 
+    public function testFileIsDroppedWhenAllDocumentedElementsAreFilteredOut(): void
+    {
+        $projectDescriptorBuilderMock = $this->prophesize(ProjectDescriptorBuilder::class);
+        $projectDescriptorBuilderMock->getDefaultPackageName()->willReturn($this->defaultPackage);
+        // Simulate a filter removing every class (e.g. because it carries @ignore).
+        $projectDescriptorBuilderMock->buildDescriptor(Argument::any(), Argument::any())->willReturn(null);
+
+        $this->fixture->setBuilder($projectDescriptorBuilderMock->reveal());
+
+        $file = new File('hash', 'Ignored.php');
+        $file->addClass(new Class_(new Fqsen('\\Test\\Ignored')));
+
+        self::assertNull($this->fixture->create($file));
+    }
+
+    public function testFileWithNoDocumentedElementsIsKept(): void
+    {
+        $file = new File('hash', 'empty.php');
+
+        self::assertNotNull($this->fixture->create($file));
+    }
+
     /**
      * Create a descriptor builder mock
      */
@@ -90,7 +114,7 @@ DOCBLOCK,
         $settings->includeSource();
 
         $projectDescriptorBuilderMock = $this->prophesize(ProjectDescriptorBuilder::class);
-        $projectDescriptorBuilderMock->getDefaultPackageName()->shouldBeCalled()->willReturn($this->defaultPackage);
+        $projectDescriptorBuilderMock->getDefaultPackageName()->willReturn($this->defaultPackage);
 
         $projectDescriptorBuilderMock->buildDescriptor(Argument::any(), Argument::any())->will(function () {
             $mock = $this->prophesize(DescriptorAbstract::class);

--- a/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/FileAssemblerTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/Builder/Reflector/FileAssemblerTest.php
@@ -50,7 +50,6 @@ final class FileAssemblerTest extends TestCase
         $this->defaultPackage = new PackageDescriptor();
         $this->defaultPackage->setName('\\PhpDocumentor');
         $this->fixture = new FileAssembler();
-        $this->fixture->setBuilder($this->getProjectDescriptorBuilderMock()->reveal());
     }
 
     /**
@@ -58,6 +57,8 @@ final class FileAssemblerTest extends TestCase
      */
     public function testCreateFileDescriptorFromReflector(): void
     {
+        $this->fixture->setBuilder($this->getProjectDescriptorBuilderMock()->reveal());
+
         $filename = 'file.php';
         $content = '<?php ... ?>';
         $hash = md5($content);
@@ -100,7 +101,40 @@ DOCBLOCK,
 
     public function testFileWithNoDocumentedElementsIsKept(): void
     {
+        $projectDescriptorBuilderMock = $this->prophesize(ProjectDescriptorBuilder::class);
+        $projectDescriptorBuilderMock->getDefaultPackageName()->willReturn($this->defaultPackage);
+
+        $this->fixture->setBuilder($projectDescriptorBuilderMock->reveal());
+
         $file = new File('hash', 'empty.php');
+
+        self::assertNotNull($this->fixture->create($file));
+    }
+
+    public function testFileIsKeptWhenAtLeastOneElementSurvivesFiltering(): void
+    {
+        $projectDescriptorBuilderMock = $this->prophesize(ProjectDescriptorBuilder::class);
+        $projectDescriptorBuilderMock->getDefaultPackageName()->willReturn($this->defaultPackage);
+        $survivor = $this->prophesize(DescriptorAbstract::class);
+        $survivor->setLocation(Argument::cetera())->shouldBeCalled();
+        $survivor->getTags()->willReturn(new Collection());
+        $survivor->getFullyQualifiedStructuralElementName()->willReturn(new Fqsen('\\Test\\Kept'));
+        $survivorMock = $survivor->reveal();
+
+        $projectDescriptorBuilderMock->buildDescriptor(Argument::any(), Argument::any())->will(
+            static function (array $args) use ($survivorMock) {
+                /** @var Class_ $class */
+                [$class] = $args;
+
+                return (string) $class->getFqsen() === '\\Test\\Ignored' ? null : $survivorMock;
+            },
+        );
+
+        $this->fixture->setBuilder($projectDescriptorBuilderMock->reveal());
+
+        $file = new File('hash', 'Mixed.php');
+        $file->addClass(new Class_(new Fqsen('\\Test\\Ignored')));
+        $file->addClass(new Class_(new Fqsen('\\Test\\Kept')));
 
         self::assertNotNull($this->fixture->create($file));
     }
@@ -114,7 +148,7 @@ DOCBLOCK,
         $settings->includeSource();
 
         $projectDescriptorBuilderMock = $this->prophesize(ProjectDescriptorBuilder::class);
-        $projectDescriptorBuilderMock->getDefaultPackageName()->willReturn($this->defaultPackage);
+        $projectDescriptorBuilderMock->getDefaultPackageName()->shouldBeCalled()->willReturn($this->defaultPackage);
 
         $projectDescriptorBuilderMock->buildDescriptor(Argument::any(), Argument::any())->will(function () {
             $mock = $this->prophesize(DescriptorAbstract::class);


### PR DESCRIPTION
When every class, interface, trait, enum, function or constant of a file is removed by a descriptor filter (typically because each element carries an `@ignore` tag) the file page was still generated, listed in the files index and exposed the full source, which defeated the purpose of `@ignore`.

`FileAssembler` now returns `null` in that case, mirroring how the class page itself is already omitted.

Refs #1959