### PR TITLE
Give phpdoc reference stubs proper titles so they appear in the ToC

### DIFF
--- a/docs/references/phpdoc/inline-tags/example.rst
+++ b/docs/references/phpdoc/inline-tags/example.rst
@@ -1,1 +1,7 @@
-.. include:: ../tags/example.rst
+@example
+========
+
+See :doc:`../tags/example` for the full reference.
+
+When used inline, ``{@example}`` expands to the contents of the referenced
+example file at the point where the tag appears inside a description.

--- a/docs/references/phpdoc/inline-tags/internal.rst
+++ b/docs/references/phpdoc/inline-tags/internal.rst
@@ -1,1 +1,8 @@
-.. include:: ../tags/internal.rst
+@internal
+=========
+
+See :doc:`../tags/internal` for the full reference.
+
+When used inline, ``{@internal}`` marks a portion of a description as
+internal; it is stripped from the rendered output unless
+``--parseprivate`` is passed.

--- a/docs/references/phpdoc/inline-tags/link.rst
+++ b/docs/references/phpdoc/inline-tags/link.rst
@@ -1,1 +1,7 @@
-.. include:: ../tags/link.rst
+@link
+=====
+
+See :doc:`../tags/link` for the full reference.
+
+When used inline, ``{@link}`` produces a hyperlink to the referenced
+URL at the location where the tag appears inside a description.

--- a/docs/references/phpdoc/inline-tags/see.rst
+++ b/docs/references/phpdoc/inline-tags/see.rst
@@ -1,1 +1,8 @@
-.. include:: ../tags/see.rst
+@see
+====
+
+See :doc:`../tags/see` for the full reference.
+
+When used inline, ``{@see}`` renders as a cross-reference to the
+referenced structural element or URL at the location where the tag
+appears inside a description.

--- a/docs/references/phpdoc/tags/property-read.rst
+++ b/docs/references/phpdoc/tags/property-read.rst
@@ -1,1 +1,9 @@
-.. include:: property.rst
+@property-read
+==============
+
+See :doc:`property` for the full reference.
+
+The ``@property-read`` tag behaves like :doc:`@property <property>` but
+declares that the magic property is only readable through the
+`\__get() <https://www.php.net/language.oop5.overloading#object.get>`_
+method.

--- a/docs/references/phpdoc/tags/property-write.rst
+++ b/docs/references/phpdoc/tags/property-write.rst
@@ -1,1 +1,9 @@
-.. include:: property.rst
+@property-write
+===============
+
+See :doc:`property` for the full reference.
+
+The ``@property-write`` tag behaves like :doc:`@property <property>` but
+declares that the magic property is only writable through the
+`\__set() <https://www.php.net/language.oop5.overloading#object.set>`_
+method.


### PR DESCRIPTION
The Tag reference and Inline tag reference tables of content on docs.phpdoc.org rendered `<Unknown>` entries for six `.rst` files whose only body was a `.. include:: <other>.rst` line (see #3759). Without a top-level title, the toctree could not extract a label for them.

Replace each include with a proper RST title matching the tag name plus a short cross-reference and a one-liner that spells out the variant's specific semantics. Users landing on each URL still get a clear pointer to the canonical reference page.

Affected files:
- `docs/references/phpdoc/tags/property-read.rst` (`@property-read`)
- `docs/references/phpdoc/tags/property-write.rst` (`@property-write`)
- `docs/references/phpdoc/inline-tags/example.rst` (`@example`)
- `docs/references/phpdoc/inline-tags/internal.rst` (`@internal`)
- `docs/references/phpdoc/inline-tags/link.rst` (`@link`)
- `docs/references/phpdoc/inline-tags/see.rst` (`@see`)

Inline-tag titles follow the existing `inheritdoc.rst` convention (bare `@tag`, no braces) so the `inline-tags` toctree stays visually uniform.

Fixes #3759