### PR TITLE
Shorten FQCNs in place inside compound type strings

### DIFF
--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/Target.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/Target.php
@@ -109,8 +109,8 @@ final class Target
                 }
 
                 $abbreviated = preg_replace_callback(
-                    '/\\\\(?:[A-Za-z_][A-Za-z0-9_]*\\\\)*([A-Za-z_][A-Za-z0-9_]*)/',
-                    static fn (array $matches): string => $matches[1],
+                    '/(?<![A-Za-z0-9_])\\\\?(?:[A-Za-z_][A-Za-z0-9_]*\\\\)+([A-Za-z_][A-Za-z0-9_]*)|\\\\([A-Za-z_][A-Za-z0-9_]*)/',
+                    static fn (array $matches): string => $matches[2] ?? $matches[1],
                     $this->title,
                 );
                 if ($abbreviated !== $this->title) {

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/Target.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/Target.php
@@ -18,6 +18,8 @@ use phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
 use function count;
 use function end;
 use function explode;
+use function preg_match;
+use function preg_replace_callback;
 
 /**
  * The target of a link and how it should be presented.
@@ -97,9 +99,22 @@ final class Target
                 break;
             case LinkRenderer::PRESENTATION_NORMAL:
             case LinkRenderer::PRESENTATION_CLASS_SHORT:
-                $parts = explode('\\', $this->title);
-                if (count($parts) > 1) {
-                    $this->abbreviation = end($parts);
+                if (preg_match('/^\\\\?[A-Za-z_][A-Za-z0-9_]*(?:\\\\[A-Za-z_][A-Za-z0-9_]*)*$/', $this->title) === 1) {
+                    $parts = explode('\\', $this->title);
+                    if (count($parts) > 1) {
+                        $this->abbreviation = end($parts);
+                    }
+
+                    break;
+                }
+
+                $abbreviated = preg_replace_callback(
+                    '/\\\\(?:[A-Za-z_][A-Za-z0-9_]*\\\\)*([A-Za-z_][A-Za-z0-9_]*)/',
+                    static fn (array $matches): string => $matches[1],
+                    $this->title,
+                );
+                if ($abbreviated !== $this->title) {
+                    $this->abbreviation = $abbreviated;
                 }
 
                 break;

--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/Target.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/Target.php
@@ -108,8 +108,10 @@ final class Target
                     break;
                 }
 
+                $fqcnPattern = '/(?<![A-Za-z0-9_])\\\\?(?:[A-Za-z_][A-Za-z0-9_]*\\\\)+([A-Za-z_][A-Za-z0-9_]*)'
+                    . '|\\\\([A-Za-z_][A-Za-z0-9_]*)/';
                 $abbreviated = preg_replace_callback(
-                    '/(?<![A-Za-z0-9_])\\\\?(?:[A-Za-z_][A-Za-z0-9_]*\\\\)+([A-Za-z_][A-Za-z0-9_]*)|\\\\([A-Za-z_][A-Za-z0-9_]*)/',
+                    $fqcnPattern,
                     static fn (array $matches): string => $matches[2] ?? $matches[1],
                     $this->title,
                 );

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/TargetTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/TargetTest.php
@@ -109,6 +109,11 @@ final class TargetTest extends TestCase
                 LinkRenderer::PRESENTATION_CLASS_SHORT,
                 'array{name?: string, chartColor?: Color, scheme?: string}',
             ],
+            'No abbreviation for a compound type that does not contain any FQCN' => [
+                'array{name: string, age: int}',
+                LinkRenderer::PRESENTATION_CLASS_SHORT,
+                null,
+            ],
         ];
     }
 }

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/TargetTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/TargetTest.php
@@ -114,6 +114,11 @@ final class TargetTest extends TestCase
                 LinkRenderer::PRESENTATION_CLASS_SHORT,
                 null,
             ],
+            'A multi-segment FQCN without leading backslash is also shortened in a compound' => [
+                'array{x: My\Super\Class}',
+                LinkRenderer::PRESENTATION_CLASS_SHORT,
+                'array{x: Class}',
+            ],
         ];
     }
 }

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/TargetTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/TargetTest.php
@@ -119,6 +119,11 @@ final class TargetTest extends TestCase
                 LinkRenderer::PRESENTATION_CLASS_SHORT,
                 'array{x: Class}',
             ],
+            'A root-namespace FQCN inside a compound drops its leading backslash' => [
+                'array{x: \DateTime}',
+                LinkRenderer::PRESENTATION_CLASS_SHORT,
+                'array{x: DateTime}',
+            ],
         ];
     }
 }

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/TargetTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/TargetTest.php
@@ -104,6 +104,11 @@ final class TargetTest extends TestCase
                 LinkRenderer::PRESENTATION_FILE_SHORT,
                 'File.php',
             ],
+            'Each FQCN inside an array shape is shortened in place' => [
+                'array{name?: string, chartColor?: \My\Chart\Color, scheme?: string}',
+                LinkRenderer::PRESENTATION_CLASS_SHORT,
+                'array{name?: string, chartColor?: Color, scheme?: string}',
+            ],
         ];
     }
 }


### PR DESCRIPTION
When a parameter type is a compound expression (e.g. `array{name?: string, chartColor?: \\App\\ChartColor, scheme?: string}`), the `class:short` presentation used to `explode('\\\\')` and keep only the last segment, dropping everything before the FQCN.

Now FQCNs are shortened in place via a callback, leaving the surrounding shape intact. Pure FQCN titles keep their existing behavior.

Fixes #4059.