### PR TITLE
Skip source-view modal in default template when include-source is disabled

### DIFF
--- a/data/templates/default/components/source-modal.html.twig
+++ b/data/templates/default/components/source-modal.html.twig
@@ -1,3 +1,4 @@
+{% if project.settings.shouldIncludeSource %}
 {% block sourceview_modal %}
 <div class="phpdocumentor-modal" id="source-view">
     <div class="phpdocumentor-modal-bg" data-exit-button></div>
@@ -95,3 +96,4 @@
         })();
     </script>
 {% endblock %}
+{% endif %}

--- a/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
+++ b/src/phpDocumentor/Descriptor/ProjectDescriptorBuilder.php
@@ -183,6 +183,17 @@ class ProjectDescriptorBuilder
         $this->project->getSettings()->setVisibility($visibility);
     }
 
+    public function setIncludeSource(bool $includeSource): void
+    {
+        if ($includeSource) {
+            $this->project->getSettings()->includeSource();
+
+            return;
+        }
+
+        $this->project->getSettings()->excludeSource();
+    }
+
     public function setName(string $title): void
     {
         $this->project->setName($title);

--- a/src/phpDocumentor/Pipeline/Stage/Parser/ParseFiles.php
+++ b/src/phpDocumentor/Pipeline/Stage/Parser/ParseFiles.php
@@ -37,6 +37,7 @@ final class ParseFiles
         // TODO: The setVisibility call should purge the cache if it differs; but once we are here, cache has already
         //       been loaded..
         $payload->getBuilder()->setVisibility($apiConfig->calculateVisiblity());
+        $payload->getBuilder()->setIncludeSource(($apiConfig['include-source'] ?? false) === true);
 
         $encoding = $apiConfig['encoding'] ?? '';
         if ($encoding) {

--- a/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorBuilderTest.php
+++ b/tests/unit/phpDocumentor/Descriptor/ProjectDescriptorBuilderTest.php
@@ -104,4 +104,18 @@ class ProjectDescriptorBuilderTest extends MockeryTestCase
 
         self::assertEquals(ApiSpecification::VISIBILITY_PUBLIC, $projectSettings->getVisibility());
     }
+
+    public function testSetIncludeSourceTogglesTheProjectSetting(): void
+    {
+        $this->fixture->createProjectDescriptor();
+        $projectSettings = $this->fixture->getProjectDescriptor()->getSettings();
+
+        self::assertFalse($projectSettings->shouldIncludeSource());
+
+        $this->fixture->setIncludeSource(true);
+        self::assertTrue($projectSettings->shouldIncludeSource());
+
+        $this->fixture->setIncludeSource(false);
+        self::assertFalse($projectSettings->shouldIncludeSource());
+    }
 }


### PR DESCRIPTION
Fixes #4024.

## Bug observé

Le template `default` injecte inconditionnellement la modal `source-view` (`<div class="phpdocumentor-modal" id="source-view">`) et son loader script sur chaque page class/interface/trait/enum/file/namespace/package. Quand `include-source` est à `false` (défaut selon `data/xsd/phpdoc.xsd`), aucun `.txt` source n'est écrit par `Transformer/Writer/Sourcecode.php`, et la modal pointe dans le vide.

## Bug latent découvert en cours de fix

`ProjectDescriptor::Settings::includeSource()` / `excludeSource()` existent mais **ne sont jamais appelés depuis `src/` en production**. Seule la branche `tests/` les utilise. Résultat : `project.settings.shouldIncludeSource` renvoyait toujours `false` quel que soit le contenu de `phpdoc.xml`. Le template `clean` utilise déjà ce guard (`data/templates/clean/class.html.twig:20`), donc le source viewer de clean ne s'appliquait lui aussi plus en 3.x.

## Fix complet

1. `ParseFiles::__invoke()` (`src/phpDocumentor/Pipeline/Stage/Parser/ParseFiles.php`) : propage maintenant `include-source` de l'`ApiSpecification` vers `ProjectDescriptor::Settings` via le builder, en miroir du `setVisibility` existant.
2. `ProjectDescriptorBuilder::setIncludeSource(bool)` (nouvelle méthode) : appelle `Settings::includeSource()` / `excludeSource()` selon la valeur booléenne propagée.
3. `data/templates/default/components/source-modal.html.twig` : wrap les deux blocs (`sourceview_modal` et `modals_script`) dans `{% if project.settings.shouldIncludeSource %}...{% endif %}`. Rien n'est émis quand la config ne demande pas le source viewer.

Conséquence : avec `include-source: true`, la modal est rendue et fonctionne. Avec `include-source: false` ou absent, la modal (et son JS) ne partent pas dans la sortie HTML.

## Tests

- Nouveau test `ProjectDescriptorBuilderTest::testSetIncludeSourceTogglesTheProjectSetting` : vérifie que `setIncludeSource(true|false)` flippe correctement `Settings::shouldIncludeSource()`.
- Les 337 tests existants de `tests/unit/phpDocumentor/Descriptor/` et `tests/unit/phpDocumentor/Pipeline/` passent.