### PR TITLE
Install unzip so Composer can unpack dist archives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM php:8.4-trixie AS base
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199#23
 RUN mkdir -p /usr/share/man/man1 \
     && apt-get update \
-    && apt-get install --no-install-recommends -yq libicu-dev libicu76 zlib1g-dev ca-certificates-java gpg
+    && apt-get install --no-install-recommends -yq libicu-dev libicu76 zlib1g-dev ca-certificates-java gpg unzip
 
 RUN apt-get -yq install openjdk-21-jre-headless \
     && rm -rf /var/lib/apt/lists/* /usr/share/man/man1 \


### PR DESCRIPTION
`docker build .` fails on master, and with it the `phpDocumentor/phpDocumentor` GitHub Action, which builds the Dockerfile without a target and therefore builds the last stage, `dev-pcov`:

```
Dockerfile:48  RUN pie install pecl/pcov
  In ZipDownloader.php line 81:
  The zip extension and unzip/7z commands are both missing, skipping.
```

## Cause

The image has neither `ext-zip` nor an `unzip`/`7z` binary, so Composer cannot unpack a zip dist. That has been true the whole time; it was invisible because Composer silently fell back to a git clone. Verbose output from PIE 1.4.7, which still works:

```
Failed to download pecl/pcov from dist: The zip extension and unzip/7z commands are both missing, skipping.
Now trying to download from source
- Installing pecl/pcov (v1.0.12): Cloning e16c08e14d from cache
```

Composer [2.10.0](https://github.com/composer/composer/blob/main/CHANGELOG.md) removed that fallback: *"BC Break / Security: Disabled automatic fallback to source checkout if dist/zip install fails"* (composer/composer#12885). PIE 1.4.8 bumped `composer/composer` from 2.9.8 to 2.10.2 (php/pie#663), so the same command now aborts:

```
Failed to download pecl/pcov from dist: The zip extension and unzip/7z commands are both missing, skipping.
Source fallback is disabled. Not trying alternative sources.
```

PIE's [usage docs](https://github.com/php/pie/blob/1.5.x/docs/usage.md) name the requirement as "`unzip`, the Zip extension, or `git`". The `dev` stage installs `git`, so this Dockerfile satisfied the documented third option. That option is exactly the one Composer 2.10 invalidated: `git` still covers repositories Composer reads over git, but it no longer substitutes for extracting a downloaded archive.

Bisected against `ghcr.io/php/pie:<version>-bin` on the unmodified `dev-pcov` stage: 1.4.3 through 1.4.7 exit 0, 1.4.8 and 1.4.9 exit 1. `COPY --from=ghcr.io/php/pie:bin` is a floating tag, so this started failing without a commit in this repository.

## Two effects

* `pie install pecl/pcov` aborts, breaking every plain `docker build .`, and with it the GitHub Action.
* `composer` is shipped inside the image but cannot install anything, so `docker compose run phpdoc composer ...` from CONTRIBUTING.md fails the same way. This one is easy to miss because nothing in CI builds it: `docker.yml` and `release.yml` both pass `--target=prod`, and `push.yml` runs the test suite without Docker.

## Fix

Install `unzip` in the `base` stage, which every other stage inherits. One package, both effects.

## Verification

* Before: `docker build .` on master fails at `Dockerfile:48`, reproducing the CI error; `composer install` inside the `prod` image fails with the same `ZipDownloader` exception.
* After: `docker build .` and `docker build --target=prod .` both exit 0, `php -m` lists `pcov`, `phpdoc --version` runs, and `composer install` inside the `prod` image completes.

## Alternative, not taken

Composer 2.10 added a `source-fallback` config option that restores the old behaviour, but it is already marked deprecated for removal in 2.11 (`The source-fallback option is deprecated and will be removed in Composer 2.11 as automatic fallback between dist and source has security implications`). Installing `unzip` fixes the actual gap instead of postponing it.

## Not addressed here

* The action builds `dev-pcov` only because it is the last stage — `action.yml` uses `image: 'Dockerfile'`, and GitHub Action metadata has no build-target option. Building a stage without the coverage tooling would need a separate final stage or a dedicated Dockerfile.
* `ghcr.io/php/pie:bin` remains a floating tag.
* No released tag currently builds either: v3.9.0, v3.9.1 and v3.10.0 have a Dockerfile identical to master, and v3.8.1 and older fail earlier on `libicu72` (#3960), since `php:8.1` now resolves to trixie. Consumers cannot work around this by pinning the action.

---

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_0129QU37uCnSL1ZkmD8bdqxQ)_
