### PR TITLE
Drop files emptied by @internal/visibility filtering (FilterEmptyFiles compile pass)

### DIFF
--- a/src/phpDocumentor/Compiler/ApiDocumentation/Pass/FilterEmptyFiles.php
+++ b/src/phpDocumentor/Compiler/ApiDocumentation/Pass/FilterEmptyFiles.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Compiler\ApiDocumentation\Pass;
+
+use phpDocumentor\Compiler\ApiDocumentation\ApiDocumentationPass;
+use phpDocumentor\Descriptor\ApiSetDescriptor;
+use phpDocumentor\Descriptor\FileDescriptor;
+use phpDocumentor\Pipeline\Attribute\Stage;
+
+#[Stage(
+    'phpdoc.pipeline.api_documentation.compile',
+    9500,
+    'Filter empty files',
+)]
+final class FilterEmptyFiles extends ApiDocumentationPass
+{
+    protected function process(ApiSetDescriptor $subject): ApiSetDescriptor
+    {
+        $files = $subject->getFiles();
+
+        foreach ($files->getAll() as $file) {
+            if (! ($file instanceof FileDescriptor) || ! $file->isEmpty()) {
+                continue;
+            }
+
+            $files->offsetUnset($file->getPath());
+        }
+
+        return $subject;
+    }
+}

--- a/src/phpDocumentor/Descriptor/FileDescriptor.php
+++ b/src/phpDocumentor/Descriptor/FileDescriptor.php
@@ -303,6 +303,19 @@ class FileDescriptor extends DescriptorAbstract implements Interfaces\FileInterf
     }
 
     /**
+     * Returns true when the file has no documented structural elements left.
+     */
+    public function isEmpty(): bool
+    {
+        return $this->classes->count() === 0
+            && $this->constants->count() === 0
+            && $this->functions->count() === 0
+            && $this->interfaces->count() === 0
+            && $this->traits->count() === 0
+            && $this->enums->count() === 0;
+    }
+
+    /**
      * Returns a series of markers contained in this file.
      *
      * A marker is a special inline comment that starts with a keyword and is followed by a single line description.

--- a/tests/unit/phpDocumentor/Compiler/ApiDocumentation/Pass/FilterEmptyFilesTest.php
+++ b/tests/unit/phpDocumentor/Compiler/ApiDocumentation/Pass/FilterEmptyFilesTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Compiler\ApiDocumentation\Pass;
+
+use phpDocumentor\Descriptor\FileDescriptor;
+use phpDocumentor\Descriptor\FunctionDescriptor;
+use phpDocumentor\Faker\Faker;
+use phpDocumentor\Reflection\Fqsen;
+use PHPUnit\Framework\TestCase;
+
+/** @link https://github.com/phpDocumentor/phpDocumentor/issues/3997 */
+final class FilterEmptyFilesTest extends TestCase
+{
+    use Faker;
+
+    public function testFilesWithoutDocumentedElementsAreRemoved(): void
+    {
+        $apiSet = self::faker()->apiSetDescriptor();
+
+        $documentedFile = self::fileWithClass('src/Documented.php', new Fqsen('\My\DocumentedClass'));
+        $emptyFile = new FileDescriptor('empty-hash');
+        $emptyFile->setPath('src/Empty.php');
+
+        $apiSet->getFiles()->set($documentedFile->getPath(), $documentedFile);
+        $apiSet->getFiles()->set($emptyFile->getPath(), $emptyFile);
+
+        (new FilterEmptyFiles())($apiSet);
+
+        self::assertCount(1, $apiSet->getFiles());
+        self::assertSame($documentedFile, $apiSet->getFiles()->get($documentedFile->getPath()));
+    }
+
+    /** @dataProvider filesWithSingleElementProvider */
+    public function testFilesWithAnyKindOfDocumentedElementAreKept(callable $populate): void
+    {
+        $apiSet = self::faker()->apiSetDescriptor();
+
+        $file = new FileDescriptor('with-element-hash');
+        $file->setPath('src/WithElement.php');
+        $populate($file);
+
+        $apiSet->getFiles()->set($file->getPath(), $file);
+
+        (new FilterEmptyFiles())($apiSet);
+
+        self::assertCount(1, $apiSet->getFiles());
+        self::assertSame($file, $apiSet->getFiles()->get($file->getPath()));
+    }
+
+    /** @return iterable<string, array{callable(FileDescriptor): void}> */
+    public static function filesWithSingleElementProvider(): iterable
+    {
+        yield 'class' => [
+            static function (FileDescriptor $file): void {
+                $class = self::faker()->classDescriptor(new Fqsen('\\My\\SomeClass'));
+                $file->getClasses()->set((string) $class->getFullyQualifiedStructuralElementName(), $class);
+            },
+        ];
+
+        yield 'interface' => [
+            static function (FileDescriptor $file): void {
+                $interface = self::faker()->interfaceDescriptor(new Fqsen('\\My\\SomeInterface'));
+                $file->getInterfaces()->set(
+                    (string) $interface->getFullyQualifiedStructuralElementName(),
+                    $interface,
+                );
+            },
+        ];
+
+        yield 'trait' => [
+            static function (FileDescriptor $file): void {
+                $trait = self::faker()->traitDescriptor(new Fqsen('\\My\\SomeTrait'));
+                $file->getTraits()->set((string) $trait->getFullyQualifiedStructuralElementName(), $trait);
+            },
+        ];
+
+        yield 'enum' => [
+            static function (FileDescriptor $file): void {
+                $enum = self::faker()->enumDescriptor(new Fqsen('\\My\\SomeEnum'));
+                $file->getEnums()->set((string) $enum->getFullyQualifiedStructuralElementName(), $enum);
+            },
+        ];
+
+        yield 'constant' => [
+            static function (FileDescriptor $file): void {
+                $constant = self::faker()->constantDescriptor(new Fqsen('\\MY_CONST'));
+                $file->getConstants()->set((string) $constant->getFullyQualifiedStructuralElementName(), $constant);
+            },
+        ];
+
+        yield 'function' => [
+            static function (FileDescriptor $file): void {
+                $function = new FunctionDescriptor();
+                $function->setName('someFunction');
+                $function->setFullyQualifiedStructuralElementName(new Fqsen('\\someFunction()'));
+                $file->getFunctions()->set((string) $function->getFullyQualifiedStructuralElementName(), $function);
+            },
+        ];
+    }
+
+    private static function fileWithClass(string $path, Fqsen $classFqsen): FileDescriptor
+    {
+        $file = new FileDescriptor('class-hash-' . $path);
+        $file->setPath($path);
+        $file->getClasses()->set((string) $classFqsen, self::faker()->classDescriptor($classFqsen));
+
+        return $file;
+    }
+}


### PR DESCRIPTION
When every class, interface, trait, enum, function and constant that a file defines is stripped (typically because they are marked `@internal` and the current visibility does not include internal elements), the file ends up with empty collections yet stays in `ApiSetDescriptor::files`. The Files index and package listings then advertise pages that render nothing (see #3997).

Add a `FilterEmptyFiles` compile pass that removes such files before `PackageTreeBuilder` runs, and a `FileDescriptor::isEmpty` helper mirroring `NamespaceDescriptor::isEmpty` so the pass stays a one-liner.

**Scope** — the emptiness check looks at the six structural collections only (classes, interfaces, traits, enums, functions, constants). A file that only carries file-level tags, a docblock summary, markers, includes or namespace aliases is considered empty: without any structural element to hang a rendered page on, the default template produces nothing meaningful for it. If a user relied on such a page, this is the deliberate behaviour change.

**Pass priority 9500** — placed between `ElementsIndexBuilder` (15000) and `PackageTreeBuilder` (9001) so the empty files never land in the package tree and stale entries never appear in `elements`/`packages`/`files` indices.

Unit tests cover:
- empty files are removed, non-empty ones stay
- files with a single class, interface, trait, enum or constant are kept (data provider)

Fixes #3997