### PR TITLE
Write logs to a file when the --log option is provided

### DIFF
--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Console;
 
+use Monolog\Logger as MonologLogger;
 use phpDocumentor\AutoloaderLocator;
 use phpDocumentor\Extension\ExtensionHandler;
 use phpDocumentor\Version;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleEvent;
@@ -25,7 +25,6 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 use function array_merge;
@@ -72,13 +71,13 @@ class Application extends BaseApplication
         $this->setDefaultCommand('project:run', false);
 
         $eventDispatcher = $container->get(EventDispatcher::class);
-        $logger = $container->get(LoggerInterface::class);
+        $logger = $container->get(MonologLogger::class);
         $this->setDispatcher($eventDispatcher);
 
         $eventDispatcher->addListener(
             ConsoleEvents::COMMAND,
             static function (ConsoleEvent $event) use ($logger): void {
-                $logger->pushHandler(new ConsoleLogHandler(new SymfonyStyle($event->getInput(), $event->getOutput())));
+                LogConfigurator::attach($logger, $event);
             },
         );
 
@@ -123,7 +122,12 @@ class Application extends BaseApplication
                     InputOption::VALUE_NONE,
                     'Do not load any extensions',
                 ),
-                new InputOption('log', null, InputOption::VALUE_OPTIONAL, 'Log file to write to'),
+                new InputOption(
+                    'log',
+                    null,
+                    InputOption::VALUE_OPTIONAL,
+                    'Log file to write to (level follows console verbosity)',
+                ),
             ],
         );
     }

--- a/src/phpDocumentor/Console/LogConfigurator.php
+++ b/src/phpDocumentor/Console/LogConfigurator.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Console;
+
+use Monolog\Handler\HandlerInterface;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger as MonologLogger;
+use Monolog\Utils;
+use Symfony\Component\Console\Event\ConsoleEvent;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function is_string;
+
+/** @internal */
+final class LogConfigurator
+{
+    public static function attach(MonologLogger $logger, ConsoleEvent $event): void
+    {
+        $output = $event->getOutput();
+        if (self::findHandler($logger, ConsoleLogHandler::class) === null) {
+            $logger->pushHandler(new ConsoleLogHandler(new SymfonyStyle($event->getInput(), $output)));
+        }
+
+        $logFile = $event->getInput()->getOption('log');
+        if (! is_string($logFile) || $logFile === '' || $output->getVerbosity() === OutputInterface::VERBOSITY_QUIET) {
+            return;
+        }
+
+        $canonicalLogFile = Utils::canonicalizePath($logFile);
+        foreach ($logger->getHandlers() as $existing) {
+            if ($existing instanceof StreamHandler && $existing->getUrl() === $canonicalLogFile) {
+                return;
+            }
+        }
+
+        $logger->pushHandler(new StreamHandler($logFile, self::levelForVerbosity($output->getVerbosity())));
+    }
+
+    private static function findHandler(MonologLogger $logger, string $class): HandlerInterface|null
+    {
+        foreach ($logger->getHandlers() as $handler) {
+            if ($handler instanceof $class) {
+                return $handler;
+            }
+        }
+
+        return null;
+    }
+
+    private static function levelForVerbosity(int $verbosity): Level
+    {
+        return match (true) {
+            $verbosity >= OutputInterface::VERBOSITY_VERY_VERBOSE => Level::Debug,
+            $verbosity >= OutputInterface::VERBOSITY_VERBOSE => Level::Info,
+            default => Level::Notice,
+        };
+    }
+}

--- a/tests/functional/assets/core/issues/issue-1872/issue-1872.php
+++ b/tests/functional/assets/core/issues/issue-1872/issue-1872.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Class Issue1872
+ */
+class Issue1872
+{
+    public string $foo = 'bar';
+}

--- a/tests/functional/phpDocumentor/issues/Issue1872FunctionalTest.php
+++ b/tests/functional/phpDocumentor/issues/Issue1872FunctionalTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace functional\phpDocumentor\issues;
+
+use phpDocumentor\FunctionalTestCase;
+
+/** @link https://github.com/phpDocumentor/phpDocumentor/issues/1872 */
+final class Issue1872FunctionalTest extends FunctionalTestCase
+{
+    public function testLogFileIsWrittenWhenLogOptionIsProvided(): void
+    {
+        $this->runPHPDocWithFile(
+            __DIR__ . '/../../assets/core/issues/issue-1872/issue-1872.php',
+            ['--log', 'phpdoc.log'],
+        );
+
+        $contents = $this->loadContents('phpdoc.log');
+        self::assertNotSame('', $contents, 'Expected --log target to receive log records');
+        self::assertStringContainsString('Collecting files from', $contents);
+    }
+}

--- a/tests/unit/phpDocumentor/Console/LogConfiguratorTest.php
+++ b/tests/unit/phpDocumentor/Console/LogConfiguratorTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Console;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger as MonologLogger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_filter;
+use function array_values;
+use function basename;
+use function chdir;
+use function getcwd;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+use const DIRECTORY_SEPARATOR;
+
+/** @coversDefaultClass \phpDocumentor\Console\LogConfigurator */
+final class LogConfiguratorTest extends TestCase
+{
+    /** @return iterable<string, array{array<string, string|bool|null>}> */
+    public static function noFileHandlerCases(): iterable
+    {
+        yield 'missing option' => [[]];
+        yield 'empty string'   => [['--log' => '']];
+    }
+
+    /**
+     * @param array<string, string|bool|null> $options
+     *
+     * @dataProvider noFileHandlerCases
+     */
+    public function testAttachSkipsFileHandlerWhenLogOptionHasNoUsableValue(array $options): void
+    {
+        $logger = new MonologLogger('test');
+        $event = $this->createConsoleEvent($options);
+
+        LogConfigurator::attach($logger, $event);
+
+        self::assertCount(0, $this->streamHandlers($logger));
+    }
+
+    public function testAttachSkipsFileHandlerWhenQuiet(): void
+    {
+        $this->withTempLogFile(function (string $logFile): void {
+            $logger = new MonologLogger('test');
+            $event = $this->createConsoleEvent(['--log' => $logFile], OutputInterface::VERBOSITY_QUIET);
+
+            LogConfigurator::attach($logger, $event);
+
+            self::assertCount(0, $this->streamHandlers($logger));
+        });
+    }
+
+    /** @link https://github.com/phpDocumentor/phpDocumentor/issues/1872 */
+    public function testAttachDoesNotDuplicateHandlersOnNestedCommands(): void
+    {
+        $this->withTempLogFile(function (string $logFile): void {
+            $logger = new MonologLogger('test');
+            $event = $this->createConsoleEvent(['--log' => $logFile]);
+
+            LogConfigurator::attach($logger, $event);
+            LogConfigurator::attach($logger, $event);
+
+            self::assertCount(1, $this->streamHandlers($logger));
+            self::assertCount(1, array_filter(
+                $logger->getHandlers(),
+                static fn ($h) => $h instanceof ConsoleLogHandler,
+            ));
+        });
+    }
+
+    public function testAttachPushesDistinctStreamHandlerForDifferentLogFiles(): void
+    {
+        $this->withTempLogFile(function (string $first): void {
+            $this->withTempLogFile(function (string $second) use ($first): void {
+                $logger = new MonologLogger('test');
+
+                LogConfigurator::attach($logger, $this->createConsoleEvent(['--log' => $first]));
+                LogConfigurator::attach($logger, $this->createConsoleEvent(['--log' => $second]));
+
+                self::assertCount(2, $this->streamHandlers($logger));
+            });
+        });
+    }
+
+    public function testAttachDeduplicatesStreamHandlerForRelativePaths(): void
+    {
+        if (DIRECTORY_SEPARATOR !== '/') {
+            self::markTestSkipped('Monolog canonicalisation mixes / and \\ on Windows, breaking path equality.');
+        }
+
+        $dir = sys_get_temp_dir();
+        $tempFile = tempnam($dir, 'phpdoc-log-test');
+        self::assertIsString($tempFile);
+        $name = basename($tempFile);
+
+        $cwd = getcwd();
+        if ($cwd === false) {
+            self::markTestSkipped('Unable to resolve the current working directory.');
+        }
+
+        try {
+            chdir($dir);
+
+            try {
+                $canonicalCwd = getcwd();
+                self::assertIsString($canonicalCwd);
+                $absolute = $canonicalCwd . '/' . $name;
+
+                $logger = new MonologLogger('test');
+                LogConfigurator::attach($logger, $this->createConsoleEvent(['--log' => $name]));
+                LogConfigurator::attach($logger, $this->createConsoleEvent(['--log' => $absolute]));
+
+                self::assertCount(1, $this->streamHandlers($logger));
+            } finally {
+                chdir($cwd);
+            }
+        } finally {
+            @unlink($tempFile);
+        }
+    }
+
+    /** @return array<string, array{int, Level}> */
+    public static function verbosityLevelMap(): array
+    {
+        return [
+            'normal'       => [OutputInterface::VERBOSITY_NORMAL, Level::Notice],
+            'verbose'      => [OutputInterface::VERBOSITY_VERBOSE, Level::Info],
+            'very verbose' => [OutputInterface::VERBOSITY_VERY_VERBOSE, Level::Debug],
+            'debug'        => [OutputInterface::VERBOSITY_DEBUG, Level::Debug],
+        ];
+    }
+
+    /** @dataProvider verbosityLevelMap */
+    public function testAttachMapsVerbosityToFileLogLevel(int $verbosity, Level $expected): void
+    {
+        $this->withTempLogFile(function (string $logFile) use ($verbosity, $expected): void {
+            $logger = new MonologLogger('test');
+            $event = $this->createConsoleEvent(['--log' => $logFile], $verbosity);
+
+            LogConfigurator::attach($logger, $event);
+
+            $streams = $this->streamHandlers($logger);
+            self::assertCount(1, $streams);
+            self::assertSame($expected, $streams[0]->getLevel());
+        });
+    }
+
+    /** @param callable(string): void $callback */
+    private function withTempLogFile(callable $callback): void
+    {
+        $logFile = tempnam(sys_get_temp_dir(), 'phpdoc-log-test');
+        self::assertIsString($logFile);
+
+        try {
+            $callback($logFile);
+        } finally {
+            @unlink($logFile);
+        }
+    }
+
+    /** @return list<StreamHandler> */
+    private function streamHandlers(MonologLogger $logger): array
+    {
+        return array_values(array_filter(
+            $logger->getHandlers(),
+            static fn ($h) => $h instanceof StreamHandler,
+        ));
+    }
+
+    /** @param array<string, string|bool|null> $options */
+    private function createConsoleEvent(
+        array $options,
+        int $verbosity = OutputInterface::VERBOSITY_NORMAL,
+    ): ConsoleEvent {
+        $definition = new InputDefinition([
+            new InputOption('log', null, InputOption::VALUE_OPTIONAL),
+        ]);
+
+        $input = new ArrayInput($options, $definition);
+        $output = new BufferedOutput($verbosity);
+
+        return new ConsoleEvent(new Command('t'), $input, $output);
+    }
+}


### PR DESCRIPTION
Wire up the `--log` CLI option so it actually creates the requested log file.

The option was declared in `Application::getDefaultInputDefinition()` but never consumed: no Monolog handler was attached, so the file was never created (see #1872).

This change:
- pushes a `Monolog\Handler\StreamHandler` for the `--log` path when the option is provided
- picks the handler level from the console verbosity to mirror what is already shown on screen (warning by default, notice at `-v`, info at `-vv`, debug at `-vvv`)
- disables file logging entirely when `-q` / `--quiet` is passed, matching the intent captured in `Transform.php`
- ships three new unit tests covering the happy path, the missing-option case, the quiet case and the verbosity-to-level mapping

The v2 `<logging>` XML node only accepts `<level>` and never had a `<paths>` child; the v3 config schema has no `logging` node at all. Fixing that XML path is out of scope for this PR.

Fixes #1872.