### PR TITLE
Allow runtime configuration 

### DIFF
--- a/data/examples/Markdown/.gitignore
+++ b/data/examples/Markdown/.gitignore
@@ -1,0 +1,2 @@
+/.phpdoc/
+build

--- a/data/examples/Markdown/docs/index.md
+++ b/data/examples/Markdown/docs/index.md
@@ -1,0 +1,4 @@
+# Markdown docs
+
+This is an example of phpDocumentor's Markdown documentation. 
+It is generated from the `docs` directory in the root of the project.

--- a/data/examples/Markdown/docs/other.md
+++ b/data/examples/Markdown/docs/other.md
@@ -1,0 +1,3 @@
+# Other page
+
+This is another page, this should show up in the sidebar.

--- a/data/examples/Markdown/docs/subdir/index.md
+++ b/data/examples/Markdown/docs/subdir/index.md
@@ -1,0 +1,3 @@
+# Sub directory
+
+This is the root page of the sub directory. It should show up in the sidebar, and it should be possible to navigate to it from the sidebar.

--- a/data/examples/Markdown/docs/subdir/page.md
+++ b/data/examples/Markdown/docs/subdir/page.md
@@ -1,0 +1,3 @@
+# nested page
+
+This page is nested inside a subdirectory, but it should still show up in the sidebar.

--- a/data/examples/Markdown/phpdoc.xml
+++ b/data/examples/Markdown/phpdoc.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+        configVersion="3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://www.phpdoc.org"
+        xsi:noNamespaceSchemaLocation="data/xsd/phpdoc.xsd"
+>
+    <title>phpDocumentor</title>
+    <paths>
+        <output>build</output>
+    </paths>
+    <version number="3.0.0">
+        <folder>latest</folder>
+        <guide format="md">
+            <source dsn=".">
+                <path>docs</path>
+            </source>
+            <output>/guide</output>
+        </guide>
+    </version>
+    <setting name="guides.enabled" value="true"/>
+</phpdocumentor>

--- a/src/phpDocumentor/Console/Application.php
+++ b/src/phpDocumentor/Console/Application.php
@@ -57,11 +57,17 @@ class Application extends BaseApplication
             $extensionsDirs = array_merge($extensionsDirs, $this->composerExtensionsDirs);
         }
 
+        // Read the --config/-c option before building the container so that
+        // ApplicationExtension can load the correct phpdoc.xml file during
+        // the DI extension prepend/load phase (before compile()).
+        $configFile = $input->getParameterOption(['--config', '-c'], null) ?: null;
+
         $extensionHandler = ExtensionHandler::getInstance($extensionsDirs);
         $containerFactory = new ContainerFactory();
         $container = $containerFactory->create(
             AutoloaderLocator::findVendorPath(),
             $extensionHandler,
+            $configFile,
         );
 
         $commands = $container->findTaggedServiceIds('console.command');

--- a/src/phpDocumentor/Console/ContainerFactory.php
+++ b/src/phpDocumentor/Console/ContainerFactory.php
@@ -41,7 +41,6 @@ final class ContainerFactory
         foreach (
             array_merge(
                 [
-                    new ApplicationExtension(),
                     new GuidesExtension(),
                     new ReStructuredTextExtension(),
                     new MarkdownExtension(),
@@ -63,7 +62,15 @@ final class ContainerFactory
     public function create(
         string $vendorDir,
         ExtensionHandler $extensionHandler,
+        string|null $configFile = null,
     ): ContainerBuilder {
+        // ApplicationExtension must be registered in create() (not the constructor) so that
+        // it can receive the config file path resolved from the command-line --config option.
+        // prepend() is called by compile() for all PrependExtensionInterface implementations,
+        // but only after all extensions have been registered via loadFromExtension().
+        // Registering first ensures prepend order is correct relative to other extensions.
+        $this->registerExtension(new ApplicationExtension($configFile));
+
         $this->container->setParameter('vendor_dir', $vendorDir);
         $this->container->setParameter('kernel.project_dir', dirname(__DIR__, 3));
         $this->container->setParameter('env(PHPDOC_PLANTUML)', 'plantuml_smetana');

--- a/src/phpDocumentor/DependencyInjection/ApplicationExtension.php
+++ b/src/phpDocumentor/DependencyInjection/ApplicationExtension.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\DependencyInjection;
 
+use phpDocumentor\Configuration\Definition\Version2;
+use phpDocumentor\Configuration\Definition\Version3;
+use phpDocumentor\Configuration\SymfonyConfigFactory;
 use phpDocumentor\Guides\Nodes\PHP\ClassDiagram;
 use phpDocumentor\Guides\Nodes\PHP\ClassList;
 use phpDocumentor\Guides\Nodes\PHP\ElementDescription;
@@ -26,11 +29,34 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 use function dirname;
+use function file_exists;
+use function getcwd;
 use function phpDocumentor\Guides\DependencyInjection\template;
 
 final class ApplicationExtension extends Extension implements PrependExtensionInterface
 {
-    public function load(array $configs, ContainerBuilder $container)
+    /**
+     * The six candidate filenames that phpDocumentor looks for by default, in order of preference.
+     */
+    private const DEFAULT_CONFIG_FILES = [
+        'phpdoc.xml',
+        'phpdoc.dist.xml',
+        'phpdoc.xml.dist',
+        '.phpdoc.xml.dist',
+        '.phpdoc.xml',
+        '.phpdoc.dist.xml',
+    ];
+
+    /**
+     * @param string|null $configFile
+     *   Absolute path to the configuration file passed via --config/-c on the command line.
+     *   When null the extension searches the default file candidates in the current working directory.
+     */
+    public function __construct(private readonly string|null $configFile = null)
+    {
+    }
+
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader(
             $container,
@@ -45,10 +71,20 @@ final class ApplicationExtension extends Extension implements PrependExtensionIn
                 $definition->addTag($attribute->name, ['priority' => $attribute->priority]);
             },
         );
+
+        // Merge and validate all configs contributed via prepend() (including the phpdoc.xml
+        // config prepended by this extension itself) against the phpdoc.xml v3 schema.
+        // The result is stored as a container parameter so that compiler passes and other
+        // extensions can read the full configuration before the container is compiled.
+        // Note: value-object normalisation (Dsn/Path) is intentionally skipped here; that
+        // step is still handled by the service-layer ConfigurationFactory.
+        $processedConfig = $this->processConfiguration(new Configuration(), $configs);
+        $container->setParameter('phpdocumentor.config', $processedConfig);
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
+        // Prepend Guides template mappings for PHP-specific node types.
         $container->prependExtensionConfig(
             'guides',
             [
@@ -60,5 +96,59 @@ final class ApplicationExtension extends Extension implements PrependExtensionIn
                 ],
             ],
         );
+
+        // Parse the phpdoc.xml configuration file and make it available as extension
+        // config so that load() can merge it with any config contributed by other
+        // extensions and validate the result against the full schema.
+        $configFile = $this->resolveConfigFile();
+        $factory = $this->createSymfonyConfigFactory();
+
+        $config = $configFile !== null
+            ? $factory->createFromFile($configFile)
+            : $factory->createDefault();
+
+        // prependExtensionConfig() stores configs in LIFO order, but since this is
+        // the primary source (phpdoc.xml), using prepend is intentional: other
+        // extensions can override values by prepending their own partial configs
+        // after this one.
+        $container->prependExtensionConfig('phpdocumentor', $config['phpdocumentor']);
+    }
+
+    /**
+     * Returns the absolute path to the configuration file to use.
+     *
+     * Uses the explicit --config path when provided, otherwise searches the
+     * default candidate filenames in the current working directory.
+     */
+    private function resolveConfigFile(): string|null
+    {
+        if ($this->configFile !== null) {
+            return $this->configFile;
+        }
+
+        $cwd = getcwd();
+        foreach (self::DEFAULT_CONFIG_FILES as $candidate) {
+            $path = $cwd . '/' . $candidate;
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Builds a SymfonyConfigFactory instance that can be used before the DI
+     * container is available.  Version2 and Version3 are plain PHP objects and
+     * can be instantiated directly.  The template name is set to the same
+     * constant default used by {@see Configuration}; the actual runtime default
+     * is resolved later by the service-layer ConfigurationFactory.
+     */
+    private function createSymfonyConfigFactory(): SymfonyConfigFactory
+    {
+        return new SymfonyConfigFactory([
+            '2' => new Version2(Configuration::DEFAULT_TEMPLATE_NAME),
+            '3' => new Version3(Configuration::DEFAULT_TEMPLATE_NAME),
+        ]);
     }
 }

--- a/src/phpDocumentor/DependencyInjection/ApplicationExtension.php
+++ b/src/phpDocumentor/DependencyInjection/ApplicationExtension.php
@@ -107,11 +107,31 @@ final class ApplicationExtension extends Extension implements PrependExtensionIn
             ? $factory->createFromFile($configFile)
             : $factory->createDefault();
 
-        // prependExtensionConfig() stores configs in LIFO order, but since this is
-        // the primary source (phpdoc.xml), using prepend is intentional: other
-        // extensions can override values by prepending their own partial configs
-        // after this one.
         $container->prependExtensionConfig('phpdocumentor', $config['phpdocumentor']);
+
+        if (! $this->hasMarkdownGuides($config['phpdocumentor'])) {
+            return;
+        }
+
+        $container->prependExtensionConfig('guides', ['automatic_menu' => true]);
+    }
+
+    /**
+     * Returns true when at least one guide entry in any version uses the Markdown format.
+     *
+     * @param array<mixed> $phpdocConfig The parsed phpdocumentor config array (without the outer 'phpdocumentor' key).
+     */
+    private function hasMarkdownGuides(array $phpdocConfig): bool
+    {
+        foreach ($phpdocConfig['versions'] ?? [] as $version) {
+            foreach ($version['guides'] ?? [] as $guide) {
+                if (($guide['format'] ?? '') === 'md') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/phpDocumentor/DependencyInjection/Configuration.php
+++ b/src/phpDocumentor/DependencyInjection/Configuration.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\DependencyInjection;
+
+use phpDocumentor\Configuration\Definition\Version3;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * Symfony DI-extension configuration for {@see ApplicationExtension}.
+ *
+ * This class exposes the same tree as the phpdoc.xml v3 schema so that the
+ * ApplicationExtension can:
+ *  - validate and merge configs contributed via prepend() by any extension, and
+ *  - store the result as the container parameter "phpdocumentor.config" before
+ *    the container is compiled.
+ *
+ * Deliberately does NOT apply value-object normalisation (Dsn/Path objects).
+ * All values are kept as plain strings/arrays so that they can safely live as
+ * container parameters.  Value-object creation remains in the service layer
+ * (ConfigurationFactory::createConfigurationFromArray()).
+ */
+final class Configuration implements ConfigurationInterface
+{
+    /** The default template name used when none is specified in phpdoc.xml. */
+    public const DEFAULT_TEMPLATE_NAME = 'default';
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        // Re-use the Version3 tree definition.  The "default" template name is
+        // only used to fill in the default value for the <template> node when
+        // none is present in the XML; the actual runtime default is resolved
+        // later by the service-layer ConfigurationFactory.
+        return (new Version3(self::DEFAULT_TEMPLATE_NAME))->getConfigTreeBuilder();
+    }
+}


### PR DESCRIPTION
Before we loaded the configuration after the application was bootstrapped, but when we introduced extensions is was already less applicable. Now I moved the configuration loading into the start of the application. This allows me to enable features on guides when the user configures particular settings. A first example is the option for auto menus when using markdown format. 

Fixes #3892