### PR TITLE
Join union types when rendering callable parameters and return

### DIFF
--- a/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/CallableAdapter.php
+++ b/src/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/CallableAdapter.php
@@ -14,11 +14,14 @@ declare(strict_types=1);
 namespace phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
 
 use InvalidArgumentException;
+use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Callable_;
+use phpDocumentor\Reflection\Types\Intersection;
 use phpDocumentor\Transformer\Writer\Twig\LinkRendererInterface;
 
 use function assert;
 use function implode;
+use function is_array;
 use function sprintf;
 use function trim;
 
@@ -54,7 +57,7 @@ final class CallableAdapter implements LinkRendererInterface
 
         $parameters = [];
         foreach ($value->getParameters() as $parameter) {
-            $type = $this->rendererChain->render($parameter->getType(), $presentation);
+            $type = $this->renderType($parameter->getType(), $presentation);
             $extraInfo = [];
             $name = '';
 
@@ -80,13 +83,22 @@ final class CallableAdapter implements LinkRendererInterface
             );
         }
 
-        return trim(sprintf(
-            'callable(%s)%s',
-            implode(', ', $parameters),
-            $value->getReturnType() !== null ? ': ' . $this->rendererChain->render(
-                $value->getReturnType(),
-                $presentation,
-            ) : '',
-        ));
+        $returnType = $value->getReturnType() !== null
+            ? ': ' . $this->renderType($value->getReturnType(), $presentation)
+            : '';
+
+        return trim(sprintf('callable(%s)%s', implode(', ', $parameters), $returnType));
+    }
+
+    private function renderType(Type $type, string $presentation): string
+    {
+        $rendered = $this->rendererChain->render($type, $presentation);
+        if (! is_array($rendered)) {
+            return $rendered;
+        }
+
+        $separator = $type instanceof Intersection ? '&' : '|';
+
+        return implode($separator, $rendered);
     }
 }

--- a/tests/integration/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
+++ b/tests/integration/phpDocumentor/Transformer/Writer/Twig/LinkRendererTest.php
@@ -22,7 +22,12 @@ use phpDocumentor\Faker\Faker;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\Boolean;
+use phpDocumentor\Reflection\Types\Callable_;
+use phpDocumentor\Reflection\Types\CallableParameter;
+use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Intersection;
 use phpDocumentor\Reflection\Types\Iterable_;
 use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Reflection\Types\Nullable;
@@ -269,6 +274,28 @@ final class LinkRendererTest extends TestCase
                 ),
                 LinkRenderer::PRESENTATION_CLASS_SHORT,
                 'iterable&lt;iterable&lt;mixed, string&gt;, string&gt;',
+            ],
+            'callable with union parameter' => [
+                new Callable_([
+                    new CallableParameter(new Compound([new Integer(), new String_()])),
+                ]),
+                LinkRenderer::PRESENTATION_CLASS_SHORT,
+                'callable(int|string)',
+            ],
+            'callable with union return type' => [
+                new Callable_(
+                    [],
+                    new Compound([new Integer(), new String_()]),
+                ),
+                LinkRenderer::PRESENTATION_CLASS_SHORT,
+                'callable(): int|string',
+            ],
+            'callable with intersection parameter' => [
+                new Callable_([
+                    new CallableParameter(new Intersection([new String_(), new Boolean()])),
+                ]),
+                LinkRenderer::PRESENTATION_CLASS_SHORT,
+                'callable(string&bool)',
             ],
         ];
     }

--- a/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/CallableAdapterTest.php
+++ b/tests/unit/phpDocumentor/Transformer/Writer/Twig/LinkRenderer/CallableAdapterTest.php
@@ -13,8 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
 
+use phpDocumentor\Reflection\Types\Boolean;
 use phpDocumentor\Reflection\Types\Callable_;
 use phpDocumentor\Reflection\Types\CallableParameter;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Intersection;
 use phpDocumentor\Reflection\Types\String_;
 use phpDocumentor\Transformer\Writer\Twig\LinkRenderer;
 use phpDocumentor\Transformer\Writer\Twig\LinkRendererInterface;
@@ -22,6 +26,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
+/** @coversDefaultClass \phpDocumentor\Transformer\Writer\Twig\LinkRenderer\CallableAdapter */
 class CallableAdapterTest extends TestCase
 {
     use ProphecyTrait;
@@ -105,5 +110,68 @@ class CallableAdapterTest extends TestCase
             ),
             'output' => 'callable(string ...&$foo)',
         ];
+    }
+
+    /**
+     * @link https://github.com/phpDocumentor/phpDocumentor/issues/3995
+     *
+     * @dataProvider unionProvider
+     */
+    public function testRenderJoinsUnionTypes(Callable_ $input, string $output): void
+    {
+        $union = new Compound([new Integer(), new String_()]);
+        $this->linkRenderer->render($union, LinkRenderer::PRESENTATION_NORMAL)
+            ->willReturn(['int', 'string']);
+        $this->linkRenderer->render(new String_(), LinkRenderer::PRESENTATION_NORMAL)
+            ->willReturn('string');
+
+        self::assertSame($output, $this->adapter->render($input, LinkRenderer::PRESENTATION_NORMAL));
+    }
+
+    /** @return iterable<string, array{input: Callable_, output: string}> */
+    public static function unionProvider(): iterable
+    {
+        $union = new Compound([new Integer(), new String_()]);
+
+        yield 'union parameter' => [
+            'input' => new Callable_([new CallableParameter($union)]),
+            'output' => 'callable(int|string)',
+        ];
+
+        yield 'union return type' => [
+            'input' => new Callable_([], $union),
+            'output' => 'callable(): int|string',
+        ];
+
+        yield 'named union parameter' => [
+            'input' => new Callable_([new CallableParameter($union, 'foo')]),
+            'output' => 'callable(int|string $foo)',
+        ];
+
+        yield 'variadic union parameter' => [
+            'input' => new Callable_([new CallableParameter($union, 'foo', false, true)]),
+            'output' => 'callable(int|string ...$foo)',
+        ];
+
+        yield 'union parameter mixed with scalar' => [
+            'input' => new Callable_([new CallableParameter($union), new CallableParameter(new String_())]),
+            'output' => 'callable(int|string, string)',
+        ];
+    }
+
+    /** @link https://github.com/phpDocumentor/phpDocumentor/issues/3995 */
+    public function testRenderJoinsIntersectionTypesWithAmpersand(): void
+    {
+        $intersection = new Intersection([new String_(), new Boolean()]);
+        $this->linkRenderer->render($intersection, LinkRenderer::PRESENTATION_NORMAL)
+            ->willReturn(['string', 'bool']);
+
+        self::assertSame(
+            'callable(string&bool)',
+            $this->adapter->render(
+                new Callable_([new CallableParameter($intersection)]),
+                LinkRenderer::PRESENTATION_NORMAL,
+            ),
+        );
     }
 }


### PR DESCRIPTION
`LinkRenderer::render` is typed `string|list<string>`, and the `IterableAdapter` matches any `Compound` type because `Compound` implements `IteratorAggregate`. `CallableAdapter` used to feed that result straight into `sprintf("%s", $type)`, which triggered a PHP *Array to string conversion* warning for any callable that carried a union type in its signature (see #3995).

Route both parameter and return type rendering through a small `renderType` helper that joins `list<string>` results with a `|` separator, mirroring what `AbstractListAdapter` already does for array/iterable element types.

Covered by new parameterised unit tests for union parameters, union return type, named/variadic/mixed union parameters.

Fixes #3995