### PR TITLE
Fix glob pattern for source paths containing a dot

### DIFF
--- a/src/phpDocumentor/Configuration/Source.php
+++ b/src/phpDocumentor/Configuration/Source.php
@@ -20,7 +20,7 @@ use phpDocumentor\FileSystem\Dsn;
 use phpDocumentor\FileSystem\Path;
 use ReturnTypeWillChange;
 
-use function array_merge;
+use function array_push;
 use function in_array;
 use function ltrim;
 use function rtrim;
@@ -69,7 +69,7 @@ final class Source implements ArrayAccess
     {
         $patterns = [];
         foreach ($this->paths as $path) {
-            $patterns = array_merge($patterns, $this->pathToGlobPatterns((string) $path));
+            array_push($patterns, ...$this->pathToGlobPatterns((string) $path));
         }
 
         return $patterns;

--- a/src/phpDocumentor/Configuration/Source.php
+++ b/src/phpDocumentor/Configuration/Source.php
@@ -20,12 +20,11 @@ use phpDocumentor\FileSystem\Dsn;
 use phpDocumentor\FileSystem\Path;
 use ReturnTypeWillChange;
 
-use function array_map;
+use function array_merge;
 use function in_array;
 use function ltrim;
 use function rtrim;
 use function sprintf;
-use function str_contains;
 use function str_ends_with;
 use function str_starts_with;
 
@@ -68,10 +67,12 @@ final class Source implements ArrayAccess
     /** @return string[] */
     public function globPatterns(): array
     {
-        return array_map(
-            fn (Path $path): string => $this->pathToGlobPattern((string) $path),
-            $this->paths,
-        );
+        $patterns = [];
+        foreach ($this->paths as $path) {
+            $patterns = array_merge($patterns, $this->pathToGlobPatterns((string) $path));
+        }
+
+        return $patterns;
     }
 
     private function normalizePath(string $path): string
@@ -87,15 +88,20 @@ final class Source implements ArrayAccess
         return rtrim($path, '/');
     }
 
-    private function pathToGlobPattern(string $path): string
+    /** @return list<string> */
+    private function pathToGlobPatterns(string $path): array
     {
         $path = $this->normalizePath($path);
 
-        if (! str_ends_with($path, '*') && ! str_contains($path, '.')) {
-            $path .= '/**/*';
+        if (str_ends_with($path, '*')) {
+            return [$path];
         }
 
-        return $path;
+        if ($path === '') {
+            return ['/**/*'];
+        }
+
+        return [$path, $path . '/**/*'];
     }
 
     /** @param string $offset */

--- a/tests/unit/phpDocumentor/Configuration/SourceTest.php
+++ b/tests/unit/phpDocumentor/Configuration/SourceTest.php
@@ -99,36 +99,44 @@ final class SourceTest extends TestCase
         unset($source['paths']);
     }
 
-    /** @dataProvider pathProvider */
-    public function testSourceGlobPathsNormalizesPaths(Path $input, string $glob): void
+    /**
+     * @param list<string> $globs
+     *
+     * @dataProvider pathProvider
+     */
+    public function testSourceGlobPathsNormalizesPaths(Path $input, array $globs): void
     {
         $source = new Source(self::faker()->dsn(), [$input]);
 
-        self::assertEquals([$glob], $source->globPatterns());
+        self::assertEquals($globs, $source->globPatterns());
     }
 
     public static function pathProvider(): array
     {
         return [
-            [
+            'directory' => [
                 new Path('src'),
-                '/src/**/*',
+                ['/src', '/src/**/*'],
             ],
-            [
+            'current directory' => [
                 new Path('.'),
-                '/**/*',
+                ['/**/*'],
             ],
-            [
+            'relative directory' => [
                 new Path('./src'),
-                '/src/**/*',
+                ['/src', '/src/**/*'],
             ],
-            [
+            'glob with trailing wildcard' => [
                 new Path('/src/*'),
-                '/src/*',
+                ['/src/*'],
             ],
-            [
+            'single file' => [
                 new Path('src/dir/test.php'),
-                '/src/dir/test.php',
+                ['/src/dir/test.php', '/src/dir/test.php/**/*'],
+            ],
+            'directory containing a dot' => [
+                new Path('test.1'),
+                ['/test.1', '/test.1/**/*'],
             ],
         ];
     }


### PR DESCRIPTION
Paths containing a dot (e.g. `test.1`) were treated as a single file and never expanded to `/path/**/*`, so phpDocumentor reported an empty documentation set when run with `-d test.1`.

The heuristic is dropped: each path emits both `/path` and `/path/**/*`, so file paths still match exactly and directory paths recurse regardless of dots in their names.

Fixes #3940